### PR TITLE
All UTF-8 string primitives have been implemented successfully. Here'…

### DIFF
--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -105,6 +105,11 @@ impl Program {
             // String operations
             "string-concat",
             "string-length",
+            "string-byte-length",
+            "string-char-at",
+            "string-substring",
+            "char->string",
+            "string-find",
             "string-split",
             "string-contains",
             "string-starts-with",

--- a/compiler/src/builtins.rs
+++ b/compiler/src/builtins.rs
@@ -545,6 +545,63 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
         ),
     );
 
+    // string-byte-length: ( ..a String -- ..a Int )
+    // Get byte length (for HTTP Content-Length, buffer allocation)
+    sigs.insert(
+        "string-byte-length".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::String),
+            StackType::RowVar("a".to_string()).push(Type::Int),
+        ),
+    );
+
+    // string-char-at: ( ..a String Int -- ..a Int )
+    // Get Unicode code point at character index
+    sigs.insert(
+        "string-char-at".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string())
+                .push(Type::String)
+                .push(Type::Int),
+            StackType::RowVar("a".to_string()).push(Type::Int),
+        ),
+    );
+
+    // string-substring: ( ..a String Int Int -- ..a String )
+    // Extract substring by character indices (string, start, length)
+    sigs.insert(
+        "string-substring".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string())
+                .push(Type::String)
+                .push(Type::Int)
+                .push(Type::Int),
+            StackType::RowVar("a".to_string()).push(Type::String),
+        ),
+    );
+
+    // char->string: ( ..a Int -- ..a String )
+    // Convert Unicode code point to single-character string
+    sigs.insert(
+        "char->string".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::Int),
+            StackType::RowVar("a".to_string()).push(Type::String),
+        ),
+    );
+
+    // string-find: ( ..a String String -- ..a Int )
+    // Find first occurrence of substring, returns character index or -1
+    sigs.insert(
+        "string-find".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string())
+                .push(Type::String)
+                .push(Type::String),
+            StackType::RowVar("a".to_string()).push(Type::Int),
+        ),
+    );
+
     // Variant operations
     // variant-field-count: ( ..a Variant -- ..a Int )
     // Get number of fields in a variant

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -237,6 +237,11 @@ impl CodeGen {
         writeln!(&mut ir, "; String operations").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_concat(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_length(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_string_byte_length(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_string_char_at(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_string_substring(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_char_to_string(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_string_find(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_split(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_contains(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_starts_with(ptr)").unwrap();
@@ -532,6 +537,11 @@ impl CodeGen {
                     // String operations (hyphen → underscore for C compatibility)
                     "string-concat" => "patch_seq_string_concat".to_string(),
                     "string-length" => "patch_seq_string_length".to_string(),
+                    "string-byte-length" => "patch_seq_string_byte_length".to_string(),
+                    "string-char-at" => "patch_seq_string_char_at".to_string(),
+                    "string-substring" => "patch_seq_string_substring".to_string(),
+                    "char->string" => "patch_seq_char_to_string".to_string(),
+                    "string-find" => "patch_seq_string_find".to_string(),
                     "string-split" => "patch_seq_string_split".to_string(),
                     "string-contains" => "patch_seq_string_contains".to_string(),
                     "string-starts-with" => "patch_seq_string_starts_with".to_string(),

--- a/docs/STRING_PRIMITIVES_PLAN.md
+++ b/docs/STRING_PRIMITIVES_PLAN.md
@@ -1,0 +1,201 @@
+# String Primitives Plan
+
+## Goal
+Add minimal runtime primitives to enable writing text parsers (CSV, JSON, etc.) in pure Seq.
+
+## Philosophy
+- Add **primitives** to the runtime (Rust)
+- Build **parsers** in the stdlib (Seq)
+- Keep the runtime minimal, let the language do the work
+- **Commit to proper UTF-8 support** - characters, not bytes
+
+## Decision: UTF-8 Character Semantics
+
+All string operations use **code point** (character) semantics, not byte semantics.
+
+```seq
+"héllo" string-length     # → 5 (characters, not 6 bytes)
+"héllo" 1 string-char-at  # → 233 (U+00E9 = é)
+```
+
+This is a **breaking change** to `string-length` (was byte-based). We fix existing
+code rather than accumulate technical debt.
+
+## Proposed Primitives
+
+### 1. `string-char-at` ( String Int -- Int )
+Get Unicode code point at character index.
+
+```seq
+"hello" 0 string-char-at  # → 104 (ASCII 'h')
+"héllo" 1 string-char-at  # → 233 (U+00E9 = é)
+"hello" 5 string-char-at  # → -1 (out of bounds)
+```
+
+### 2. `string-substring` ( String Int Int -- String )
+Extract substring: `string start length -> result`
+
+```seq
+"hello" 1 3 string-substring  # → "ell"
+"hello" 0 5 string-substring  # → "hello"
+"hello" 2 10 string-substring # → "llo" (clamp to end)
+```
+
+**Edge cases:**
+- Start beyond end: return empty string
+- Length extends past end: clamp to available
+
+### 3. `char->string` ( Int -- String )
+Convert code point to single-character string.
+
+```seq
+65 char->string   # → "A"
+104 char->string  # → "h"
+10 char->string   # → "\n" (newline)
+```
+
+**Note:** Enables building strings character by character.
+
+### 4. `string-find` ( String String -- Int )
+Find first occurrence of substring, returns -1 if not found.
+
+```seq
+"hello world" "world" string-find  # → 6
+"hello world" "xyz" string-find    # → -1
+"hello" "l" string-find            # → 2 (first match)
+```
+
+**Use case:** Locating delimiters, checking for substrings.
+
+## Implementation Checklist
+
+For each primitive:
+
+### Runtime (`runtime/src/string_ops.rs`)
+```rust
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_string_char_at(stack: Stack) -> Stack {
+    // Pop index (Int), pop string (String)
+    // Get character at index
+    // Push result (Int) - code point or -1
+}
+```
+
+### Runtime exports (`runtime/src/lib.rs`)
+```rust
+pub use string_ops::patch_seq_string_char_at;
+```
+
+### Type signatures (`compiler/src/builtins.rs`)
+```rust
+// string-char-at: ( ..a String Int -- ..a Int )
+sigs.insert(
+    "string-char-at".to_string(),
+    Effect::new(
+        StackType::RowVar("a".to_string())
+            .push(Type::String)
+            .push(Type::Int),
+        StackType::RowVar("a".to_string()).push(Type::Int),
+    ),
+);
+```
+
+### Codegen (`compiler/src/codegen.rs`)
+1. Add declaration:
+   ```rust
+   writeln!(&mut ir, "declare ptr @patch_seq_string_char_at(ptr)").unwrap();
+   ```
+2. Add to name mapping:
+   ```rust
+   "string-char-at" => "patch_seq_string_char_at".to_string(),
+   ```
+
+## What This Enables
+
+### In stdlib (pure Seq):
+
+**CSV Parser** (`stdlib/csv.seq`):
+```seq
+: csv-parse-field ( String Int -- String Int )
+  # Parse one field starting at index
+  # Returns field value and next index
+  ...
+;
+```
+
+**JSON Tokenizer** (`stdlib/json.seq`):
+```seq
+: json-skip-whitespace ( String Int -- Int )
+  # Skip spaces, tabs, newlines
+  ...
+;
+
+: json-parse-string ( String Int -- String Int )
+  # Parse "..." string literal
+  ...
+;
+```
+
+**Number Parser** (needed for JSON):
+```seq
+: string->int ( String -- Int )
+  # Parse integer from string
+  # "123" -> 123
+  ...
+;
+```
+
+## Implementation Order
+
+1. **Phase 1: Core primitives** (this PR)
+   - `string-char-at`
+   - `string-substring`
+   - `char->string`
+   - `string-find`
+
+2. **Phase 2: Basic parsing stdlib**
+   - `string->int` (in Seq using primitives)
+   - `std:string` - additional string utilities
+
+3. **Phase 3: CSV support**
+   - `csv-parse-line`
+   - `csv-parse-field`
+
+4. **Phase 4: JSON support**
+   - JSON tokenizer
+   - JSON parser (returns Variants)
+
+## Testing Strategy
+
+Each runtime function needs:
+1. Unit tests in Rust (`string_ops.rs`)
+2. Integration test compiling Seq program
+3. Edge case coverage (empty strings, bounds, UTF-8)
+
+## Estimated Effort
+
+- Phase 1 (primitives): 1 session
+- Phase 2 (string stdlib): 1 session
+- Phase 3 (CSV): 1 session
+- Phase 4 (JSON): 2-3 sessions (recursive parsing is tricky)
+
+## Resolved Decisions
+
+1. **UTF-8 handling**: ✅ Use Unicode code points (characters), not bytes
+   - `string-length` returns character count
+   - `string-char-at` returns code point value
+   - Add `string-byte-length` for when bytes needed (HTTP Content-Length)
+
+2. **Error handling**: Return -1 for out of bounds (allows safe iteration patterns)
+
+3. **Breaking change**: Fix `string-length` now while language is young
+
+## Additional Primitive Needed
+
+### `string-byte-length` ( String -- Int )
+Get byte count (needed for HTTP Content-Length, buffer allocation).
+
+```seq
+"hello" string-byte-length  # → 5
+"héllo" string-byte-length  # → 6 (é is 2 bytes in UTF-8)
+```

--- a/stdlib/http.seq
+++ b/stdlib/http.seq
@@ -42,8 +42,9 @@
 
 # Build HTTP 200 OK response with body
 # Stack effect: ( body -- response )
+# Note: Uses string-byte-length for Content-Length (HTTP requires byte count)
 : http-ok ( String -- String )
-  dup string-length int->string
+  dup string-byte-length int->string
   "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: " swap string-concat
   "\r\n\r\n" string-concat
   swap string-concat
@@ -51,8 +52,9 @@
 
 # Build HTTP 404 Not Found response with body
 # Stack effect: ( body -- response )
+# Note: Uses string-byte-length for Content-Length (HTTP requires byte count)
 : http-not-found ( String -- String )
-  dup string-length int->string
+  dup string-byte-length int->string
   "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: " swap string-concat
   "\r\n\r\n" string-concat
   swap string-concat
@@ -60,8 +62,9 @@
 
 # Build HTTP 500 Internal Server Error response with body
 # Stack effect: ( body -- response )
+# Note: Uses string-byte-length for Content-Length (HTTP requires byte count)
 : http-error ( String -- String )
-  dup string-length int->string
+  dup string-byte-length int->string
   "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: " swap string-concat
   "\r\n\r\n" string-concat
   swap string-concat
@@ -95,6 +98,7 @@
 
 # Build complete HTTP response with custom status
 # Stack effect: ( status_code reason_phrase body -- response )
+# Note: Uses string-byte-length for Content-Length (HTTP requires byte count)
 #
 # Example: 201 "Created" "Resource created" http-response
 : http-response ( Int String String -- String )
@@ -111,9 +115,9 @@
   # Add Content-Type header
   "Content-Type: text/plain\r\n" string-concat
 
-  # Add Content-Length header
+  # Add Content-Length header (uses byte length for HTTP compliance)
   "Content-Length: " string-concat
-  over string-length int->string string-concat
+  over string-byte-length int->string string-concat
   "\r\n\r\n" string-concat
 
   # Add body


### PR DESCRIPTION
…s a summary:

Summary

Implemented 5 new string primitives + 1 breaking change:

Breaking Change

- string-length - Now returns character count (code points), not byte count
  - "héllo" string-length → 5 (was 6)
  - "hi🎉" string-length → 3 (was 6)

New Primitives

1. string-byte-length ( String -- Int ) - Get UTF-8 byte count (for HTTP Content-Length)
2. string-char-at ( String Int -- Int ) - Get Unicode code point at character index (-1 if out of bounds)
3. string-substring ( String Int Int -- String ) - Extract substring by character indices
4. char->string ( Int -- String ) - Convert code point to single-character string
5. string-find ( String String -- Int ) - Find substring, return character index (-1 if not found)

Files Modified

- runtime/src/string_ops.rs - Added 5 new runtime functions with 20+ tests
- compiler/src/ast.rs - Added built-in word declarations
- compiler/src/builtins.rs - Added type signatures
- compiler/src/codegen.rs - Added LLVM declarations and name mappings
- stdlib/http.seq - Updated to use string-byte-length for HTTP Content-Length

Test Results

- 270 tests pass (106 compiler + 155 runtime + 8 closures + 1 thread migration)
- All clippy warnings resolved
- Integration test verified all new primitives work end-to-end

This enables writing text parsers (CSV, JSON, etc.) in pure Seq with proper UTF-8 support.