### PR TITLE
os phase 2

### DIFF
--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -387,6 +387,9 @@ impl Program {
             "getenv",
             "home-dir",
             "current-dir",
+            "path-exists",
+            "path-is-file",
+            "path-is-dir",
             // Float arithmetic operations
             "f.add",
             "f.subtract",

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -685,6 +685,36 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
         ),
     );
 
+    // path-exists: ( ..a String -- ..a Int )
+    // Check if path exists, returns 1 if exists, 0 otherwise
+    sigs.insert(
+        "path-exists".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::String),
+            StackType::RowVar("a".to_string()).push(Type::Int),
+        ),
+    );
+
+    // path-is-file: ( ..a String -- ..a Int )
+    // Check if path is a regular file, returns 1 if file, 0 otherwise
+    sigs.insert(
+        "path-is-file".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::String),
+            StackType::RowVar("a".to_string()).push(Type::Int),
+        ),
+    );
+
+    // path-is-dir: ( ..a String -- ..a Int )
+    // Check if path is a directory, returns 1 if directory, 0 otherwise
+    sigs.insert(
+        "path-is-dir".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::String),
+            StackType::RowVar("a".to_string()).push(Type::Int),
+        ),
+    );
+
     // String operations
     // string-concat: ( ..a String String -- ..a String )
     // Concatenate two strings

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -107,6 +107,9 @@ static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock
         ("getenv", "patch_seq_getenv"),
         ("home-dir", "patch_seq_home_dir"),
         ("current-dir", "patch_seq_current_dir"),
+        ("path-exists", "patch_seq_path_exists"),
+        ("path-is-file", "patch_seq_path_is_file"),
+        ("path-is-dir", "patch_seq_path_is_dir"),
         // String operations
         ("string-concat", "patch_seq_string_concat"),
         ("string-length", "patch_seq_string_length"),
@@ -659,6 +662,9 @@ impl CodeGen {
         writeln!(&mut ir, "declare ptr @patch_seq_getenv(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_home_dir(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_current_dir(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_path_exists(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_path_is_file(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_path_is_dir(ptr)").unwrap();
         writeln!(&mut ir, "; String operations").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_concat(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_length(ptr)").unwrap();
@@ -984,6 +990,9 @@ impl CodeGen {
         writeln!(ir, "declare ptr @patch_seq_getenv(ptr)").unwrap();
         writeln!(ir, "declare ptr @patch_seq_home_dir(ptr)").unwrap();
         writeln!(ir, "declare ptr @patch_seq_current_dir(ptr)").unwrap();
+        writeln!(ir, "declare ptr @patch_seq_path_exists(ptr)").unwrap();
+        writeln!(ir, "declare ptr @patch_seq_path_is_file(ptr)").unwrap();
+        writeln!(ir, "declare ptr @patch_seq_path_is_dir(ptr)").unwrap();
         writeln!(ir, "; String operations").unwrap();
         writeln!(ir, "declare ptr @patch_seq_string_concat(ptr)").unwrap();
         writeln!(ir, "declare ptr @patch_seq_string_length(ptr)").unwrap();

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -118,6 +118,13 @@ pub use tcp::{
     patch_seq_tcp_write as tcp_write,
 };
 
+// OS operations (exported for LLVM linking)
+pub use os::{
+    patch_seq_current_dir as current_dir, patch_seq_getenv as getenv,
+    patch_seq_home_dir as home_dir, patch_seq_path_exists as path_exists,
+    patch_seq_path_is_dir as path_is_dir, patch_seq_path_is_file as path_is_file,
+};
+
 // Variant operations (exported for LLVM linking)
 pub use variant_ops::{
     patch_seq_make_variant_0 as make_variant_0, patch_seq_make_variant_1 as make_variant_1,

--- a/crates/runtime/src/os.rs
+++ b/crates/runtime/src/os.rs
@@ -96,3 +96,78 @@ pub unsafe extern "C" fn patch_seq_current_dir(stack: Stack) -> Stack {
         }
     }
 }
+
+/// Check if a path exists
+///
+/// Stack effect: ( path -- exists )
+///
+/// Returns 1 if path exists, 0 otherwise.
+///
+/// # Safety
+/// Stack must have a String (path) on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_path_exists(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, path_val) = pop(stack);
+        let path = match path_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-exists: expected String (path) on stack, got {:?}",
+                path_val
+            ),
+        };
+
+        let exists = std::path::Path::new(path.as_str()).exists();
+        push(stack, Value::Int(if exists { 1 } else { 0 }))
+    }
+}
+
+/// Check if a path is a regular file
+///
+/// Stack effect: ( path -- is-file )
+///
+/// Returns 1 if path is a regular file, 0 otherwise.
+///
+/// # Safety
+/// Stack must have a String (path) on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_path_is_file(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, path_val) = pop(stack);
+        let path = match path_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-is-file: expected String (path) on stack, got {:?}",
+                path_val
+            ),
+        };
+
+        let is_file = std::path::Path::new(path.as_str()).is_file();
+        push(stack, Value::Int(if is_file { 1 } else { 0 }))
+    }
+}
+
+/// Check if a path is a directory
+///
+/// Stack effect: ( path -- is-dir )
+///
+/// Returns 1 if path is a directory, 0 otherwise.
+///
+/// # Safety
+/// Stack must have a String (path) on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_path_is_dir(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, path_val) = pop(stack);
+        let path = match path_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-is-dir: expected String (path) on stack, got {:?}",
+                path_val
+            ),
+        };
+
+        let is_dir = std::path::Path::new(path.as_str()).is_dir();
+        push(stack, Value::Int(if is_dir { 1 } else { 0 }))
+    }
+}

