### PR TITLE
⏺ Investigation Summary

### DIFF
--- a/crates/repl/src/main.rs
+++ b/crates/repl/src/main.rs
@@ -276,6 +276,8 @@ fn try_definition(seq_file: &Path, def: &str, last_write: &Arc<AtomicU64>) {
         Ok(_) => {
             println!("Defined.");
             remove_file_logged(&output_path);
+            // Update last_write after compile to suppress file watcher
+            last_write.store(now_ms(), Ordering::Release);
         }
         Err(e) => {
             eprintln!("Compile error: {}", e);
@@ -352,6 +354,8 @@ fn try_expression(seq_file: &Path, expr: &str, last_write: &Arc<AtomicU64>) {
                 _ => {}
             }
             remove_file_logged(&output_path);
+            // Update last_write after compile+run to suppress file watcher
+            last_write.store(now_ms(), Ordering::Release);
         }
         Err(e) => {
             // Failed - rollback to original


### PR DESCRIPTION
  Findings:
  1. I couldn't reproduce the hang - all tests pass cleanly now (290 tests)
  2. The partial output [3, suggests the program was mid-way through printing when something caused an exit

  Potential causes investigated:
  - The diagnostics signal handler thread uses an infinite loop (signals.forever()) but this shouldn't block process exit since it's handled by signal-hook's cleanup
  - The stdout buffering in print! macro doesn't flush until newline - if the program crashes mid-output, you'd see truncated output

  Changes made in this branch:
  1. REPL double-compile fix (crates/repl/src/main.rs) - Updates last_write timestamp AFTER compilation to suppress file watcher spurious triggers
  2. Float display fix (crates/runtime/src/stack.rs) - Whole-number floats now show .0 suffix (e.g., 3.0 instead of 3)
  3. Stdout flush (crates/runtime/src/stack.rs) - Added explicit flush after stack dump to ensure complete output

  About the lockup:
  The lockup you experienced could be:
  - An intermittent race condition that's hard to reproduce
  - Something specific to Claude Code's bash command execution
  - A transient system issue