### PR TITLE
⏺ CI passes. Here's the fix summary:

### DIFF
--- a/crates/compiler/src/typechecker.rs
+++ b/crates/compiler/src/typechecker.rs
@@ -81,6 +81,25 @@ impl TypeChecker {
         }
     }
 
+    /// Register external union type names (e.g., from included modules).
+    ///
+    /// This allows field types in union definitions to reference types from includes.
+    /// We only register the name as a valid type; we don't need full variant info
+    /// since the actual union definition lives in the included file.
+    pub fn register_external_unions(&mut self, union_names: &[&str]) {
+        for name in union_names {
+            // Insert a placeholder union with no variants
+            // This makes is_valid_type_name() return true for this type
+            self.unions.insert(
+                name.to_string(),
+                UnionTypeInfo {
+                    name: name.to_string(),
+                    variants: vec![],
+                },
+            );
+        }
+    }
+
     /// Extract the type map (quotation ID -> inferred type)
     ///
     /// This should be called after check_program() to get the inferred types


### PR DESCRIPTION
  Issue: LSP flagged Unknown type 'Sexpr' when a union defined in the current file referenced a type from an included file.

  Root cause: The typechecker's validate_union_field_types() checks if field types are valid by looking in self.unions. But the LSP only registered union names from the current document, not from includes.

  Fix (3 parts):

  1. Typechecker (typechecker.rs): Added register_external_unions() method to register union type names from includes: pub fn register_external_unions(&mut self, union_names: &[&str])
  2. Includes (includes.rs): Modified resolve_includes() to return IncludeResolution containing both words and union names: pub struct IncludeResolution { pub words: Vec<IncludedWord>, pub union_names: Vec<String>, }
  2. Now extracts union_def.name when parsing includes.
  3. Diagnostics (diagnostics.rs): Updated to register external unions before type checking: typechecker.register_external_unions(&external_unions);

  Now when eval.seq includes parser.seq (which includes sexpr.seq defining Sexpr), the LSP recognizes Sexpr as a valid type for union field declarations.