--- a/examples/os/os-demo.seq
+++ b/examples/os/os-demo.seq
@@ -4,6 +4,9 @@
 #   - getenv: Get environment variables
 #   - home-dir: Get user's home directory
 #   - current-dir: Get current working directory
+#   - path-exists: Check if path exists
+#   - path-is-file: Check if path is a regular file
+#   - path-is-dir: Check if path is a directory
 #
 # Build and run:
 #   seqc examples/os/os-demo.seq -o os-demo
@@ -61,6 +64,60 @@
     drop "  Found (unexpected)" write_line
   else
     drop "  Not found (expected)" write_line
+  then
+  "" write_line
+
+  # Test path operations
+  "Path operations:" write_line
+
+  # Test with current directory (should exist and be a directory)
+  "." path-exists if
+    "  '.' exists: yes" write_line
+  else
+    "  '.' exists: no (unexpected)" write_line
+  then
+
+  "." path-is-dir if
+    "  '.' is directory: yes" write_line
+  else
+    "  '.' is directory: no (unexpected)" write_line
+  then
+
+  "." path-is-file if
+    "  '.' is file: yes (unexpected)" write_line
+  else
+    "  '.' is file: no" write_line
+  then
+  "" write_line
+
+  # Test with a path that shouldn't exist
+  "/this/path/does/not/exist/12345" path-exists if
+    "  Non-existent path exists: yes (unexpected)" write_line
+  else
+    "  Non-existent path exists: no" write_line
+  then
+  "" write_line
+
+  # Test with home directory (should exist and be a directory)
+  home-dir if
+    dup "  Testing home dir: " swap string-concat write_line
+    dup path-exists if
+      "    exists: yes" write_line
+    else
+      "    exists: no (unexpected)" write_line
+    then
+    dup path-is-dir if
+      "    is directory: yes" write_line
+    else
+      "    is directory: no (unexpected)" write_line
+    then
+    path-is-file if
+      "    is file: yes (unexpected)" write_line
+    else
+      "    is file: no" write_line
+    then
+  else
+    drop "  Could not get home directory" write_line
   then
 
   "" write_line


### PR DESCRIPTION
⏺ Phase 2 implementation complete. Summary of changes:

  Runtime (crates/runtime/src/os.rs):
  - patch_seq_path_exists - check if path exists
  - patch_seq_path_is_file - check if path is a regular file
  - patch_seq_path_is_dir - check if path is a directory

  Compiler updates:
  - ast.rs - added intrinsics: path-exists, path-is-file, path-is-dir
  - builtins.rs - added stack effects: ( String -- Int ) for all three
  - codegen.rs - added mappings and extern declarations (both locations)
  - lib.rs - added exports for all OS functions (including Phase 1 exports that were missing)

  Demo updated (examples/os/os-demo.seq):
  - Tests all three new functions with ., a non-existent path, and home directory

  All 489 tests pass, and the demo output shows:
  Path operations:
    '.' exists: yes '.' is directory: yes '.' is file: no

    Non-existent path exists: no

    Testing home dir: /Users/navicore
      exists: yes
      is directory: yes
      is file: no