### PR TITLE
⏺ Phase 2 TCO Complete!

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -94,6 +94,8 @@ pub use string_ops::{
 // Quotation operations (exported for LLVM linking)
 pub use quotations::{
     patch_seq_call as call, patch_seq_forever as forever,
+    patch_seq_peek_is_quotation as peek_is_quotation,
+    patch_seq_peek_quotation_fn_ptr as peek_quotation_fn_ptr,
     patch_seq_push_quotation as push_quotation, patch_seq_spawn as spawn, patch_seq_times as times,
     patch_seq_until_loop as until_loop, patch_seq_while_loop as while_loop,
 };

--- a/tests/tco_quotation_call.seq
+++ b/tests/tco_quotation_call.seq
@@ -1,0 +1,19 @@
+# Quotation Call TCO Test (Phase 2)
+#
+# This test verifies that quotation calls in tail position get TCO.
+# Without TCO, 100000 recursive quotation calls would overflow the stack.
+# With Phase 2 TCO, quotations are called directly via musttail.
+
+: recurse-via-quotation ( Int -- )
+    dup 0 > if
+        1 subtract [ recurse-via-quotation ] call
+    else
+        drop
+    then
+;
+
+: main ( -- )
+    "Testing quotation call TCO with 100000 recursive calls..." write_line
+    100000 recurse-via-quotation
+    "Success! Quotation call TCO is working." write_line
+;


### PR DESCRIPTION
  Summary of Changes

  Runtime (crates/runtime/src/quotations.rs)

  Added two new helper functions for the compiler to use when generating inline dispatch for call:
  - patch_seq_peek_is_quotation(Stack) -> i64 - Returns 1 if top of stack is a Quotation, 0 otherwise
  - patch_seq_peek_quotation_fn_ptr(Stack) -> usize - Extracts the function pointer from a Quotation

  Compiler (crates/compiler/src/codegen.rs)

  1. Added declarations for the new runtime helpers
  2. Updated will_emit_tail_call() to recognize call as TCO-eligible
  3. Added special handling in codegen_statement() for call in tail position
  4. Implemented codegen_tail_call_quotation() which generates inline dispatch:
    - Checks if top of stack is a Quotation
    - For Quotations: pops, extracts fn_ptr, emits musttail call tailcc directly
    - For Closures: falls back to regular patch_seq_call (Phase 3 will address closures)

  Tests

  - Added tests/tco_quotation_call.seq - Tests 100k recursive quotation calls

  Results

  All tests pass:
  - ✅ tco_test.seq - Basic word TCO (100k calls)
  - ✅ tco_mutual_recursion.seq - Mutual recursion TCO (100k calls)
  - ✅ tco_nested_if.seq - Nested if TCO (50k calls)
  - ✅ tco_quotation_call.seq - NEW Quotation call TCO (100k calls)
  - ✅ tco_closure_no_tco.seq - Closures work (no TCO yet)
  - ✅ non_tail_recursive.seq - Non-tail recursion still works
  - ✅ All example programs compile and run correctly

  Phase 3 (Closure TCO via Arc refactor) remains for future work.