### PR TITLE
os phase 3

### DIFF
--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -390,6 +390,9 @@ impl Program {
             "path-exists",
             "path-is-file",
             "path-is-dir",
+            "path-join",
+            "path-parent",
+            "path-filename",
             // Float arithmetic operations
             "f.add",
             "f.subtract",

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -715,6 +715,42 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
         ),
     );
 
+    // path-join: ( ..a String String -- ..a String )
+    // Join two path components
+    sigs.insert(
+        "path-join".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string())
+                .push(Type::String)
+                .push(Type::String),
+            StackType::RowVar("a".to_string()).push(Type::String),
+        ),
+    );
+
+    // path-parent: ( ..a String -- ..a String Int )
+    // Get parent directory, returns path and success flag
+    sigs.insert(
+        "path-parent".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::String),
+            StackType::RowVar("a".to_string())
+                .push(Type::String)
+                .push(Type::Int),
+        ),
+    );
+
+    // path-filename: ( ..a String -- ..a String Int )
+    // Get filename component, returns filename and success flag
+    sigs.insert(
+        "path-filename".to_string(),
+        Effect::new(
+            StackType::RowVar("a".to_string()).push(Type::String),
+            StackType::RowVar("a".to_string())
+                .push(Type::String)
+                .push(Type::Int),
+        ),
+    );
+
     // String operations
     // string-concat: ( ..a String String -- ..a String )
     // Concatenate two strings

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -110,6 +110,9 @@ static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock
         ("path-exists", "patch_seq_path_exists"),
         ("path-is-file", "patch_seq_path_is_file"),
         ("path-is-dir", "patch_seq_path_is_dir"),
+        ("path-join", "patch_seq_path_join"),
+        ("path-parent", "patch_seq_path_parent"),
+        ("path-filename", "patch_seq_path_filename"),
         // String operations
         ("string-concat", "patch_seq_string_concat"),
         ("string-length", "patch_seq_string_length"),
@@ -665,6 +668,9 @@ impl CodeGen {
         writeln!(&mut ir, "declare ptr @patch_seq_path_exists(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_path_is_file(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_path_is_dir(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_path_join(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_path_parent(ptr)").unwrap();
+        writeln!(&mut ir, "declare ptr @patch_seq_path_filename(ptr)").unwrap();
         writeln!(&mut ir, "; String operations").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_concat(ptr)").unwrap();
         writeln!(&mut ir, "declare ptr @patch_seq_string_length(ptr)").unwrap();
@@ -993,6 +999,9 @@ impl CodeGen {
         writeln!(ir, "declare ptr @patch_seq_path_exists(ptr)").unwrap();
         writeln!(ir, "declare ptr @patch_seq_path_is_file(ptr)").unwrap();
         writeln!(ir, "declare ptr @patch_seq_path_is_dir(ptr)").unwrap();
+        writeln!(ir, "declare ptr @patch_seq_path_join(ptr)").unwrap();
+        writeln!(ir, "declare ptr @patch_seq_path_parent(ptr)").unwrap();
+        writeln!(ir, "declare ptr @patch_seq_path_filename(ptr)").unwrap();
         writeln!(ir, "; String operations").unwrap();
         writeln!(ir, "declare ptr @patch_seq_string_concat(ptr)").unwrap();
         writeln!(ir, "declare ptr @patch_seq_string_length(ptr)").unwrap();

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -122,7 +122,9 @@ pub use tcp::{
 pub use os::{
     patch_seq_current_dir as current_dir, patch_seq_getenv as getenv,
     patch_seq_home_dir as home_dir, patch_seq_path_exists as path_exists,
-    patch_seq_path_is_dir as path_is_dir, patch_seq_path_is_file as path_is_file,
+    patch_seq_path_filename as path_filename, patch_seq_path_is_dir as path_is_dir,
+    patch_seq_path_is_file as path_is_file, patch_seq_path_join as path_join,
+    patch_seq_path_parent as path_parent,
 };
 
 // Variant operations (exported for LLVM linking)

--- a/crates/runtime/src/os.rs
+++ b/crates/runtime/src/os.rs
@@ -171,3 +171,110 @@ pub unsafe extern "C" fn patch_seq_path_is_dir(stack: Stack) -> Stack {
         push(stack, Value::Int(if is_dir { 1 } else { 0 }))
     }
 }
+
+/// Join two path components
+///
+/// Stack effect: ( base component -- joined )
+///
+/// Joins the base path with the component using the platform's path separator.
+///
+/// # Safety
+/// Stack must have two Strings on top (base, then component)
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_path_join(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, component_val) = pop(stack);
+        let (stack, base_val) = pop(stack);
+
+        let base = match base_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-join: expected String (base) on stack, got {:?}",
+                base_val
+            ),
+        };
+
+        let component = match component_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-join: expected String (component) on stack, got {:?}",
+                component_val
+            ),
+        };
+
+        let joined = std::path::Path::new(base.as_str())
+            .join(component.as_str())
+            .to_string_lossy()
+            .into_owned();
+
+        push(stack, Value::String(global_string(joined)))
+    }
+}
+
+/// Get the parent directory of a path
+///
+/// Stack effect: ( path -- parent success )
+///
+/// Returns the parent directory and 1 on success, "" and 0 if no parent.
+///
+/// # Safety
+/// Stack must have a String (path) on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_path_parent(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, path_val) = pop(stack);
+        let path = match path_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-parent: expected String (path) on stack, got {:?}",
+                path_val
+            ),
+        };
+
+        match std::path::Path::new(path.as_str()).parent() {
+            Some(parent) => {
+                let parent_str = parent.to_string_lossy().into_owned();
+                let stack = push(stack, Value::String(global_string(parent_str)));
+                push(stack, Value::Int(1)) // success
+            }
+            None => {
+                let stack = push(stack, Value::String(global_string(String::new())));
+                push(stack, Value::Int(0)) // no parent
+            }
+        }
+    }
+}
+
+/// Get the filename component of a path
+///
+/// Stack effect: ( path -- filename success )
+///
+/// Returns the filename and 1 on success, "" and 0 if no filename.
+///
+/// # Safety
+/// Stack must have a String (path) on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_path_filename(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, path_val) = pop(stack);
+        let path = match path_val {
+            Value::String(s) => s,
+            _ => panic!(
+                "path-filename: expected String (path) on stack, got {:?}",
+                path_val
+            ),
+        };
+
+        match std::path::Path::new(path.as_str()).file_name() {
+            Some(filename) => {
+                let filename_str = filename.to_string_lossy().into_owned();
+                let stack = push(stack, Value::String(global_string(filename_str)));
+                push(stack, Value::Int(1)) // success
+            }
+            None => {
+                let stack = push(stack, Value::String(global_string(String::new())));
+                push(stack, Value::Int(0)) // no filename
+            }
+        }
+    }
+}

