### PR TITLE
⏺ make-variant has been completely removed from the codebase.

### DIFF
--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -213,7 +213,6 @@ impl Program {
             "variant-append",
             "variant-last",
             "variant-init",
-            "make-variant",
             "make-variant-0",
             "make-variant-1",
             "make-variant-2",

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -880,20 +880,6 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
         ),
     );
 
-    // make-variant: ( ..a field1 ... fieldN count tag -- ..a Variant )
-    // Create a variant with given tag and N fields (count specifies N)
-    // Type signature only validates count and tag are Ints; runtime validates field count
-    // WARNING: This builtin has incomplete type checking - use make-variant-N for type safety
-    sigs.insert(
-        "make-variant".to_string(),
-        Effect::new(
-            StackType::RowVar("a".to_string())
-                .push(Type::Int) // count
-                .push(Type::Int), // tag
-            StackType::RowVar("a".to_string()).push(Type::Var("V".to_string())),
-        ),
-    );
-
     // Type-safe variant constructors with fixed arity
     // These have proper type signatures that account for all consumed values
 

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -151,7 +151,6 @@ static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock
         ("variant-append", "patch_seq_variant_append"),
         ("variant-last", "patch_seq_variant_last"),
         ("variant-init", "patch_seq_variant_init"),
-        ("make-variant", "patch_seq_make_variant"),
         ("make-variant-0", "patch_seq_make_variant_0"),
         ("make-variant-1", "patch_seq_make_variant_1"),
         ("make-variant-2", "patch_seq_make_variant_2"),
