### PR TITLE
fix for https://github.com/navicore/patch-seq/issues/65

### DIFF
--- a/crates/compiler/src/unification.rs
+++ b/crates/compiler/src/unification.rs
@@ -139,6 +139,18 @@ pub fn unify_types(t1: &Type, t2: &Type) -> Result<Subst, String> {
         | (Type::Bool, Type::Bool)
         | (Type::String, Type::String) => Ok(Subst::empty()),
 
+        // Union types unify if they have the same name
+        (Type::Union(name1), Type::Union(name2)) => {
+            if name1 == name2 {
+                Ok(Subst::empty())
+            } else {
+                Err(format!(
+                    "Type mismatch: cannot unify Union({}) with Union({})",
+                    name1, name2
+                ))
+            }
+        }
+
         // Type variable unifies with anything (with occurs check)
         (Type::Var(name), ty) | (ty, Type::Var(name)) => {
             // If unifying a variable with itself, no substitution needed

--- a/tests/integration/expected/test-union-same-type-fields.txt
+++ b/tests/integration/expected/test-union-same-type-fields.txt
@@ -1,0 +1,1 @@
+PASS: Make-MakeLambda with two Sexpr fields

--- a/tests/integration/src/test-union-same-type-fields.seq
+++ b/tests/integration/src/test-union-same-type-fields.seq
@@ -1,0 +1,35 @@
+# Test case for Issue #65: Union type unification with same-type fields
+#
+# This tests if a variant with two fields of the same union type
+# causes unification errors. NO INCLUDES used - single file test.
+
+# Define a simple union type
+union Sexpr {
+  Nil
+  Number { value: Int }
+}
+
+# Variant with TWO fields of the SAME union type (Sexpr)
+union Lambda {
+  MakeLambda { params: Sexpr, body: Sexpr }
+}
+
+# Constructor: Make-MakeLambda ( Sexpr Sexpr -- Lambda )
+# This should work - two Sexpr values go in, one Lambda comes out
+
+: test-make-lambda ( -- )
+  # Create two Sexpr values
+  42 Make-Number     # First Sexpr (params)
+  99 Make-Number     # Second Sexpr (body)
+
+  # Create the Lambda with both Sexpr values
+  Make-MakeLambda
+
+  # If we get here, unification worked
+  drop
+  "PASS: Make-MakeLambda with two Sexpr fields" write_line
+;
+
+: main ( -- )
+  test-make-lambda
+;


### PR DESCRIPTION
⏺ All 20 tests pass including our new test.

⏺ Summary of the fix for Issue #65:

  1. Root cause: The unify_types function in unification.rs didn't have a case for Type::Union. When unifying two union types (even identical ones like Union("Sexpr") with Union("Sexpr")), they fell through to the default _ catch-all case which always returns an error.
  2. The bug was NOT related to includes - we reproduced it with a single-file test case. As you suspected, includes just flatten everything into a single code stream.
  3. The fix: Added a simple pattern match case for union types: (Type::Union(name1), Type::Union(name2)) => { if name1 == name2 { Ok(Subst::empty()) } else { Err(format!("Type mismatch: cannot unify Union({}) with Union({})", name1, name2)) } }
  4. Test added: tests/integration/src/test-union-same-type-fields.seq which creates a variant with two fields of the same union type.