### PR TITLE
fix for issue 66

### DIFF
--- a/docs/TCO_GUIDE.md
+++ b/docs/TCO_GUIDE.md
@@ -172,9 +172,9 @@ call, it gets TCO:
   match
     SNil ->
       0                    # Base case, no recursion
-    SCons { head tail } ->
-      head do-something    # Not tail position
-      tail process-list    # Last statement - gets TCO ✓
+    SCons { >head >tail } ->
+      swap do-something    # Not tail position (head on stack)
+      process-list         # Last statement - gets TCO ✓
   end
 ;
 ```
@@ -185,15 +185,18 @@ tail call behavior:
 ```seq
 : eval-expr ( Expr -- Value )
   match
-    Literal { value } ->
-      value                # No recursion needed
-    BinOp { left op right } ->
-      left eval-expr       # NOT tail - result used below
-      right eval-expr
-      op apply-op
-    Call { func args } ->
-      args eval-args
-      func eval-expr       # Last statement - gets TCO ✓
+    Literal { >value } ->
+      # value on stack
+                           # No recursion needed
+    BinOp { >left >op >right } ->
+      # Stack: ( left op right )
+      rot eval-expr        # NOT tail - result used below
+      swap eval-expr
+      apply-op
+    Call { >func >args } ->
+      # Stack: ( func args )
+      eval-args
+      eval-expr            # Last statement - gets TCO ✓
   end
 ;
 ```

--- a/docs/design/ADT_DESIGN.md
+++ b/docs/design/ADT_DESIGN.md
@@ -57,17 +57,17 @@ All fields pushed to stack in declaration order:
 
 #### Named Bindings (Pragmatic)
 
-Only requested fields, in specified order:
+Only requested fields, in specified order. The `>` prefix indicates stack extraction (not variable binding):
 
 ```seq
 : handle ( Message -- )
   match
-    Get { chan } ->         # ( chan )
-      chan send-response
-    Increment { chan } ->   # ( chan )
-      do-increment chan send-response
-    Report { delta } ->     # ( delta )
-      delta aggregate-add
+    Get { >chan } ->         # ( chan )
+      send-response
+    Increment { >chan } ->   # ( chan )
+      do-increment swap send-response
+    Report { >delta } ->     # ( delta )
+      aggregate-add
   end
 ;
 ```
@@ -96,7 +96,7 @@ Both styles can be used in the same codebase, even different arms of the same ma
 
 : complex-handler ( Message -- )
   match
-    Report { delta total } -> delta total process
+    Report { >delta >total } -> process
   end
 ;
 ```
@@ -111,7 +111,7 @@ union Option { Some { value: Int }, None }
 # Row polymorphic in ..a, works with ADT
 : unwrap-or ( ..a Option Int -- ..a Int )
   match
-    Some { value } -> drop value
+    Some { >value } -> drop value
     None ->          # use default already on stack
   end
 ;

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -347,22 +347,24 @@ All fields are pushed to stack in declaration order:
 
 ### Named Bindings
 
-Request specific fields by name:
+Request specific fields by name using `>` prefix (indicating stack extraction, not variable binding):
 
 ```seq
 : handle ( Message -- )
   match
-    Get { response-chan } ->
-      response-chan send-response
-    Increment { amount } ->
-      amount do-increment
-    Report { delta } ->     # only 'delta' pushed to stack
-      delta process
+    Get { >response-chan } ->
+      # response-chan is now on stack
+      send-response
+    Increment { >amount } ->
+      # amount is now on stack
+      do-increment
+    Report { >delta } ->     # only 'delta' pushed to stack
+      process
   end
 ;
 ```
 
-Both styles compile to identical code. Mix them freely.
+The `>` prefix makes clear these are stack extractions, not local variables. Both styles compile to identical code. Mix them freely.
 
 ### ADTs with Row Polymorphism
 
@@ -374,7 +376,7 @@ union Option { Some { value: Int }, None }
 # Row polymorphic - extra stack values pass through
 : unwrap-or ( ..a Option Int -- ..a Int )
   match
-    Some { value } -> drop value
+    Some { >value } -> drop value
     None ->          # use default already on stack
   end
 ;

