### PR TITLE
diagnostics ff

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["compilers", "development-tools"]
 [lib]
 crate-type = ["staticlib", "rlib"]  # staticlib for LLVM linking, rlib for testing
 
+[features]
+default = ["diagnostics"]
+diagnostics = ["signal-hook"]  # Strand registry + SIGQUIT handler for production debugging
+
 [dependencies]
 # May - Erlang-style green threads / coroutines for CSP concurrency
 may.workspace = true
@@ -26,9 +30,9 @@ libc.workspace = true
 serde.workspace = true
 bincode.workspace = true
 
-# Signal handling for SIGQUIT diagnostics (Unix only)
+# Signal handling for SIGQUIT diagnostics (Unix only, optional via diagnostics feature)
 [target.'cfg(unix)'.dependencies]
-signal-hook = "0.3"
+signal-hook = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runtime/src/diagnostics.rs
+++ b/crates/runtime/src/diagnostics.rs
@@ -20,6 +20,14 @@
 //! directly from a signal handler. Instead, we spawn a dedicated thread that
 //! waits for signals using signal-hook's iterator API, making all the I/O
 //! operations safe.
+//!
+//! ## Feature Flag
+//!
+//! This module is only compiled when the `diagnostics` feature is enabled (default).
+//! Disable it for benchmarks to eliminate SystemTime::now() syscalls and strand
+//! registry overhead on every spawn.
+
+#![cfg(feature = "diagnostics")]
 
 use crate::memory_stats::memory_registry;
 use crate::scheduler::{

--- a/crates/runtime/src/watchdog.rs
+++ b/crates/runtime/src/watchdog.rs
@@ -29,6 +29,13 @@
 //!
 //! This piggybacks on the existing strand registry infrastructure, requiring
 //! no additional tracking overhead on the hot path.
+//!
+//! ## Feature Flag
+//!
+//! This module requires the `diagnostics` feature (enabled by default).
+//! When disabled, the watchdog is not compiled.
+
+#![cfg(feature = "diagnostics")]
 
 use crate::diagnostics::dump_diagnostics;
 use crate::scheduler::strand_registry;


### PR DESCRIPTION
  Changes made:

  1. Cargo.toml: Added diagnostics feature (default enabled), signal-hook is now optional
  2. scheduler.rs: Wrapped with #[cfg(feature = "diagnostics")]:
    - StrandSlot, StrandRegistry structs and impls
    - STRAND_REGISTRY static and strand_registry() function
    - register() and unregister() calls in spawn path
    - 4 registry-related tests
  3. diagnostics.rs: Added #![cfg(feature = "diagnostics")] to disable entire module
  4. watchdog.rs: Added #![cfg(feature = "diagnostics")] to disable entire module

  Usage for benchmarks:

  # Build without diagnostics (no SystemTime::now() syscalls, no O(n) registry scans)
  cargo build --release -p seq-runtime --no-default-features

  # Or in the compiler:
  cargo build --release --no-default-features

  Test results:
  - 280 tests pass with diagnostics (default)
  - 267 tests pass without diagnostics (13 diagnostic-related tests skipped)
  - Clippy clean both ways