### PR TITLE
⏺ Refactoring Complete

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -260,7 +260,9 @@ pub fn compile_file_with_config(
 
     // Generate LLVM IR with type information and external builtins
     let mut codegen = CodeGen::new();
-    let ir = codegen.codegen_program_with_ffi(&program, quotation_types, config, &ffi_bindings)?;
+    let ir = codegen
+        .codegen_program_with_ffi(&program, quotation_types, config, &ffi_bindings)
+        .map_err(|e| e.to_string())?;
 
     // Write IR to file
     let ir_path = output_path.with_extension("ll");
@@ -358,7 +360,9 @@ pub fn compile_to_ir_with_config(source: &str, config: &CompilerConfig) -> Resul
     let quotation_types = type_checker.take_quotation_types();
 
     let mut codegen = CodeGen::new();
-    codegen.codegen_program_with_config(&program, quotation_types, config)
+    codegen
+        .codegen_program_with_config(&program, quotation_types, config)
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
  Successfully replaced 545 .unwrap() calls with proper ? error propagation.

  Changes Made

  1. Created CodeGenError enum (codegen.rs:28-61) pub enum CodeGenError {
      Logic(String),      // Logical errors (missing definitions, etc.)
      Format(std::fmt::Error),  // Formatting errors from write!
  }
  1. With From impls for both String and std::fmt::Error.
  2. Updated method signatures - All codegen methods now return Result<_, CodeGenError>:
    - codegen_program, codegen_program_with_config, codegen_program_with_ffi
    - escape_llvm_string, get_string_global
    - emit_runtime_declarations
    - And all internal codegen_* methods
  3. Updated callers in lib.rs - Added .map_err(|e| e.to_string()) to maintain backward-compatible Result<String, String> API.

  Remaining .unwrap() calls (12 total, all legitimate)

  | Count | Type                 | Reason                                                   |
  |-------|----------------------|----------------------------------------------------------|
  | 3     | body.last().unwrap() | Option unwrap (not fmt::Write) - accessing slice element |
  | 9     | Test code            | Appropriate for tests                                    |

  Result

  - Before: 557 .unwrap() calls
  - After: 12 .unwrap() calls (all legitimate)
  - All 297 tests pass

  The codegen now properly propagates errors instead of panicking, making it future-proof if anyone changes the write targets.