### PR TITLE
⏺ forever has been completely removed from the language:

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cargo test --all
 - Numeric literals: decimal, hex (`0xFF`), binary (`0b1010`)
 - Comparisons: `=`, `<`, `>`, `<=`, `>=`, `<>`
 - Conditionals: `if`/`else`/`then`
-- Quotations: First-class functions with `call`, `times`, `while`, `until`, `forever`
+- Quotations: First-class functions with `call`, `times`, `while`, `until`
 - Closures: Captured environments with type-driven inference
 
 **Tail Call Optimization:**

--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -269,7 +269,6 @@ impl Program {
             "times",
             "while",
             "until",
-            "forever",
             "spawn",
             "cond",
             // TCP operations

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -566,20 +566,6 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
         ),
     );
 
-    // forever: ( ..a Quotation -- ..a )
-    // Executes quotation infinitely. Quotation must have effect ( ..a -- ..a )
-    // Note: This never returns in practice, but type-wise it has same stack effect
-    sigs.insert(
-        "forever".to_string(),
-        Effect::new(
-            StackType::RowVar("a".to_string()).push(Type::Quotation(Box::new(Effect::new(
-                StackType::RowVar("a".to_string()),
-                StackType::RowVar("a".to_string()),
-            )))),
-            StackType::RowVar("a".to_string()),
-        ),
-    );
-
     // spawn: ( ..a Quotation -- ..a Int )
     // Spawns a quotation as a new strand, returns strand ID
     // The quotation should have effect ( -- ) (empty stack in, empty stack out)

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -94,7 +94,6 @@ static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock
         ("times", "patch_seq_times"),
         ("while", "patch_seq_while_loop"),
         ("until", "patch_seq_until_loop"),
-        ("forever", "patch_seq_forever"),
         ("spawn", "patch_seq_spawn"),
         ("cond", "patch_seq_cond"),
         // TCP operations
