### PR TITLE
⏺ Progress Summary

### DIFF
--- a/crates/runtime/src/float_ops.rs
+++ b/crates/runtime/src/float_ops.rs
@@ -4,7 +4,7 @@
 //! All float operations use the `f.` prefix to distinguish from integer operations.
 
 use crate::seqstring::global_string;
-use crate::stack::{Stack, pop, push};
+use crate::stack::{Stack, pop, pop_two, push};
 use crate::value::Value;
 
 // =============================================================================
@@ -30,13 +30,9 @@ pub unsafe extern "C" fn patch_seq_push_float(stack: Stack, value: f64) -> Stack
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_add(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.add: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.add: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.add") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => unsafe { push(stack, Value::Float(x + y)) },
+        (Value::Float(x), Value::Float(y)) => unsafe { push(rest, Value::Float(x + y)) },
         _ => panic!("f.add: expected two Floats on stack"),
     }
 }
@@ -47,13 +43,9 @@ pub unsafe extern "C" fn patch_seq_f_add(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_subtract(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.subtract: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.subtract: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.subtract") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => unsafe { push(stack, Value::Float(x - y)) },
+        (Value::Float(x), Value::Float(y)) => unsafe { push(rest, Value::Float(x - y)) },
         _ => panic!("f.subtract: expected two Floats on stack"),
     }
 }
@@ -64,13 +56,9 @@ pub unsafe extern "C" fn patch_seq_f_subtract(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_multiply(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.multiply: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.multiply: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.multiply") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => unsafe { push(stack, Value::Float(x * y)) },
+        (Value::Float(x), Value::Float(y)) => unsafe { push(rest, Value::Float(x * y)) },
         _ => panic!("f.multiply: expected two Floats on stack"),
     }
 }
@@ -83,13 +71,9 @@ pub unsafe extern "C" fn patch_seq_f_multiply(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_divide(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.divide: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.divide: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.divide") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => unsafe { push(stack, Value::Float(x / y)) },
+        (Value::Float(x), Value::Float(y)) => unsafe { push(rest, Value::Float(x / y)) },
         _ => panic!("f.divide: expected two Floats on stack"),
     }
 }
@@ -108,16 +92,11 @@ pub unsafe extern "C" fn patch_seq_f_divide(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_eq(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.=: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.=: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.=") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => {
-            let result = if x == y { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
-        }
+        (Value::Float(x), Value::Float(y)) => unsafe {
+            push(rest, Value::Int(if x == y { 1 } else { 0 }))
+        },
         _ => panic!("f.=: expected two Floats on stack"),
     }
 }
@@ -128,16 +107,11 @@ pub unsafe extern "C" fn patch_seq_f_eq(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_lt(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.<: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.<: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.<") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => {
-            let result = if x < y { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
-        }
+        (Value::Float(x), Value::Float(y)) => unsafe {
+            push(rest, Value::Int(if x < y { 1 } else { 0 }))
+        },
         _ => panic!("f.<: expected two Floats on stack"),
     }
 }
@@ -148,16 +122,11 @@ pub unsafe extern "C" fn patch_seq_f_lt(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_gt(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.>: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.>: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.>") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => {
-            let result = if x > y { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
-        }
+        (Value::Float(x), Value::Float(y)) => unsafe {
+            push(rest, Value::Int(if x > y { 1 } else { 0 }))
+        },
         _ => panic!("f.>: expected two Floats on stack"),
     }
 }
@@ -168,16 +137,11 @@ pub unsafe extern "C" fn patch_seq_f_gt(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_lte(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.<=: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.<=: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.<=") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => {
-            let result = if x <= y { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
-        }
+        (Value::Float(x), Value::Float(y)) => unsafe {
+            push(rest, Value::Int(if x <= y { 1 } else { 0 }))
+        },
         _ => panic!("f.<=: expected two Floats on stack"),
     }
 }
@@ -188,16 +152,11 @@ pub unsafe extern "C" fn patch_seq_f_lte(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_gte(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.>=: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.>=: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.>=") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => {
-            let result = if x >= y { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
-        }
+        (Value::Float(x), Value::Float(y)) => unsafe {
+            push(rest, Value::Int(if x >= y { 1 } else { 0 }))
+        },
         _ => panic!("f.>=: expected two Floats on stack"),
     }
 }
@@ -208,16 +167,11 @@ pub unsafe extern "C" fn patch_seq_f_gte(stack: Stack) -> Stack {
 /// Stack must have two Float values on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_f_neq(stack: Stack) -> Stack {
-    assert!(!stack.is_null(), "f.<>: stack is empty");
-    let (stack, b) = unsafe { pop(stack) };
-    assert!(!stack.is_null(), "f.<>: need two floats");
-    let (stack, a) = unsafe { pop(stack) };
-
+    let (rest, a, b) = unsafe { pop_two(stack, "f.<>") };
     match (a, b) {
-        (Value::Float(x), Value::Float(y)) => {
-            let result = if x != y { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
-        }
+        (Value::Float(x), Value::Float(y)) => unsafe {
+            push(rest, Value::Int(if x != y { 1 } else { 0 }))
+        },
         _ => panic!("f.<>: expected two Floats on stack"),
     }
 }

--- a/crates/runtime/src/stack.rs
+++ b/crates/runtime/src/stack.rs
@@ -61,6 +61,25 @@ pub unsafe fn pop(stack: Stack) -> (Stack, Value) {
     }
 }
 
+/// Pop two values from the stack (for binary operations)
+///
+/// Returns the rest of the stack and both values (first popped, second popped).
+/// This is a common pattern for binary operations like add, subtract, etc.
+///
+/// # Safety
+/// Stack must have at least two values
+///
+/// # Returns
+/// (remaining_stack, second_value, first_value) - note: second is "a", first is "b"
+/// for operations like a - b where b is on top
+pub unsafe fn pop_two(stack: Stack, op_name: &str) -> (Stack, Value, Value) {
+    assert!(!stack.is_null(), "{}: stack is empty", op_name);
+    let (rest, b) = unsafe { pop(stack) };
+    assert!(!rest.is_null(), "{}: need two values", op_name);
+    let (rest, a) = unsafe { pop(rest) };
+    (rest, a, b)
+}
+
 /// Check if the stack is empty
 pub fn is_empty(stack: Stack) -> bool {
     stack.is_null()


### PR DESCRIPTION
  I've completed several significant refactoring improvements:

  Completed

  1. Builtin Symbol Mapping - codegen.rs
    - Replaced 135-line match statement with a clean HashMap lookup
    - Now just 14 lines with centralized symbol definitions
    - Adding new builtins now requires only one entry in BUILTIN_SYMBOLS
  2. Capture Push Helper - codegen.rs
    - Extracted ~110 lines of repetitive capture type handling into emit_capture_push()
    - Closure code generation now uses a simple 3-line loop
  3. pop_two Helper - stack.rs, arithmetic.rs, float_ops.rs
    - Created pop_two(stack, op_name) helper with consistent error messages
    - Updated 22 binary operations to use it
    - Reduced ~4 lines per operation to 1 line each