--- a/examples/csp/actor_counters.seq
+++ b/examples/csp/actor_counters.seq
@@ -87,13 +87,13 @@ union Message {
   2 pick receive             # ( parent my count pending msg )
 
   match
-    Get { response_chan } ->
+    Get { >response_chan } ->
       # Return current count on response channel
       # Stack: ( parent my count pending response_chan )
       2 pick swap send       # ( parent my count pending )
       store-loop
 
-    Increment { response_chan } ->
+    Increment { >response_chan } ->
       # Increment counter and return new count
       # Stack: ( parent my count pending response_chan )
       rot 1 add              # ( parent my pending response_chan count+1 )
@@ -142,13 +142,13 @@ union Message {
   over receive               # ( parent my total msg )
 
   match
-    Get { response_chan } ->
+    Get { >response_chan } ->
       # Return aggregate total on response channel
       # Stack: ( parent my total response_chan )
       over swap send         # ( parent my total ) - sent total
       district-loop
 
-    Report { delta } ->
+    Report { >delta } ->
       # Add delta, forward to region immediately
       # Stack: ( parent my total delta )
       dup rot add            # ( parent my delta total+delta )
@@ -187,13 +187,13 @@ union Message {
   over receive               # ( parent my total msg )
 
   match
-    Get { response_chan } ->
+    Get { >response_chan } ->
       # Return aggregate total on response channel
       # Stack: ( parent my total response_chan )
       over swap send         # ( parent my total )
       region-loop
 
-    Report { delta } ->
+    Report { >delta } ->
       # Add delta, forward to company immediately
       # Stack: ( parent my total delta )
       dup rot add            # ( parent my delta total+delta )
@@ -231,13 +231,13 @@ union Message {
   over receive               # ( my-chan total msg )
 
   match
-    Get { response_chan } ->
+    Get { >response_chan } ->
       # Return aggregate total on response channel
       # Stack: ( my-chan total response_chan )
       over swap send         # ( my-chan total )
       company-loop
 
-    Report { delta } ->
+    Report { >delta } ->
       # Add delta (no forwarding - company is top of hierarchy)
       # Stack: ( my-chan total delta )
       add                    # ( my-chan total+delta )

--- a/examples/lisp/eval.seq
+++ b/examples/lisp/eval.seq
@@ -91,7 +91,7 @@ include "parser"
       # Stack after match: ( Expr Env value )
       # SNum - return original Expr as-is
       drop drop  # ( Expr )
-    SSym { name } ->
+    SSym { >name } ->
       # Stack after match: ( Expr Env name )
       # SSym - lookup in environment
       rot drop  # ( Env name )

--- a/examples/lisp/sexpr.seq
+++ b/examples/lisp/sexpr.seq
@@ -80,12 +80,12 @@ union SexprList {
 
 : sexpr-to-string ( Sexpr -- String )
   match
-    SNum { value } ->
+    SNum { >value } ->
       # Stack: ( value )
       int->string
-    SSym { name } ->
+    SSym { >name } ->
       # Stack: ( name ) - already a string
-    SList { items } ->
+    SList { >items } ->
       # Stack: ( items )
       list-to-string
   end
@@ -99,7 +99,7 @@ union SexprList {
   match
     SNil ->
       ""
-    SCons { head tail } ->
+    SCons { >head >tail } ->
       # Stack: ( head tail )
       swap sexpr-to-string  # ( tail head_str )
       swap                  # ( head_str tail )


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/66

⏺ Done! Here's a summary of the changes for Issue #66:

  Summary:

  The match binding syntax now requires a > prefix to make clear these are stack extractions, not variable bindings (like Rust's 'a for lifetimes):

  Before (confusing):
  SCons { head tail } ->
    swap process    # Users surprised they need swap

  After (clear):
  SCons { >head >tail } ->
    swap process    # The > signals "pushed to stack"

  Changes made:
  1. Parser (parser.rs): Updated to require > prefix, with helpful error message
  2. Examples: Updated examples/lisp/sexpr.seq, examples/lisp/eval.seq, examples/csp/actor_counters.seq
  3. Docs: Updated language-guide.md, TCO_GUIDE.md, ADT_DESIGN.md
  4. Tests: Added test for old syntax rejection, updated existing binding test