--- a/examples/os/os-demo.seq
+++ b/examples/os/os-demo.seq
@@ -7,6 +7,9 @@
 #   - path-exists: Check if path exists
 #   - path-is-file: Check if path is a regular file
 #   - path-is-dir: Check if path is a directory
+#   - path-join: Join path components
+#   - path-parent: Get parent directory
+#   - path-filename: Get filename component
 #
 # Build and run:
 #   seqc examples/os/os-demo.seq -o os-demo
@@ -118,6 +121,45 @@
     then
   else
     drop "  Could not get home directory" write_line
+  then
+  "" write_line
+
+  # Test path manipulation
+  "Path manipulation:" write_line
+
+  # Test path-join
+  "/usr" "local" path-join
+  "  path-join '/usr' 'local' = " swap string-concat write_line
+
+  "/home/user" ".config" path-join
+  "  path-join '/home/user' '.config' = " swap string-concat write_line
+  "" write_line
+
+  # Test path-parent
+  "/home/user/documents/file.txt" path-parent if
+    "  path-parent '/home/user/documents/file.txt' = " swap string-concat write_line
+  else
+    drop "  path-parent failed (unexpected)" write_line
+  then
+
+  "/" path-parent if
+    "  path-parent '/' = '" swap string-concat "'" string-concat write_line
+  else
+    drop "  path-parent '/' = (no parent)" write_line
+  then
+  "" write_line
+
+  # Test path-filename
+  "/home/user/documents/file.txt" path-filename if
+    "  path-filename '/home/user/documents/file.txt' = " swap string-concat write_line
+  else
+    drop "  path-filename failed (unexpected)" write_line
+  then
+
+  "/home/user/" path-filename if
+    "  path-filename '/home/user/' = " swap string-concat write_line
+  else
+    drop "  path-filename '/home/user/' = (no filename)" write_line
   then
 
   "" write_line


### PR DESCRIPTION
⏺ Phase 3 complete! Summary:

for https://github.com/navicore/patch-seq/issues/84

  Runtime (crates/runtime/src/os.rs):
  - patch_seq_path_join - join two path components using platform separator
  - patch_seq_path_parent - get parent directory (returns path + success flag)
  - patch_seq_path_filename - get filename component (returns filename + success flag)

  Compiler updates:
  - ast.rs - added intrinsics
  - builtins.rs - added stack effects
  - codegen.rs - added mappings and extern declarations
  - lib.rs - added exports

  Demo output shows all functions working:
  Path manipulation:
    path-join '/usr' 'local' = /usr/local path-join '/home/user' '.config' = /home/user/.config

    path-parent '/home/user/documents/file.txt' = /home/user/documents path-parent '/' = (no parent)

    path-filename '/home/user/documents/file.txt' = file.txt path-filename '/home/user/' = user

  The complete std:os module now provides:

  | Phase | Function      | Stack Effect                |
  |-------|---------------|-----------------------------|
  | 1     | getenv        | ( String -- String Int )    |
  | 1     | home-dir      | ( -- String Int )           |
  | 1     | current-dir   | ( -- String Int )           |
  | 2     | path-exists   | ( String -- Int )           |
  | 2     | path-is-file  | ( String -- Int )           |
  | 2     | path-is-dir   | ( String -- Int )           |
  | 3     | path-join     | ( String String -- String ) |
  | 3     | path-parent   | ( String -- String Int )    |
  | 3     | path-filename | ( String -- String Int )    |