### PR TITLE
⏺ All good on macOS:

### DIFF
--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -1121,7 +1121,16 @@ impl CodeGen {
             )
             .unwrap();
             writeln!(&mut self.output, "  ret ptr %{}", result_var).unwrap();
+        } else if is_seq_word {
+            // Non-tail call to user-defined word: must use tailcc calling convention
+            writeln!(
+                &mut self.output,
+                "  %{} = call tailcc ptr @{}(ptr %{})",
+                result_var, function_name, stack_var
+            )
+            .unwrap();
         } else {
+            // Call to builtin (C calling convention)
             writeln!(
                 &mut self.output,
                 "  %{} = call ptr @{}(ptr %{})",


### PR DESCRIPTION
  - patch-seq: 431 tests pass
  - seq-lisp: all tests pass
  - Test case works: 2 3 just-add outputs 5

  The fix adds tailcc to non-tail calls to user-defined words. Ready for you to test on Linux!