### PR TITLE
Clang Check

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -120,17 +120,17 @@ fn parse_clang_version(output: &str) -> Option<u32> {
     // Look for "clang version X.Y.Z" pattern to avoid false positives
     // This handles: "clang version", "Apple clang version", "Homebrew clang version", etc.
     for line in output.lines() {
-        if line.contains("clang version") {
-            if let Some(idx) = line.find("version ") {
-                let after_version = &line[idx + 8..];
-                // Extract the major version number
-                let major: String = after_version
-                    .chars()
-                    .take_while(|c| c.is_ascii_digit())
-                    .collect();
-                if !major.is_empty() {
-                    return major.parse().ok();
-                }
+        if line.contains("clang version")
+            && let Some(idx) = line.find("version ")
+        {
+            let after_version = &line[idx + 8..];
+            // Extract the major version number
+            let major: String = after_version
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if !major.is_empty() {
+                return major.parse().ok();
             }
         }
     }


### PR DESCRIPTION
  Clang version check:
  - Added MIN_CLANG_VERSION = 15 constant (our IR uses opaque pointers)
  - check_clang_version() runs clang --version and parses the output
  - Handles different clang flavors: standard, Apple, Homebrew, Ubuntu
  - Apple clang 14+ maps to LLVM 15, so we allow that
  - Clear error messages explaining why the version matters and how to fix it
  - Called before invoking clang to compile the IR

  If someone has an old clang, they'll see:
  clang version 13 detected, but seqc requires clang 15 or later.
  The generated LLVM IR uses opaque pointers (requires LLVM 15+).
  Please upgrade your clang installation.