@@ -590,7 +589,6 @@ impl CodeGen {
         writeln!(&mut ir, "declare ptr @patch_seq_variant_append(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_variant_last(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_variant_init(ptr)").unwrap();
-        writeln!(&mut ir, "declare ptr @patch_seq_make_variant(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_make_variant_0(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_make_variant_1(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_make_variant_2(ptr)").unwrap();

--- a/crates/compiler/stdlib/json.seq
+++ b/crates/compiler/stdlib/json.seq
@@ -104,7 +104,7 @@
 # Create a JSON null value
 # Stack: ( -- JsonNull )
 : json-null
-  0 0 make-variant
+  0 make-variant-0
 ;
 
 # Create a JSON boolean from an Int
@@ -112,29 +112,29 @@
 # Input: 0 for false, non-zero for true
 : json-bool
   0 <> if 1 else 0 then
-  1 1 make-variant
+  1 make-variant-1
 ;
 
 # Convenience: create JSON true
 : json-true
-  1 1 1 make-variant
+  1 1 make-variant-1
 ;
 
 # Convenience: create JSON false
 : json-false
-  0 1 1 make-variant
+  0 1 make-variant-1
 ;
 
 # Create a JSON number from a Float
 # Stack: ( Float -- JsonNumber )
 : json-number
-  1 2 make-variant
+  2 make-variant-1
 ;
 
 # Create a JSON string
 # Stack: ( String -- JsonString )
 : json-string
-  1 3 make-variant
+  3 make-variant-1
 ;
 
 # ============================================================================
@@ -422,7 +422,7 @@
 # Stack: ( String Int -- PState )
 # Note: PState is a variant with tag 100 and 2 fields [str, pos]
 : make-pstate
-  2 100 make-variant
+  100 make-variant-2
 ;
 
 # Get the string from parser state (non-destructive)
@@ -887,13 +887,13 @@
 # Create an empty JSON array
 # Stack: ( -- JsonArray )
 : json-empty-array ( -- Variant )
-  0 4 make-variant
+  4 make-variant-0
 ;
 
 # Create an empty JSON object
 # Stack: ( -- JsonObject )
 : json-empty-object ( -- Variant )
-  0 5 make-variant
+  5 make-variant-0
 ;
 
 # Skip whitespace characters

--- a/crates/compiler/stdlib/yaml.seq
+++ b/crates/compiler/stdlib/yaml.seq
@@ -54,28 +54,28 @@
 
 # Create a YAML null value
 : yaml-null
-  0 0 make-variant
+  0 make-variant-0
 ;
 
 # Create a YAML boolean (0 or 1)
 : yaml-bool
   0 <> if 1 else 0 then
-  1 1 make-variant
+  1 make-variant-1
 ;
 
 # Create a YAML number from a Float
 : yaml-number
-  1 2 make-variant
+  2 make-variant-1
 ;
 
 # Create a YAML string
 : yaml-string
-  1 3 make-variant
+  3 make-variant-1
 ;
 
 # Create an empty YAML object
 : yaml-empty-object
-  0 5 make-variant
+  5 make-variant-0
 ;
 
 # ============================================================================

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -118,10 +118,9 @@ pub use tcp::{
 
 // Variant operations (exported for LLVM linking)
 pub use variant_ops::{
-    patch_seq_make_variant as make_variant, patch_seq_make_variant_0 as make_variant_0,
-    patch_seq_make_variant_1 as make_variant_1, patch_seq_make_variant_2 as make_variant_2,
-    patch_seq_make_variant_3 as make_variant_3, patch_seq_make_variant_4 as make_variant_4,
-    patch_seq_variant_field_at as variant_field_at,
+    patch_seq_make_variant_0 as make_variant_0, patch_seq_make_variant_1 as make_variant_1,
+    patch_seq_make_variant_2 as make_variant_2, patch_seq_make_variant_3 as make_variant_3,
+    patch_seq_make_variant_4 as make_variant_4, patch_seq_variant_field_at as variant_field_at,
     patch_seq_variant_field_count as variant_field_count, patch_seq_variant_tag as variant_tag,
 };
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,15 +131,16 @@ Types are inferred at compile time. The type checker:
 Variants are tagged unions with N fields:
 
 ```seq
-# Create: field1 field2 ... fieldN count tag make-variant
-42 "hello" 2 1 make-variant    # Tag 1 with fields [42, "hello"]
+# Create using typed constructors (0-4 fields)
+42 "hello" 1 make-variant-2    # Tag 1 with fields [42, "hello"]
+5 make-variant-0               # Tag 5 with no fields
 
 # Access
 variant-tag           # ( Variant -- Int )
 variant-field-count   # ( Variant -- Int )
 0 variant-field-at    # ( Variant Int -- Value )
 
-# Functional append
+# Functional append (for building dynamic collections)
 value variant-append  # ( Variant Value -- Variant' )
 ```
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,8 +1,8 @@
 # Known Issues
 
-## make-variant Type Annotation Bug (FIXED)
+## make-variant Type Annotation Bug (RESOLVED)
 
-**Status**: Fixed in this commit
+**Status**: Resolved - old `make-variant` removed, typed constructors available
 **Discovered**: During SeqLisp implementation exercise
 
 ### Problem
@@ -11,7 +11,7 @@ The original `make-variant` builtin had an incomplete type signature that didn't
 
 ### Solution
 
-Added type-safe variant constructors with fixed arity:
+Replaced with type-safe variant constructors with fixed arity:
 
 - `make-variant-0`: `( tag -- Variant )` - 0 fields
 - `make-variant-1`: `( field1 tag -- Variant )` - 1 field
@@ -22,29 +22,22 @@ Added type-safe variant constructors with fixed arity:
 ### Usage
 
 ```seq
-# Old way (incomplete type checking):
 : snum ( Int -- Variant )
-  1 1 make-variant ;   # ERROR: type mismatch
+  1 make-variant-1 ;   # Type-safe!
 
-# New way (proper type safety):
-: snum ( Int -- Variant )
-  1 make-variant-1 ;   # Works correctly!
+: empty-array ( -- Variant )
+  4 make-variant-0 ;   # Tag 4, no fields
 ```
 
-### Note
+### Migration Completed
 
-The original `make-variant` is still available for backward compatibility and for cases where the field count is dynamic, but it provides incomplete type checking. Prefer the typed `make-variant-N` variants for type safety.
+- ✅ `make-variant-N` variants implemented (0-4 fields)
+- ✅ `json.seq` migrated to use typed variants
+- ✅ `yaml.seq` migrated to use typed variants
+- ✅ Original `make-variant` removed
 
 ### Future Work
 
-We plan to revisit the type inference system to:
-
-1. **Remove `make-variant`**: Once all code is migrated to use the typed `make-variant-N` variants, deprecate and remove the original `make-variant` to prevent accidentally bypassing type safety.
-
-2. **Evaluate more robust solutions**: The fixed-arity approach works but has limitations (max 4 fields, verbose for common cases). Potential improvements to discuss:
-   - **Literal tracking in type system**: Infer field count from compile-time literal values
-   - **Dependent types**: Full dependent type support (significant complexity)
-   - **Macro-based generation**: Generate `make-variant-N` at compile time based on usage
-   - **Builder pattern**: Functional variant construction with `variant-new` / `variant-with-field`
-
-3. **Update stdlib**: Migrate `json.seq`, `yaml.seq`, and other stdlib code to use typed variants.
+The fixed-arity approach works but has limitations (max 4 fields). If needed, potential improvements:
+- Add `make-variant-5` through `make-variant-N` as needed
+- Use `variant-append` for building dynamic collections (already supported)

--- a/docs/TYPE_SYSTEM_GUIDE.md
+++ b/docs/TYPE_SYSTEM_GUIDE.md
@@ -485,16 +485,21 @@ Higher-order combinators like `map` are not yet in the standard library.
 
 ### Variants (Runtime Algebraic Types)
 
-Seq supports variants (tagged unions) at runtime via `make-variant`:
+Seq supports variants (tagged unions) at runtime via typed constructors:
 
 ```seq
 # Create a variant with tag 1 and 2 fields
-42 "hello" 2 1 make-variant  # Tag 1, 2 fields
+42 "hello" 1 make-variant-2  # Tag 1, 2 fields
+
+# Empty variant (0 fields)
+5 make-variant-0             # Tag 5, no fields
 
 # Access variant data
-variant-tag       # Get the tag (Int)
+variant-tag         # Get the tag (Int)
 0 variant-field-at  # Get field at index 0
 ```
+
+Available constructors: `make-variant-0` through `make-variant-4` for 0-4 fields.
 
 Variants are dynamically typed at runtime. Full compile-time algebraic data type syntax is planned for a future phase:
 

--- a/examples/yaml/README.md
+++ b/examples/yaml/README.md
@@ -13,7 +13,7 @@ allows building complex parsers without language changes.
 The YAML parser uses these existing primitives:
 - String operations: `string-find`, `string-substring`, `string-trim`, `string-empty`, `string-length`, `string-char-at`, `string-concat`, `string->float`
 - Character conversion: `char->string`
-- Variant operations: `make-variant`, `variant-tag`, `variant-field-at`, `variant-field-count`, `variant-append`
+- Variant operations: `make-variant-0`, `make-variant-1`, `variant-tag`, `variant-field-at`, `variant-field-count`, `variant-append`
 - Standard stack operations: `dup`, `drop`, `swap`, `over`, `rot`
 - Arithmetic and comparison: `add`, `subtract`, `<`, `>`, `=`, `<>`
 - Control flow: `if/else/then`

--- a/tests/integration/src/test-variant-typed.seq
+++ b/tests/integration/src/test-variant-typed.seq
@@ -1,7 +1,7 @@
 # Test type-safe make-variant-N builtins
 #
 # These builtins properly account for field consumption in the type system,
-# unlike the original make-variant which has incomplete type checking.
+# providing compile-time type safety for variant creation.
 
 # 0 fields: empty variant
 : make-empty ( -- Variant )


### PR DESCRIPTION
  Summary of changes:

  | File                                         | Change                                             |
  |----------------------------------------------|----------------------------------------------------|
  | crates/compiler/src/ast.rs                   | Removed from builtin list                          |
  | crates/compiler/src/builtins.rs              | Removed type signature                             |
  | crates/compiler/src/codegen.rs               | Removed LLVM mapping + declaration                 |
  | crates/runtime/src/variant_ops.rs            | Removed implementation (~65 lines) + updated tests |
  | crates/runtime/src/lib.rs                    | Removed export                                     |
  | docs/ARCHITECTURE.md                         | Updated examples                                   |
  | docs/TYPE_SYSTEM_GUIDE.md                    | Updated examples                                   |
  | docs/KNOWN_ISSUES.md                         | Updated to show issue resolved                     |
  | examples/yaml/README.md                      | Updated primitives list                            |
  | tests/integration/src/test-variant-typed.seq | Updated comment                                    |

  All 436 tests pass. JSON and YAML stdlib work correctly.