@@ -476,7 +475,6 @@ impl CodeGen {
         writeln!(&mut ir, "declare ptr @patch_seq_times(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_while_loop(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_until_loop(ptr)").unwrap();
-        writeln!(&mut ir, "declare ptr @patch_seq_forever(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_spawn(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_cond(ptr)").unwrap();
         writeln!(&mut ir, "; Closure operations").unwrap();

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -328,7 +328,6 @@ fn get_builtin_completions() -> Vec<CompletionItem> {
             "Loop until condition is true",
         ),
         ("times", "( quot n -- )", "Execute quotation n times"),
-        ("forever", "( quot -- )", "Execute quotation forever"),
         ("call", "( quot -- ... )", "Execute a quotation"),
         (
             "spawn",

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -93,8 +93,7 @@ pub use string_ops::{
 
 // Quotation operations (exported for LLVM linking)
 pub use quotations::{
-    patch_seq_call as call, patch_seq_forever as forever,
-    patch_seq_peek_is_quotation as peek_is_quotation,
+    patch_seq_call as call, patch_seq_peek_is_quotation as peek_is_quotation,
     patch_seq_peek_quotation_fn_ptr as peek_quotation_fn_ptr,
     patch_seq_push_quotation as push_quotation, patch_seq_spawn as spawn, patch_seq_times as times,
     patch_seq_until_loop as until_loop, patch_seq_while_loop as while_loop,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -373,7 +373,7 @@ json-empty-object "name" json-string "John" json-string obj-with
 
 ## Current Limitations
 
-1. **No loop keywords** - Use recursion (with TCO) or combinators (`times`, `while`, `forever`)
+1. **No loop keywords** - Use recursion (with TCO) or combinators (`times`, `while`, `until`)
 2. **Serialization size limits** - Arrays > 3 elements, objects > 2 pairs show as `[...]`/`{...}`
 3. **No string escapes** - `\"` not supported in strings
 4. **roll type checking** - `3 roll` works at runtime but type checker can't fully verify

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,4 +72,4 @@ Additional types for closure capture (lower priority since error messages now he
 
 - **Pattern matching syntax** - Stack destructuring via existing words is sufficient
 - **Let bindings / VALUE** - Not idiomatic for concatenative languages
-- **Loop syntax** - `while`, `until`, `times`, `forever` quotation combinators cover this
+- **Loop syntax** - `while`, `until`, `times` combinators plus recursion with TCO cover this

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -640,10 +640,9 @@ Build network servers with strand-per-connection:
 ;
 
 : accept-loop ( Int -- )
-    [
-        dup tcp-accept                    # ( listener client )
-        [ handle-client ] spawn drop      # spawn handler
-    ] forever
+    dup tcp-accept                    # ( listener client )
+    [ handle-client ] spawn drop      # spawn handler
+    accept-loop                       # tail call - runs forever, no stack growth
 ;
 
 : main ( -- )
@@ -653,9 +652,9 @@ Build network servers with strand-per-connection:
 ;
 ```
 
-Each connection runs in its own strand. The runtime handles scheduling - when
-one strand blocks on I/O, others continue running. No callbacks, no async/await,
-just sequential code that scales.
+Each connection runs in its own strand. The recursive `accept-loop` runs forever
+without growing the stack - TCO converts the tail call into a jump. No callbacks,
+no async/await, just sequential code that scales.
 
 ### Why Strands?
 

--- a/examples/http/http_server.seq
+++ b/examples/http/http_server.seq
@@ -401,47 +401,42 @@
 #
 # This runs forever, accepting connections and spawning workers.
 #
-# QUOTATIONS: The [ ... ] syntax creates a "quotation" - a block of code
-# that can be passed around as a value. Think of it like a lambda/closure.
+# TAIL CALL OPTIMIZATION: The recursive call to accept-loop at the end is
+# in tail position - the compiler converts it to a jump, so the stack never
+# grows. This is how Seq handles infinite loops: recursion + TCO.
 #
-# FOREVER: Takes a quotation and runs it in an infinite loop, preserving
-# whatever's on the stack between iterations.
+# Stack effect: ( listener_socket -- )
+# Note: This never returns - it loops forever via tail recursion.
 #
-# Stack effect: ( listener_socket -- Int )
-# Note: "forever" never actually returns, but we declare Int for type checking.
-#
-: accept-loop ( Int -- Int )
-  [
-    # This quotation runs once per connection.
-    # Stack at start of each iteration: ( listener_socket )
+: accept-loop ( Int -- )
+  # Stack: ( listener_socket )
 
-    dup tcp-accept
-    # dup:        ( listener_socket listener_socket )
-    # tcp-accept: ( listener_socket client_socket )
-    # We keep the listener to accept more connections!
+  dup tcp-accept
+  # dup:        ( listener_socket listener_socket )
+  # tcp-accept: ( listener_socket client_socket )
+  # We keep the listener to accept more connections!
 
-    make-channel
-    # Creates a channel for sending the socket to the worker
-    # Stack: ( listener_socket client_socket channel_id )
+  make-channel
+  # Creates a channel for sending the socket to the worker
+  # Stack: ( listener_socket client_socket channel_id )
 
-    dup [ worker ] spawn
-    # dup:    ( listener_socket client_socket channel_id channel_id )
-    # [ worker ]: Push the worker quotation
-    # spawn:  Start a new strand running "worker" with channel_id
-    # Stack: ( listener_socket client_socket channel_id strand_id )
+  dup [ worker ] spawn
+  # dup:    ( listener_socket client_socket channel_id channel_id )
+  # [ worker ]: Push the worker quotation
+  # spawn:  Start a new strand running "worker" with channel_id
+  # Stack: ( listener_socket client_socket channel_id strand_id )
 
-    drop
-    # We don't need the strand_id
-    # Stack: ( listener_socket client_socket channel_id )
+  drop
+  # We don't need the strand_id
+  # Stack: ( listener_socket client_socket channel_id )
 
-    send
-    # Send client_socket through the channel to the worker
-    # Stack: ( listener_socket )
-    # The worker receives the socket and handles the connection!
+  send
+  # Send client_socket through the channel to the worker
+  # Stack: ( listener_socket )
+  # The worker receives the socket and handles the connection!
 
-    # Loop continues with listener_socket ready for next accept
-  ]
-  forever
+  accept-loop
+  # Tail call - TCO converts this to a jump, no stack growth
 ;
 
 # ============================================================================
@@ -450,10 +445,10 @@
 #
 # Every Seq program needs a "main" word. This starts the server.
 #
-# Stack effect: ( -- Int )
-# The Int is the exit code (0 = success).
+# Stack effect: ( -- )
+# This server runs forever via tail recursion, never returning.
 #
-: main ( -- Int )
+: main ( -- )
   # Print startup messages
   "Starting concurrent HTTP server on port 8080..." write_line
   "Try: curl http://localhost:8080/" write_line
@@ -470,8 +465,7 @@
   "Listening..." write_line
 
   accept-loop
-  # Enters infinite loop accepting connections
-  # Never returns, but type system expects Int
+  # Enters infinite loop via tail recursion - never returns
 ;
 
 # ============================================================================

--- a/examples/include_demo/http_simple.seq
+++ b/examples/include_demo/http_simple.seq
@@ -33,23 +33,21 @@ include std:http
   tcp-close
 ;
 
-: accept-loop ( Int -- Int )
-  [
-    dup tcp-accept
-    make-channel
-    dup [ receive handle-connection ] spawn
-    drop
-    send
-  ]
-  forever
+: accept-loop ( Int -- )
+  dup tcp-accept
+  make-channel
+  dup [ receive handle-connection ] spawn
+  drop
+  send
+  accept-loop   # tail call - runs forever, no stack growth
 ;
 
-: main ( -- Int )
+: main ( -- )
   "Simple HTTP server using std:http" write_line
   "Listening on port 8080..." write_line
   "Try: curl http://localhost:8080/" write_line
   "Try: curl http://localhost:8080/health" write_line
   "Try: curl http://localhost:8080/custom" write_line
   8080 tcp-listen
-  accept-loop
+  accept-loop   # never returns
 ;


### PR DESCRIPTION
  Code removed from:
  - ast.rs - builtin list
  - builtins.rs - type signature
  - codegen.rs - LLVM mapping + declaration
  - quotations.rs - runtime implementation (~50 lines)
  - lib.rs - export
  - completion.rs - LSP autocomplete

  Docs updated:
  - README.md - removed from quotation combinators list
  - ROADMAP.md - replaced with "recursion with TCO"
  - ARCHITECTURE.md - removed from combinators list

  Examples updated:
  - http_server.seq - now uses tail-recursive accept-loop
  - http_simple.seq - now uses tail-recursive accept-loop

  Build passes, tests pass, examples compile. The language now embraces its philosophy: infinite loops are expressed through recursion, and TCO makes
  them safe.