### PR TITLE
  Summary

### DIFF
--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -57,6 +57,7 @@ impl Program {
             // I/O operations
             "write_line",
             "read_line",
+            "int->string",
             // Arithmetic operations
             "add",
             "subtract",

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -137,6 +137,7 @@ impl CodeGen {
         writeln!(&mut ir, "declare ptr @push_string(ptr, ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @write_line(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @read_line(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @int_to_string(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @add(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @subtract(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @multiply(ptr)").unwrap();
@@ -258,6 +259,7 @@ impl CodeGen {
                 let function_name = match name.as_str() {
                     // I/O operations
                     "write_line" | "read_line" => name.to_string(),
+                    "int->string" => "int_to_string".to_string(),
                     // Arithmetic operations
                     "add" | "subtract" | "multiply" | "divide" => name.to_string(),
                     // Comparison operations (symbolic → named)

--- a/compiler/src/typechecker.rs
+++ b/compiler/src/typechecker.rs
@@ -136,6 +136,7 @@ impl TypeChecker {
             // I/O operations
             "write_line" => depth.pop(name), // ( str -- )
             "read_line" => Ok(depth.push()), // ( -- str )
+            "int->string" => depth.pop(name).map(|d| d.push()), // ( int -- str )
 
             // Arithmetic operations ( a b -- result )
             "add" | "subtract" | "multiply" | "divide" => {

--- a/examples/test-comparison.cem
+++ b/examples/test-comparison.cem
@@ -2,35 +2,35 @@
 # All comparisons return 1 (true) or 0 (false) as integers
 
 : test-eq ( -- )
-  5 5 = write_line
-  5 3 = write_line
+  5 5 = int->string write_line
+  5 3 = int->string write_line
 ;
 
 : test-lt ( -- )
-  3 5 < write_line
-  5 3 < write_line
+  3 5 < int->string write_line
+  5 3 < int->string write_line
 ;
 
 : test-gt ( -- )
-  5 3 > write_line
-  3 5 > write_line
+  5 3 > int->string write_line
+  3 5 > int->string write_line
 ;
 
 : test-lte ( -- )
-  3 5 <= write_line
-  5 5 <= write_line
-  5 3 <= write_line
+  3 5 <= int->string write_line
+  5 5 <= int->string write_line
+  5 3 <= int->string write_line
 ;
 
 : test-gte ( -- )
-  5 3 >= write_line
-  5 5 >= write_line
-  3 5 >= write_line
+  5 3 >= int->string write_line
+  5 5 >= int->string write_line
+  3 5 >= int->string write_line
 ;
 
 : test-neq ( -- )
-  5 3 <> write_line
-  5 5 <> write_line
+  5 3 <> int->string write_line
+  5 5 <> int->string write_line
 ;
 
 : main ( -- )

--- a/runtime/src/io.rs
+++ b/runtime/src/io.rs
@@ -80,6 +80,24 @@ pub unsafe extern "C" fn read_line(stack: Stack) -> Stack {
     unsafe { push(stack, Value::String(line)) }
 }
 
+/// Convert an integer to a string
+///
+/// Stack effect: ( Int -- String )
+///
+/// # Safety
+/// Stack must have an Int value on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn int_to_string(stack: Stack) -> Stack {
+    assert!(!stack.is_null(), "int_to_string: stack is empty");
+
+    let (rest, value) = unsafe { pop(stack) };
+
+    match value {
+        Value::Int(n) => unsafe { push(rest, Value::String(n.to_string())) },
+        _ => panic!("int_to_string: expected Int on stack, got {:?}", value),
+    }
+}
+
 /// Push a C string literal onto the stack (for compiler-generated code)
 ///
 /// Stack effect: ( -- str )


### PR DESCRIPTION
  Added int->string operation:
  - Runtime (runtime/src/io.rs:83-99): Converts Int to String
  - AST (compiler/src/ast.rs:60): Added to builtins list
  - Type checker (compiler/src/typechecker.rs:139): Stack effect ( Int -- String )
  - Codegen (compiler/src/codegen.rs:140, 262): Maps int->string → int_to_string
  - Example (examples/test-comparison.cem): Updated to use int->string before write_line

  Test Results:
  - ✅ 73 tests passing (27 compiler + 46 runtime)
  - ✅ test-comparison example works correctly (prints 1s and 0s)

  This is a simple, non-presumptive operation that fits cleanly into the current minimal type system and will work fine when Phase 8.5 full types are
  implemented.