### PR TITLE
⏺ Summary: Bool Type Consistency Complete

### DIFF
--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -3369,9 +3369,8 @@ impl CodeGen {
             zext, cmp_result
         )?;
 
-        // Store result as Value::Int (discriminant 0 at slot0, value at slot1)
-        // Comparison results are Forth-style: 0 for false, 1 for true
-        writeln!(&mut self.output, "  store i64 0, ptr %{}", ptr_a)?;
+        // Store result as Value::Bool (discriminant 2 at slot0, 0/1 at slot1)
+        writeln!(&mut self.output, "  store i64 2, ptr %{}", ptr_a)?;
         writeln!(&mut self.output, "  store i64 %{}, ptr %{}", zext, slot1_a)?;
 
         // SP = SP - 1 (consumed b)
@@ -3638,9 +3637,8 @@ impl CodeGen {
             zext, cmp_result
         )?;
 
-        // Store result as Value::Int (discriminant 0 at slot0, value at slot1)
-        // Comparison results are Forth-style: 0 for false, 1 for true
-        writeln!(&mut self.output, "  store i64 0, ptr %{}", ptr_a)?;
+        // Store result as Value::Bool (discriminant 2 at slot0, 0/1 at slot1)
+        writeln!(&mut self.output, "  store i64 2, ptr %{}", ptr_a)?;
         writeln!(&mut self.output, "  store i64 %{}, ptr %{}", zext, slot1_a)?;
 
         // SP = SP - 1 (consumed b)

--- a/crates/compiler/stdlib/http.seq
+++ b/crates/compiler/stdlib/http.seq
@@ -126,28 +126,28 @@
 
 # Check if request is GET method
 # Stack effect: ( request -- bool )
-: http-is-get ( String -- Int )
+: http-is-get ( String -- Bool )
   http-request-method
   "GET" string.equal?
 ;
 
 # Check if request is POST method
 # Stack effect: ( request -- bool )
-: http-is-post ( String -- Int )
+: http-is-post ( String -- Bool )
   http-request-method
   "POST" string.equal?
 ;
 
 # Check if request path matches
 # Stack effect: ( request path -- bool )
-: http-path-is ( String String -- Int )
+: http-path-is ( String String -- Bool )
   swap http-request-path
   swap string.equal?
 ;
 
 # Check if request path starts with prefix
 # Stack effect: ( request prefix -- bool )
-: http-path-starts-with ( String String -- Int )
+: http-path-starts-with ( String String -- Bool )
   swap http-request-path
   swap string.starts-with
 ;

--- a/crates/compiler/stdlib/json.seq
+++ b/crates/compiler/stdlib/json.seq
@@ -169,37 +169,37 @@
 # ============================================================================
 
 # Check if value is null
-# Stack: ( JsonValue -- JsonValue Int )
+# Stack: ( JsonValue -- JsonValue Bool )
 : json-null?
   dup variant.tag 0 i.=
 ;
 
 # Check if value is bool
-# Stack: ( JsonValue -- JsonValue Int )
+# Stack: ( JsonValue -- JsonValue Bool )
 : json-bool?
   dup variant.tag 1 i.=
 ;
 
 # Check if value is number
-# Stack: ( JsonValue -- JsonValue Int )
+# Stack: ( JsonValue -- JsonValue Bool )
 : json-number?
   dup variant.tag 2 i.=
 ;
 
 # Check if value is string
-# Stack: ( JsonValue -- JsonValue Int )
+# Stack: ( JsonValue -- JsonValue Bool )
 : json-string?
   dup variant.tag 3 i.=
 ;
 
 # Check if value is array
-# Stack: ( JsonValue -- JsonValue Int )
+# Stack: ( JsonValue -- JsonValue Bool )
 : json-array?
   dup variant.tag 4 i.=
 ;
 
 # Check if value is object
-# Stack: ( JsonValue -- JsonValue Int )
+# Stack: ( JsonValue -- JsonValue Bool )
 : json-object?
   dup variant.tag 5 i.=
 ;
@@ -450,9 +450,9 @@
 ;
 
 # Check if parser state is at end of string
-# Stack: ( ..rest PState -- ..rest PState Int )
-# Note: Returns 1 if pos >= len, 0 otherwise
-: pstate-at-end? ( ..rest Variant -- ..rest Variant Int )
+# Stack: ( ..rest PState -- ..rest PState Bool )
+# Note: Returns true if pos >= len, false otherwise
+: pstate-at-end? ( ..rest Variant -- ..rest Variant Bool )
   # Get length of string
   dup 0 variant.field-at    # PState str
   string.length             # PState len
@@ -472,13 +472,13 @@
 ;
 
 # Check if a character code is whitespace (space, tab, newline, carriage return)
-# Stack: ( Int -- Int )
-: pstate-is-ws-char? ( Int -- Int )
-  dup 32 i.= if drop 1 else
-  dup 9 i.= if drop 1 else
-  dup 10 i.= if drop 1 else
-  dup 13 i.= if drop 1 else
-  drop 0
+# Stack: ( Int -- Bool )
+: pstate-is-ws-char? ( Int -- Bool )
+  dup 32 i.= if drop true else
+  dup 9 i.= if drop true else
+  dup 10 i.= if drop true else
+  dup 13 i.= if drop true else
+  drop false
   then then then then
 ;
 
@@ -511,8 +511,8 @@
 ;
 
 # Check if position is at end of string
-# Stack: ( str pos -- str pos Int )
-: json-at-end? ( ..rest String Int -- ..rest String Int Int )
+# Stack: ( str pos -- str pos Bool )
+: json-at-end? ( ..rest String Int -- ..rest String Int Bool )
   # Stack: str pos
   # Check: pos >= string.length(str)
   over string.length  # str pos len
@@ -537,8 +537,8 @@
 # ============================================================================
 
 # Parse "null" keyword
-# Stack: ( str pos -- str pos JsonValue Int )
-# Returns JsonValue and 1 if successful, 0 if not
+# Stack: ( str pos -- str pos JsonValue Bool )
+# Returns JsonValue and true if successful, false if not
 : json-parse-null
   json-char-at 110 i.= if
     1 json-advance
@@ -548,23 +548,23 @@
         1 json-advance
         json-char-at 108 i.= if
           1 json-advance
-          json-null 1
+          json-null true
         else
-          json-null 0
+          json-null false
         then
       else
-        json-null 0
+        json-null false
       then
     else
-      json-null 0
+      json-null false
     then
   else
-    json-null 0
+    json-null false
   then
 ;
 
 # Parse "true" keyword
-# Stack: ( str pos -- str pos JsonValue Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
 : json-parse-true
   json-char-at 116 i.= if
     1 json-advance
@@ -574,23 +574,23 @@
         1 json-advance
         json-char-at 101 i.= if
           1 json-advance
-          json-true 1
+          json-true true
         else
-          json-null 0
+          json-null false
         then
       else
-        json-null 0
+        json-null false
       then
     else
-      json-null 0
+      json-null false
     then
   else
-    json-null 0
+    json-null false
   then
 ;
 
 # Parse "false" keyword
-# Stack: ( str pos -- str pos JsonValue Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
 : json-parse-false
   json-char-at 102 i.= if
     1 json-advance
@@ -602,39 +602,39 @@
           1 json-advance
           json-char-at 101 i.= if
             1 json-advance
-            json-false 1
+            json-false true
           else
-            json-null 0
+            json-null false
           then
         else
-          json-null 0
+          json-null false
         then
       else
-        json-null 0
+        json-null false
       then
     else
-      json-null 0
+      json-null false
     then
   else
-    json-null 0
+    json-null false
   then
 ;
 
 # Check if character code is a digit 0-9
-# Stack: ( Int -- Int )
-: json-is-digit? ( ..rest Int -- ..rest Int )
+# Stack: ( Int -- Bool )
+: json-is-digit? ( ..rest Int -- ..rest Bool )
   dup 48 i.>= swap 57 i.<= and
 ;
 
 # Check if character starts a JSON number (digit or minus sign)
-# Stack: ( Int -- Int )
-: json-is-number-start? ( ..rest Int -- ..rest Int )
+# Stack: ( Int -- Bool )
+: json-is-number-start? ( ..rest Int -- ..rest Bool )
   dup 45 i.= swap json-is-digit? or
 ;
 
 # Check if character is part of a JSON number (digit, minus, plus, dot, e, E)
-# Stack: ( Int -- Int )
-: json-is-number-char? ( ..rest Int -- ..rest Int )
+# Stack: ( Int -- Bool )
+: json-is-number-char? ( ..rest Int -- ..rest Bool )
   dup json-is-digit? swap
   dup 45 i.= swap  # minus
   dup 43 i.= swap  # plus
@@ -645,8 +645,8 @@
 ;
 
 # Check if character code is whitespace
-# Stack: ( Int -- Int )
-: json-is-ws? ( ..rest Int -- ..rest Int )
+# Stack: ( Int -- Bool )
+: json-is-ws? ( ..rest Int -- ..rest Bool )
   dup 32 i.= swap dup 9 i.= swap dup 10 i.= swap 13 i.= or or or
 ;
 
@@ -698,11 +698,11 @@
 ;
 
 # Parse a JSON string
-# Stack: ( str pos -- str pos JsonValue Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
 # Expects position to be at opening quote (ASCII 34)
 #
 # This version properly returns the new position after the closing quote.
-: json-parse-string ( ..rest String Int -- ..rest String Int Variant Int )
+: json-parse-string ( ..rest String Int -- ..rest String Int Variant Bool )
   # Check for opening quote
   json-char-at 34 i.= if
     # Stack: str pos (at opening quote)
@@ -719,7 +719,7 @@
     dup 0 i.< if
       # No closing quote - cleanup and fail
       3drop drop    # str pos
-      json-null 0
+      json-null false
     else
       # Stack: str pos str startpos PState closepos
       # Drop PState, compute len = closepos - startpos
@@ -750,10 +750,10 @@
       rot                    # newpos str JsonString
       rot                    # str JsonString newpos
       swap                   # str newpos JsonString
-      1
+      true
     then
   else
-    json-null 0
+    json-null false
   then
 ;
 
@@ -840,24 +840,24 @@
 ;
 
 # Parse a JSON number using PState with boundary detection
-# Stack: ( PState -- PState' JsonValue Int )
-: pstate-parse-number ( Variant -- Variant Variant Int )
+# Stack: ( PState -- PState' JsonValue Bool )
+: pstate-parse-number ( Variant -- Variant Variant Bool )
   pstate-extract-number-str  # PState' numstr
   string->float              # PState' float success
-  0 i.= if
-    drop json-null 0
+  not if
+    drop json-null false
   else
-    json-number 1
+    json-number true
   then
 ;
 
 # Parse a JSON number (legacy interface using str pos)
-# Stack: ( str pos -- str pos JsonValue Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
 # Expects position to be at start of number (digit or minus)
 #
 # This version uses boundary detection to correctly parse numbers
 # inside arrays/objects (e.g., "1]" parses as 1, not error)
-: json-parse-number ( ..rest String Int -- ..rest String Int Variant Int )
+: json-parse-number ( ..rest String Int -- ..rest String Int Variant Bool )
   # Convert to PState, parse, convert back
   make-pstate                # PState
   pstate-parse-number        # PState' JsonValue success
@@ -912,19 +912,19 @@
 
 # Parse a single array element and add it to an array
 # Stack: ( PState arr -- PState' arr' Int )
-# Returns success=1 if element was parsed and added, 0 on failure
-: pstate-parse-one-element ( ..rest Variant Variant -- ..rest Variant Variant Int )
+# Returns success=true if element was parsed and added, false on failure
+: pstate-parse-one-element ( ..rest Variant Variant -- ..rest Variant Variant Bool )
   # Stack: PState arr
   swap                           # arr PState
   # Parse the element
   dup 0 variant.field-at         # arr PState str
   over 1 variant.field-at        # arr PState str pos
   json-parse-value               # arr PState str' pos' elem success
-  0 i.= if
+  not if
     # Failed to parse element
     3drop               # arr PState
     swap                         # PState arr
-    0
+    false
   else
     # Stack: arr PState str' pos' elem
     # Update PState
@@ -935,18 +935,18 @@
     # array-with expects: arr elem -- arr'
     rot rot                      # PState' arr elem
     array-with                   # PState' arr'
-    1
+    true
   then
 ;
 
 # Parse array elements recursively
-# Stack: ( PState arr -- PState' arr' Int )
+# Stack: ( PState arr -- PState' arr' Bool )
 # Parses elements until ] is found
-: pstate-parse-array-elements ( ..rest Variant Variant -- ..rest Variant Variant Int )
+: pstate-parse-array-elements ( ..rest Variant Variant -- ..rest Variant Variant Bool )
   pstate-parse-one-element       # PState' arr' success
-  0 i.= if
+  not if
     # Failed to parse element
-    0
+    false
   else
     # Successfully parsed one element, check for more
     # Stack: PState' arr'
@@ -957,7 +957,7 @@
       drop                       # arr' PState'
       1 pstate-advance           # arr' PState''
       swap                       # PState'' arr'
-      1
+      true
     else
       44 i.= if                    # ',' - more elements
         1 pstate-advance         # arr' PState''
@@ -967,58 +967,58 @@
       else
         # Unexpected character
         swap                     # PState' arr'
-        0
+        false
       then
     then
   then
 ;
 
 # Parse array contents using PState with array-with for building
-# Stack: ( PState -- PState JsonArray Int )
+# Stack: ( PState -- PState JsonArray Bool )
 # Position should be at first element (after [ and whitespace)
-: pstate-parse-array-contents ( ..rest Variant -- ..rest Variant Variant Int )
+: pstate-parse-array-contents ( ..rest Variant -- ..rest Variant Variant Bool )
   json-empty-array               # PState arr
   pstate-parse-array-elements    # PState' arr' success
 ;
 
 # Parse array contents (non-empty case)
-# Stack: ( str pos -- str pos JsonArray Int )
+# Stack: ( str pos -- str pos JsonArray Bool )
 # Position should be at first element (after [ and whitespace)
 : json-parse-array-contents
   # Convert to PState for easier manipulation
   make-pstate                    # PState
   pstate-parse-array-contents    # PState' arr success
-  0 i.= if
+  not if
     # Failed - extract str pos from PState
     drop                         # PState'
     dup 0 variant.field-at       # PState' str
     swap 1 variant.field-at      # str pos
-    json-null 0
+    json-null false
   else
     # Success - extract str pos from PState
     swap                         # arr PState'
     dup 0 variant.field-at       # arr PState' str
     swap 1 variant.field-at      # arr str pos
     rot                          # str pos arr
-    1
+    true
   then
 ;
 
 # Parse an array - handles empty and non-empty arrays
-# Stack: ( str pos -- str pos JsonValue Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
 # We're positioned at '['
-: json-parse-array ( ..rest String Int -- ..rest String Int Variant Int )
+: json-parse-array ( ..rest String Int -- ..rest String Int Variant Bool )
   # Move past '['
   1 json-advance
   json-skip-ws
 
   json-at-end? if
-    json-null 0
+    json-null false
   else
     json-char-at 93 i.= if
       # Found ']' immediately - empty array
       1 json-advance
-      json-empty-array 1
+      json-empty-array true
     else
       # Non-empty array - parse contents
       json-parse-array-contents
@@ -1027,9 +1027,9 @@
 ;
 
 # Parse a single key-value pair and add it to an object
-# Stack: ( PState obj -- PState' obj' Int )
-# Returns success=1 if pair was parsed and added, 0 on failure
-: pstate-parse-one-pair ( ..rest Variant Variant -- ..rest Variant Variant Int )
+# Stack: ( PState obj -- PState' obj' Bool )
+# Returns success=true if pair was parsed and added, false on failure
+: pstate-parse-one-pair ( ..rest Variant Variant -- ..rest Variant Variant Bool )
   # Stack: PState obj
   swap                           # obj PState
   pstate-char-at 34 i.= if         # Check for opening quote
@@ -1037,11 +1037,11 @@
     dup 0 variant.field-at       # obj PState str
     over 1 variant.field-at      # obj PState str pos
     json-parse-string            # obj PState str' pos' JsonString success
-    0 i.= if
+    not if
       # Failed to parse key
       3drop             # obj PState
       swap                       # PState obj
-      0
+      false
     else
       # Stack: obj PState str' pos' JsonString
       # Update PState with new position
@@ -1059,11 +1059,11 @@
         dup 0 variant.field-at   # obj JsonString PState' str
         over 1 variant.field-at  # obj JsonString PState' str pos
         json-parse-value         # obj JsonString PState' str' pos' val success
-        0 i.= if
+        not if
           # Failed to parse value
           3drop         # obj JsonString PState'
           rot drop               # PState' obj
-          0
+          false
         else
           # Stack: obj JsonString PState' str' pos' val
           # Update PState
@@ -1079,29 +1079,29 @@
           3 roll                 # val PState'' obj JsonString
           3 roll                 # PState'' obj JsonString val
           obj-with               # PState'' obj'
-          1
+          true
         then
       else
         # Missing colon
         rot drop                 # PState' obj
-        0
+        false
       then
     then
   else
     # Key must start with quote
     swap                         # PState obj
-    0
+    false
   then
 ;
 
 # Parse object pairs recursively
-# Stack: ( PState obj -- PState' obj' Int )
+# Stack: ( PState obj -- PState' obj' Bool )
 # Parses pairs until } is found
-: pstate-parse-object-pairs ( ..rest Variant Variant -- ..rest Variant Variant Int )
+: pstate-parse-object-pairs ( ..rest Variant Variant -- ..rest Variant Variant Bool )
   pstate-parse-one-pair          # PState' obj' success
-  0 i.= if
+  not if
     # Failed to parse pair
-    0
+    false
   else
     # Successfully parsed one pair, check for more
     # Stack: PState' obj'
@@ -1112,7 +1112,7 @@
       drop                       # obj' PState'
       1 pstate-advance           # obj' PState''
       swap                       # PState'' obj'
-      1
+      true
     else
       44 i.= if                    # ',' - more pairs
         1 pstate-advance         # obj' PState''
@@ -1122,58 +1122,58 @@
       else
         # Unexpected character
         swap                     # PState' obj'
-        0
+        false
       then
     then
   then
 ;
 
 # Parse object contents using PState with obj-with for building
-# Stack: ( PState -- PState JsonObject Int )
+# Stack: ( PState -- PState JsonObject Bool )
 # Position should be at first key (after { and whitespace)
-: pstate-parse-object-contents ( ..rest Variant -- ..rest Variant Variant Int )
+: pstate-parse-object-contents ( ..rest Variant -- ..rest Variant Variant Bool )
   json-empty-object              # PState obj
   pstate-parse-object-pairs      # PState' obj' success
 ;
 
 # Parse object contents (non-empty case) - single pair only
-# Stack: ( str pos -- str pos JsonObject Int )
+# Stack: ( str pos -- str pos JsonObject Bool )
 # Position should be at first key (after { and whitespace)
-: json-parse-object-contents ( ..rest String Int -- ..rest String Int Variant Int )
+: json-parse-object-contents ( ..rest String Int -- ..rest String Int Variant Bool )
   # Convert to PState for easier manipulation
   make-pstate                    # PState
   pstate-parse-object-contents   # PState' obj success
-  0 i.= if
+  not if
     # Failed - extract str pos from PState
     drop                         # PState'
     dup 0 variant.field-at       # PState' str
     swap 1 variant.field-at      # str pos
-    json-null 0
+    json-null false
   else
     # Success - extract str pos from PState
     swap                         # obj PState'
     dup 0 variant.field-at       # obj PState' str
     swap 1 variant.field-at      # obj str pos
     rot                          # str pos obj
-    1
+    true
   then
 ;
 
 # Parse an object - handles empty and non-empty objects
-# Stack: ( str pos -- str pos JsonValue Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
 # We're positioned at '{'
-: json-parse-object ( ..rest String Int -- ..rest String Int Variant Int )
+: json-parse-object ( ..rest String Int -- ..rest String Int Variant Bool )
   # Move past '{'
   1 json-advance
   json-skip-ws
 
   json-at-end? if
-    json-null 0
+    json-null false
   else
     json-char-at 125 i.= if
       # Found '}' immediately - empty object
       1 json-advance
-      json-empty-object 1
+      json-empty-object true
     else
       # Non-empty object - parse contents
       json-parse-object-contents
@@ -1183,10 +1183,10 @@
 
 # Main JSON parser entry point
 # Parses any JSON value
-# Stack: ( str pos -- str pos JsonValue Int )
-: json-parse-value ( ..rest String Int -- ..rest String Int Variant Int )
+# Stack: ( str pos -- str pos JsonValue Bool )
+: json-parse-value ( ..rest String Int -- ..rest String Int Variant Bool )
   json-at-end? if
-    json-null 0
+    json-null false
   else
     json-skip-ws
     json-char-at
@@ -1218,14 +1218,14 @@
     dup 123 i.= if
       drop json-parse-object
     else
-      drop json-null 0
+      drop json-null false
     then then then then then then then
   then
 ;
 
 # Simple JSON parse interface
-# Stack: ( String -- JsonValue Int )
-# Returns the parsed value and 1 on success, json-null and 0 on failure
+# Stack: ( String -- JsonValue Bool )
+# Returns the parsed value and true on success, json-null and false on failure
 : json-parse
   0
   json-parse-value

--- a/crates/compiler/stdlib/yaml.seq
+++ b/crates/compiler/stdlib/yaml.seq
@@ -186,13 +186,13 @@
 ;
 
 # Parse a simple "key: value" line
-# Stack: ( String -- YamlValue Int )
+# Stack: ( String -- YamlValue Bool )
 # Returns an object with one key-value pair, and success flag
-: yaml-parse-line ( ..rest String -- ..rest Variant Int )
+: yaml-parse-line ( ..rest String -- ..rest Variant Bool )
   dup yaml-find-colon
   dup 0 i.< if
     # No colon found - not a valid key-value
-    drop drop yaml-empty-object 0
+    drop drop yaml-empty-object false
   else
     # Found colon at position
     # Stack: str colonpos
@@ -204,7 +204,7 @@
     yaml-empty-object           # keystr value obj
     rot rot                     # obj keystr value
     yaml-obj-with               # obj'
-    1
+    true
   then
 ;
 
@@ -219,15 +219,15 @@
 ;
 
 # Check if string is empty or whitespace-only
-: yaml-is-blank-line ( ..rest String -- ..rest Int )
+: yaml-is-blank-line ( ..rest String -- ..rest Bool )
   string.trim string.empty?
 ;
 
 # Check if string starts with # (comment)
-: yaml-is-comment ( ..rest String -- ..rest Int )
+: yaml-is-comment ( ..rest String -- ..rest Bool )
   string.trim
   dup string.empty? if
-    drop 0
+    drop false
   else
     0 string.char-at 35 i.=
   then
@@ -296,9 +296,9 @@
 ;
 
 # Parse YAML (flat) - handles single or multi-line documents without nesting
-: yaml-parse-flat ( ..rest String -- ..rest Variant Int )
+: yaml-parse-flat ( ..rest String -- ..rest Variant Bool )
   yaml-empty-object swap yaml-parse-lines
-  dup variant.field-count 0 i.> if 1 else 0 then
+  dup variant.field-count 0 i.> if true else false then
 ;
 
 # ============================================================================
@@ -321,17 +321,17 @@
 ;
 
 # Check if a line is "key-only" (has colon with nothing after)
-# Stack: ( String -- Int )
-: yaml-is-key-only? ( ..rest String -- ..rest Int )
+# Stack: ( String -- Bool )
+: yaml-is-key-only? ( ..rest String -- ..rest Bool )
   string.trim
   dup yaml-find-colon
   dup 0 i.< if
-    drop drop 0
+    drop drop false
   else
     # Check what's after the colon
     1 i.add
     over string.length over i.<= if
-      drop drop 1  # colon is at end
+      drop drop true  # colon is at end
     else
       over string.length over i.subtract
       string.substring string.trim string.empty?
@@ -537,7 +537,7 @@
 ;
 
 # Check if first line is blank
-: yaml-first-line-is-blank? ( ..rest String -- ..rest Int )
+: yaml-first-line-is-blank? ( ..rest String -- ..rest Bool )
   dup yaml-find-newline
   dup 0 i.< if
     drop yaml-is-blank-line
@@ -547,7 +547,7 @@
 ;
 
 # Check if first line is a comment
-: yaml-first-line-is-comment? ( ..rest String -- ..rest Int )
+: yaml-first-line-is-comment? ( ..rest String -- ..rest Bool )
   dup yaml-find-newline
   dup 0 i.< if
     drop yaml-is-comment
@@ -603,10 +603,10 @@
 ;
 
 # Parse nested YAML content recursively
-# Stack: ( String -- Variant Int )
-: yaml-parse-nested ( ..rest String -- ..rest Variant Int )
+# Stack: ( String -- Variant Bool )
+: yaml-parse-nested ( ..rest String -- ..rest Variant Bool )
   yaml-empty-object swap yaml-parse-nested-lines
-  dup variant.field-count 0 i.> if 1 else 0 then
+  dup variant.field-count 0 i.> if true else false then
 ;
 
 # Parse multiple lines with nesting support
@@ -648,8 +648,8 @@
 ;
 
 # Check if first line of a string is key-only
-# Stack: ( String -- Int )
-: yaml-first-line-is-key-only? ( ..rest String -- ..rest Int )
+# Stack: ( String -- Bool )
+: yaml-first-line-is-key-only? ( ..rest String -- ..rest Bool )
   dup yaml-find-newline
   dup 0 i.< if
     drop yaml-is-key-only?
@@ -659,7 +659,7 @@
 ;
 
 # Main entry point - handles nested YAML
-: yaml-parse ( ..rest String -- ..rest Variant Int )
+: yaml-parse ( ..rest String -- ..rest Variant Bool )
   yaml-parse-nested
 ;
 

--- a/crates/runtime/src/arithmetic.rs
+++ b/crates/runtime/src/arithmetic.rs
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn patch_seq_eq(stack: Stack) -> Stack {
     let (rest, a, b) = unsafe { pop_two(stack, "=") };
     match (a, b) {
         (Value::Int(a_val), Value::Int(b_val)) => unsafe {
-            push(rest, Value::Int(if a_val == b_val { 1 } else { 0 }))
+            push(rest, Value::Bool(a_val == b_val))
         },
         _ => panic!("=: expected two integers on stack"),
     }
@@ -150,9 +150,7 @@ pub unsafe extern "C" fn patch_seq_eq(stack: Stack) -> Stack {
 pub unsafe extern "C" fn patch_seq_lt(stack: Stack) -> Stack {
     let (rest, a, b) = unsafe { pop_two(stack, "<") };
     match (a, b) {
-        (Value::Int(a_val), Value::Int(b_val)) => unsafe {
-            push(rest, Value::Int(if a_val < b_val { 1 } else { 0 }))
-        },
+        (Value::Int(a_val), Value::Int(b_val)) => unsafe { push(rest, Value::Bool(a_val < b_val)) },
         _ => panic!("<: expected two integers on stack"),
     }
 }
@@ -168,9 +166,7 @@ pub unsafe extern "C" fn patch_seq_lt(stack: Stack) -> Stack {
 pub unsafe extern "C" fn patch_seq_gt(stack: Stack) -> Stack {
     let (rest, a, b) = unsafe { pop_two(stack, ">") };
     match (a, b) {
-        (Value::Int(a_val), Value::Int(b_val)) => unsafe {
-            push(rest, Value::Int(if a_val > b_val { 1 } else { 0 }))
-        },
+        (Value::Int(a_val), Value::Int(b_val)) => unsafe { push(rest, Value::Bool(a_val > b_val)) },
         _ => panic!(">: expected two integers on stack"),
     }
 }
@@ -187,7 +183,7 @@ pub unsafe extern "C" fn patch_seq_lte(stack: Stack) -> Stack {
     let (rest, a, b) = unsafe { pop_two(stack, "<=") };
     match (a, b) {
         (Value::Int(a_val), Value::Int(b_val)) => unsafe {
-            push(rest, Value::Int(if a_val <= b_val { 1 } else { 0 }))
+            push(rest, Value::Bool(a_val <= b_val))
         },
         _ => panic!("<=: expected two integers on stack"),
     }
@@ -205,7 +201,7 @@ pub unsafe extern "C" fn patch_seq_gte(stack: Stack) -> Stack {
     let (rest, a, b) = unsafe { pop_two(stack, ">=") };
     match (a, b) {
         (Value::Int(a_val), Value::Int(b_val)) => unsafe {
-            push(rest, Value::Int(if a_val >= b_val { 1 } else { 0 }))
+            push(rest, Value::Bool(a_val >= b_val))
         },
         _ => panic!(">=: expected two integers on stack"),
     }
@@ -223,7 +219,7 @@ pub unsafe extern "C" fn patch_seq_neq(stack: Stack) -> Stack {
     let (rest, a, b) = unsafe { pop_two(stack, "<>") };
     match (a, b) {
         (Value::Int(a_val), Value::Int(b_val)) => unsafe {
-            push(rest, Value::Int(if a_val != b_val { 1 } else { 0 }))
+            push(rest, Value::Bool(a_val != b_val))
         },
         _ => panic!("<>: expected two integers on stack"),
     }
@@ -604,27 +600,27 @@ mod tests {
     #[test]
     fn test_comparisons() {
         unsafe {
-            // Test eq (returns 1 for true, 0 for false - Forth style)
+            // Test eq (returns true/false Bool)
             let stack = crate::stack::alloc_test_stack();
             let stack = push_int(stack, 5);
             let stack = push_int(stack, 5);
             let stack = eq(stack);
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1)); // 1 = true
+            assert_eq!(result, Value::Bool(true));
 
             // Test lt
             let stack = push_int(stack, 3);
             let stack = push_int(stack, 5);
             let stack = lt(stack);
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1)); // 1 = true
+            assert_eq!(result, Value::Bool(true));
 
             // Test gt
             let stack = push_int(stack, 7);
             let stack = push_int(stack, 5);
             let stack = gt(stack);
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1)); // 1 = true
+            assert_eq!(result, Value::Bool(true));
         }
     }
 

--- a/crates/runtime/src/float_ops.rs
+++ b/crates/runtime/src/float_ops.rs
@@ -259,11 +259,11 @@ pub unsafe extern "C" fn patch_seq_string_to_float(stack: Stack) -> Stack {
         Value::String(s) => match s.as_str().parse::<f64>() {
             Ok(f) => {
                 let stack = unsafe { push(stack, Value::Float(f)) };
-                unsafe { push(stack, Value::Int(1)) }
+                unsafe { push(stack, Value::Bool(true)) }
             }
             Err(_) => {
                 let stack = unsafe { push(stack, Value::Float(0.0)) };
-                unsafe { push(stack, Value::Int(0)) }
+                unsafe { push(stack, Value::Bool(false)) }
             }
         },
         _ => panic!("string->float: expected String on stack"),

--- a/crates/runtime/src/os.rs
+++ b/crates/runtime/src/os.rs
@@ -32,11 +32,11 @@ pub unsafe extern "C" fn patch_seq_getenv(stack: Stack) -> Stack {
         match std::env::var(name.as_str()) {
             Ok(value) => {
                 let stack = push(stack, Value::String(global_string(value)));
-                push(stack, Value::Int(1)) // success
+                push(stack, Value::Bool(true)) // success
             }
             Err(_) => {
                 let stack = push(stack, Value::String(global_string(String::new())));
-                push(stack, Value::Int(0)) // failure
+                push(stack, Value::Bool(false)) // failure
             }
         }
     }
@@ -56,19 +56,19 @@ pub unsafe extern "C" fn patch_seq_home_dir(stack: Stack) -> Stack {
         // Try HOME env var first (works on Unix and some Windows configs)
         if let Ok(home) = std::env::var("HOME") {
             let stack = push(stack, Value::String(global_string(home)));
-            return push(stack, Value::Int(1));
+            return push(stack, Value::Bool(true));
         }
 
         // On Windows, try USERPROFILE
         #[cfg(windows)]
         if let Ok(home) = std::env::var("USERPROFILE") {
             let stack = push(stack, Value::String(global_string(home)));
-            return push(stack, Value::Int(1));
+            return push(stack, Value::Bool(true));
         }
 
         // Fallback: return empty string with failure flag
         let stack = push(stack, Value::String(global_string(String::new())));
-        push(stack, Value::Int(0))
+        push(stack, Value::Bool(false))
     }
 }
 
@@ -87,11 +87,11 @@ pub unsafe extern "C" fn patch_seq_current_dir(stack: Stack) -> Stack {
             Ok(path) => {
                 let path_str = path.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(path_str)));
-                push(stack, Value::Int(1)) // success
+                push(stack, Value::Bool(true)) // success
             }
             Err(_) => {
                 let stack = push(stack, Value::String(global_string(String::new())));
-                push(stack, Value::Int(0)) // failure
+                push(stack, Value::Bool(false)) // failure
             }
         }
     }
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn patch_seq_path_exists(stack: Stack) -> Stack {
         };
 
         let exists = std::path::Path::new(path.as_str()).exists();
-        push(stack, Value::Int(if exists { 1 } else { 0 }))
+        push(stack, Value::Bool(exists))
     }
 }
 
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn patch_seq_path_is_file(stack: Stack) -> Stack {
         };
 
         let is_file = std::path::Path::new(path.as_str()).is_file();
-        push(stack, Value::Int(if is_file { 1 } else { 0 }))
+        push(stack, Value::Bool(is_file))
     }
 }
 
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn patch_seq_path_is_dir(stack: Stack) -> Stack {
         };
 
         let is_dir = std::path::Path::new(path.as_str()).is_dir();
-        push(stack, Value::Int(if is_dir { 1 } else { 0 }))
+        push(stack, Value::Bool(is_dir))
     }
 }
 
@@ -215,7 +215,7 @@ pub unsafe extern "C" fn patch_seq_path_join(stack: Stack) -> Stack {
 ///
 /// Stack effect: ( path -- parent success )
 ///
-/// Returns the parent directory and 1 on success, "" and 0 if no parent.
+/// Returns the parent directory and true on success, "" and false if no parent.
 ///
 /// # Safety
 /// Stack must have a String (path) on top
@@ -235,11 +235,11 @@ pub unsafe extern "C" fn patch_seq_path_parent(stack: Stack) -> Stack {
             Some(parent) => {
                 let parent_str = parent.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(parent_str)));
-                push(stack, Value::Int(1)) // success
+                push(stack, Value::Bool(true)) // success
             }
             None => {
                 let stack = push(stack, Value::String(global_string(String::new())));
-                push(stack, Value::Int(0)) // no parent
+                push(stack, Value::Bool(false)) // no parent
             }
         }
     }
@@ -249,7 +249,7 @@ pub unsafe extern "C" fn patch_seq_path_parent(stack: Stack) -> Stack {
 ///
 /// Stack effect: ( path -- filename success )
 ///
-/// Returns the filename and 1 on success, "" and 0 if no filename.
+/// Returns the filename and true on success, "" and false if no filename.
 ///
 /// # Safety
 /// Stack must have a String (path) on top
@@ -269,11 +269,11 @@ pub unsafe extern "C" fn patch_seq_path_filename(stack: Stack) -> Stack {
             Some(filename) => {
                 let filename_str = filename.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(filename_str)));
-                push(stack, Value::Int(1)) // success
+                push(stack, Value::Bool(true)) // success
             }
             None => {
                 let stack = push(stack, Value::String(global_string(String::new())));
-                push(stack, Value::Int(0)) // no filename
+                push(stack, Value::Bool(false)) // no filename
             }
         }
     }

--- a/crates/runtime/src/quotations.rs
+++ b/crates/runtime/src/quotations.rs
@@ -378,8 +378,8 @@ pub unsafe extern "C" fn patch_seq_while_loop(mut stack: Stack) -> Stack {
             // Pop the condition result
             let (stack_after_cond, cond_result) = pop(stack);
             let is_true = match cond_result {
-                Value::Int(n) => n != 0,
-                _ => panic!("while: condition must return Int, got {:?}", cond_result),
+                Value::Bool(b) => b,
+                _ => panic!("while: condition must return Bool, got {:?}", cond_result),
             };
 
             if !is_true {
@@ -461,8 +461,8 @@ pub unsafe extern "C" fn patch_seq_until_loop(mut stack: Stack) -> Stack {
             // Pop the condition result
             let (stack_after_cond, cond_result) = pop(stack);
             let is_true = match cond_result {
-                Value::Int(n) => n != 0,
-                _ => panic!("until: condition must return Int, got {:?}", cond_result),
+                Value::Bool(b) => b,
+                _ => panic!("until: condition must return Bool, got {:?}", cond_result),
             };
 
             if is_true {

--- a/crates/runtime/src/string_ops.rs
+++ b/crates/runtime/src/string_ops.rs
@@ -66,8 +66,7 @@ pub unsafe extern "C" fn patch_seq_string_empty(stack: Stack) -> Stack {
     match value {
         Value::String(s) => {
             let is_empty = s.as_str().is_empty();
-            let result = if is_empty { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
+            unsafe { push(stack, Value::Bool(is_empty)) }
         }
         _ => panic!("string_empty: expected String on stack"),
     }
@@ -90,8 +89,7 @@ pub unsafe extern "C" fn patch_seq_string_contains(stack: Stack) -> Stack {
     match (str_val, substring_val) {
         (Value::String(s), Value::String(sub)) => {
             let contains = s.as_str().contains(sub.as_str());
-            let result = if contains { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
+            unsafe { push(stack, Value::Bool(contains)) }
         }
         _ => panic!("string_contains: expected two strings on stack"),
     }
@@ -114,8 +112,7 @@ pub unsafe extern "C" fn patch_seq_string_starts_with(stack: Stack) -> Stack {
     match (str_val, prefix_val) {
         (Value::String(s), Value::String(prefix)) => {
             let starts = s.as_str().starts_with(prefix.as_str());
-            let result = if starts { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
+            unsafe { push(stack, Value::Bool(starts)) }
         }
         _ => panic!("string_starts_with: expected two strings on stack"),
     }
@@ -421,8 +418,7 @@ pub unsafe extern "C" fn patch_seq_string_equal(stack: Stack) -> Stack {
     match (str1_val, str2_val) {
         (Value::String(s1), Value::String(s2)) => {
             let equal = s1.as_str() == s2.as_str();
-            let result = if equal { 1 } else { 0 };
-            unsafe { push(stack, Value::Int(result)) }
+            unsafe { push(stack, Value::Bool(equal)) }
         }
         _ => panic!("string_equal: expected two strings on stack"),
     }
@@ -496,11 +492,11 @@ pub unsafe extern "C" fn patch_seq_string_to_int(stack: Stack) -> Stack {
         Value::String(s) => match s.as_str().trim().parse::<i64>() {
             Ok(i) => {
                 let stack = unsafe { push(stack, Value::Int(i)) };
-                unsafe { push(stack, Value::Int(1)) }
+                unsafe { push(stack, Value::Bool(true)) }
             }
             Err(_) => {
                 let stack = unsafe { push(stack, Value::Int(0)) };
-                unsafe { push(stack, Value::Int(0)) }
+                unsafe { push(stack, Value::Bool(false)) }
             }
         },
         _ => panic!("string->int: expected String on stack"),
@@ -711,7 +707,7 @@ mod tests {
             let stack = string_empty(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1));
+            assert_eq!(result, Value::Bool(true));
         }
     }
 
@@ -724,7 +720,7 @@ mod tests {
             let stack = string_empty(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(0));
+            assert_eq!(result, Value::Bool(false));
         }
     }
 
@@ -741,7 +737,7 @@ mod tests {
             let stack = string_contains(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1));
+            assert_eq!(result, Value::Bool(true));
         }
     }
 
@@ -758,7 +754,7 @@ mod tests {
             let stack = string_contains(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(0));
+            assert_eq!(result, Value::Bool(false));
         }
     }
 
@@ -775,7 +771,7 @@ mod tests {
             let stack = string_starts_with(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1));
+            assert_eq!(result, Value::Bool(true));
         }
     }
 
@@ -792,7 +788,7 @@ mod tests {
             let stack = string_starts_with(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(0));
+            assert_eq!(result, Value::Bool(false));
         }
     }
 
@@ -841,7 +837,7 @@ mod tests {
             let stack = string_starts_with(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1));
+            assert_eq!(result, Value::Bool(true));
         }
     }
 
@@ -976,7 +972,7 @@ mod tests {
             let stack = string_equal(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1));
+            assert_eq!(result, Value::Bool(true));
         }
     }
 
@@ -990,7 +986,7 @@ mod tests {
             let stack = string_equal(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(0));
+            assert_eq!(result, Value::Bool(false));
         }
     }
 
@@ -1004,7 +1000,7 @@ mod tests {
             let stack = string_equal(stack);
 
             let (_stack, result) = pop(stack);
-            assert_eq!(result, Value::Int(1));
+            assert_eq!(result, Value::Bool(true));
         }
     }
 
@@ -1480,7 +1476,7 @@ mod tests {
 
             let (stack, success) = pop(stack);
             let (_stack, value) = pop(stack);
-            assert_eq!(success, Value::Int(1));
+            assert_eq!(success, Value::Bool(true));
             assert_eq!(value, Value::Int(42));
         }
     }
@@ -1495,7 +1491,7 @@ mod tests {
 
             let (stack, success) = pop(stack);
             let (_stack, value) = pop(stack);
-            assert_eq!(success, Value::Int(1));
+            assert_eq!(success, Value::Bool(true));
             assert_eq!(value, Value::Int(-99));
         }
     }
@@ -1510,7 +1506,7 @@ mod tests {
 
             let (stack, success) = pop(stack);
             let (_stack, value) = pop(stack);
-            assert_eq!(success, Value::Int(1));
+            assert_eq!(success, Value::Bool(true));
             assert_eq!(value, Value::Int(123));
         }
     }
@@ -1528,7 +1524,7 @@ mod tests {
 
             let (stack, success) = pop(stack);
             let (_stack, value) = pop(stack);
-            assert_eq!(success, Value::Int(0));
+            assert_eq!(success, Value::Bool(false));
             assert_eq!(value, Value::Int(0));
         }
     }
@@ -1543,7 +1539,7 @@ mod tests {
 
             let (stack, success) = pop(stack);
             let (_stack, value) = pop(stack);
-            assert_eq!(success, Value::Int(0));
+            assert_eq!(success, Value::Bool(false));
             assert_eq!(value, Value::Int(0));
         }
     }
@@ -1558,7 +1554,7 @@ mod tests {
 
             let (stack, success) = pop(stack);
             let (_stack, value) = pop(stack);
-            assert_eq!(success, Value::Int(1));
+            assert_eq!(success, Value::Bool(true));
             assert_eq!(value, Value::Int(7));
         }
     }

--- a/crates/runtime/src/test.rs
+++ b/crates/runtime/src/test.rs
@@ -136,8 +136,8 @@ pub unsafe extern "C" fn patch_seq_test_finish(stack: Stack) -> Stack {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_test_has_failures(stack: Stack) -> Stack {
     let ctx = TEST_CONTEXT.lock().unwrap();
-    let has_failures = if ctx.has_failures() { 1 } else { 0 };
-    unsafe { push(stack, Value::Int(has_failures)) }
+    let has_failures = ctx.has_failures();
+    unsafe { push(stack, Value::Bool(has_failures)) }
 }
 
 /// Assert that a value is truthy (non-zero)

--- a/examples/cond.seq
+++ b/examples/cond.seq
@@ -1,0 +1,66 @@
+# Cond Combinator Example
+#
+# The `cond` combinator provides multi-way conditional branching using
+# quotation pairs. It's a concatenative alternative to match/case statements.
+#
+# Stack effect: ( value [pred1] [body1] ... [predN] [bodyN] N -- result )
+#
+# How it works:
+#   1. Push the value to test
+#   2. Push N predicate/body quotation pairs
+#   3. Push the count N
+#   4. Call cond - tries predicates in order, runs first matching body
+#
+# Each predicate: ( value -- value Bool ) - KEEPS value, ADDS true or false
+# Each body:      ( value -- result )     - consumes value, produces result
+#
+# Default case pattern: [ true ] [ body ] - always matches
+
+# Example 1: Classify a number as negative, zero, or positive
+: classify ( Int -- String )
+  [ dup 0 i.< ]  [ drop "negative" ]
+  [ dup 0 i.= ]  [ drop "zero" ]
+  [ true ]       [ drop "positive" ]  # default case: always matches
+  3 cond
+;
+
+# Example 2: FizzBuzz logic using cond
+: fizzbuzz ( Int -- String )
+  [ dup 15 i.% 0 i.= ]  [ drop "FizzBuzz" ]
+  [ dup 3 i.% 0 i.= ]   [ drop "Fizz" ]
+  [ dup 5 i.% 0 i.= ]   [ drop "Buzz" ]
+  [ true ]              [ int->string ]
+  4 cond
+;
+
+# Example 3: Grade letter from score
+: grade ( Int -- String )
+  [ dup 90 i.>= ]  [ drop "A" ]
+  [ dup 80 i.>= ]  [ drop "B" ]
+  [ dup 70 i.>= ]  [ drop "C" ]
+  [ dup 60 i.>= ]  [ drop "D" ]
+  [ true ]         [ drop "F" ]
+  5 cond
+;
+
+: main ( -- )
+  "=== Classify Numbers ===" io.write-line
+  0 5 i.- classify io.write-line   # -5 -> "negative"
+  0 classify io.write-line          # 0  -> "zero"
+  42 classify io.write-line         # 42 -> "positive"
+
+  "" io.write-line
+  "=== FizzBuzz ===" io.write-line
+  1 fizzbuzz io.write-line    # 1
+  3 fizzbuzz io.write-line    # Fizz
+  5 fizzbuzz io.write-line    # Buzz
+  15 fizzbuzz io.write-line   # FizzBuzz
+
+  "" io.write-line
+  "=== Grades ===" io.write-line
+  95 grade io.write-line   # A
+  85 grade io.write-line   # B
+  75 grade io.write-line   # C
+  65 grade io.write-line   # D
+  55 grade io.write-line   # F
+;

--- a/examples/csp/actor_counters.seq
+++ b/examples/csp/actor_counters.seq
@@ -267,7 +267,7 @@ union Message {
 
 # Look up in a registry
 # Stack: ( registry path -- channel-id found? )
-: lookup-store ( Variant String -- Int Int )
+: lookup-store ( Variant String -- Int Bool )
   map.get-safe   # ( value found? )
 ;
 
@@ -568,13 +568,13 @@ union Message {
 
 # Check if string ends with suffix
 # Stack: ( str suffix -- bool )
-: string-ends-with? ( String String -- Int )
+: string-ends-with? ( String String -- Bool )
   dup string.length         # ( str suffix suffix-len )
   rot dup string.length     # ( suffix suffix-len str str-len )
   rot                       # ( suffix str str-len suffix-len )
   2dup i.< if
     # suffix longer than string - can't match
-    3drop drop 0
+    3drop drop false
   else
     # Get the end of the string
     i.subtract                # ( suffix str offset )
@@ -596,7 +596,7 @@ union Message {
   # Stack: ( registry socket path )
   2 pick swap lookup-store  # ( registry socket chan found? )
 
-  0 i.= if
+  not if
     # Store not found
     drop                    # ( registry socket )
     "Store not found" http-not-found
@@ -623,7 +623,7 @@ union Message {
   # Stack: ( registry socket path )
   2 pick swap lookup-store  # ( registry socket chan found? )
 
-  0 i.= if
+  not if
     drop                    # ( registry socket )
     "Store not found" http-not-found
     over tcp.write
@@ -649,7 +649,7 @@ union Message {
   # Stack: ( registry socket path )
   2 pick swap lookup-store  # ( registry socket chan found? )
 
-  0 i.= if
+  not if
     # Actor not found
     drop                    # ( registry socket )
     "Actor not found" http-not-found

--- a/examples/ffi/sqlite/sqlite-demo.seq
+++ b/examples/ffi/sqlite/sqlite-demo.seq
@@ -15,8 +15,8 @@
 # SQLite result codes
 : SQLITE_OK ( -- Int ) 0 ;
 
-# Check if SQLite operation succeeded (returns 1 for success, 0 for failure)
-: db-ok? ( Int -- Int ) SQLITE_OK i.= ;
+# Check if SQLite operation succeeded (returns true for success, false for failure)
+: db-ok? ( Int -- Bool ) SQLITE_OK i.= ;
 
 # Open database and check result
 : open-db ( String -- Int Int )

--- a/examples/hackers-delight/02-power-of-two.seq
+++ b/examples/hackers-delight/02-power-of-two.seq
@@ -5,7 +5,7 @@
 # Check if x is a power of 2 (and x > 0)
 # Formula: x & (x - 1) == 0  (and x != 0)
 # Powers of 2 have exactly one bit set
-: power-of-2? ( Int -- Int )
+: power-of-2? ( Int -- Bool )
   dup 0 i.>                    # x > 0?
   swap dup 1 i.subtract band   # x & (x-1)
   0 i.=                        # == 0?
@@ -32,14 +32,14 @@
 ;
 
 # Check if x is a power of 2 (alternative using popcount)
-: power-of-2-alt? ( Int -- Int )
+: power-of-2-alt? ( Int -- Bool )
   dup 0 i.>              # x > 0?
   swap popcount 1 i.=    # exactly one bit set?
   and
 ;
 
 # Test helpers
-: bool->string ( Int -- )
+: bool->string ( Bool -- )
   if "true" io.write-line
   else "false" io.write-line
   then

--- a/examples/hackers-delight/04-branchless.seq
+++ b/examples/hackers-delight/04-branchless.seq
@@ -4,11 +4,16 @@
 #
 # Note: Classic Hacker's Delight uses arithmetic right shift (sign-extending).
 # Seq has logical right shift, so we use alternative formulations based on
-# comparison operators that return 0 or 1.
+# comparison operators. Bool results are converted to 0/1 integers for arithmetic.
+
+# Convert Bool to Int (0 or 1)
+: bool->int ( Bool -- Int )
+  if 1 else 0 then
+;
 
 # Create a mask: -1 if x < 0, else 0
 : negative-mask ( Int -- Int )
-  0 i.<                  # 1 if negative, 0 if not
+  0 i.< bool->int        # 1 if negative, 0 if not
   0 swap i.subtract      # -1 or 0
 ;
 
@@ -24,8 +29,8 @@
 
 # Sign of x: returns -1, 0, or 1
 : sign ( Int -- Int )
-  dup 0 i.>              # x pos?
-  swap 0 i.<             # pos? neg?
+  dup 0 i.> bool->int    # x pos?
+  swap 0 i.< bool->int   # pos? neg?
   0 swap i.subtract      # pos? -neg?
   i.add                  # pos - neg = 1, -1, or 0
 ;
@@ -34,7 +39,7 @@
 # min(a, b) = b + ((a - b) & mask)  where mask = -1 if a < b, else 0
 : min-branchless ( Int Int -- Int )
   2dup i.subtract   # a b (a-b)
-  dup 0 i.<              # a b diff (diff<0)?
+  dup 0 i.< bool->int    # a b diff (diff<0)?
   0 swap i.subtract      # a b diff mask
   band                 # a b (diff & mask)
   i.add                  # a (b + masked_diff)
@@ -45,7 +50,7 @@
 # max(a, b) = a - ((a - b) & mask)  where mask = -1 if a < b, else 0
 : max-branchless ( Int Int -- Int )
   2dup i.subtract   # a b (a-b)
-  dup 0 i.<              # a b diff (diff<0)?
+  dup 0 i.< bool->int    # a b diff (diff<0)?
   0 swap i.subtract      # a b diff mask
   band                 # a b (diff & mask)
   rot swap             # b a masked_diff

--- a/examples/hackers-delight/05-swap-reverse.seq
+++ b/examples/hackers-delight/05-swap-reverse.seq
@@ -59,8 +59,13 @@
 ;
 
 # Check if a bit is set at position n
-: bit-set? ( Int Int -- Int )
+: bit-set? ( Int Int -- Bool )
   1 swap shl band 0 i.<>
+;
+
+# Convert bool to string for display
+: bool->str ( Bool -- String )
+  if "true" else "false" then
 ;
 
 # Set bit at position n
@@ -105,8 +110,8 @@
   "Bit operations:" io.write-line
   "  value = 0b1010 (10)" io.write-line
   "" io.write-line
-  "  bit 1 set? " io.write-line 0b1010 1 bit-set? int->string io.write-line
-  "  bit 2 set? " io.write-line 0b1010 2 bit-set? int->string io.write-line
+  "  bit 1 set? " io.write-line 0b1010 1 bit-set? bool->str io.write-line
+  "  bit 2 set? " io.write-line 0b1010 2 bit-set? bool->str io.write-line
   "" io.write-line
   "  set bit 0:    " io.write-line 0b1010 0 bit-set int->string io.write-line
   "  clear bit 1:  " io.write-line 0b1010 1 bit-clear int->string io.write-line

--- a/examples/json/json_tree.seq
+++ b/examples/json/json_tree.seq
@@ -36,7 +36,7 @@ include std:json
 
 # Check if argument looks like a file (ends with .json)
 # Non-destructive: keeps the string on stack
-: is-json-file? ( String -- String Int )
+: is-json-file? ( String -- String Bool )
   dup ".json" string.contains
 ;
 
@@ -85,7 +85,7 @@ include std:json
     "" io.write-line
 
     json-parse
-    0 i.= if
+    not if
       drop
       "Parse error!" io.write-line
       1

--- a/examples/lisp/eval.seq
+++ b/examples/lisp/eval.seq
@@ -45,7 +45,7 @@ include "parser"
 : make-closure ( Variant Variant Variant -- Variant )
   60 variant.make-3 ;
 
-: closure? ( Variant -- Int )
+: closure? ( Variant -- Bool )
   variant.tag 60 i.= ;
 
 : closure-params ( Variant -- Variant )

--- a/examples/lisp/parser.seq
+++ b/examples/lisp/parser.seq
@@ -30,19 +30,19 @@ union ParseResult {
 # Token Predicates
 # ============================================
 
-: is-lparen ( String -- Int )
+: is-lparen ( String -- Bool )
   "(" string.equal? ;
 
-: is-rparen ( String -- Int )
+: is-rparen ( String -- Bool )
   ")" string.equal? ;
 
-: is-digit ( Int -- Int )
+: is-digit ( Int -- Bool )
   dup 48 i.>= swap 57 i.<= and ;
 
-: is-number-token ( String -- Int )
+: is-number-token ( String -- Bool )
   # Check if first char is a digit or minus followed by digit
   dup string.length 0 i.= if
-    drop 0
+    drop false
   else
     dup 0 string.char-at
     dup 45 i.= if
@@ -50,7 +50,7 @@ union ParseResult {
       drop dup string.length 1 i.> if
         1 string.char-at is-digit
       else
-        drop 0
+        drop false
       then
     else
       is-digit nip

--- a/examples/lisp/sexpr.seq
+++ b/examples/lisp/sexpr.seq
@@ -43,16 +43,16 @@ union SexprList {
 # Predicates
 # ============================================
 
-: snum? ( Sexpr -- Int )
+: snum? ( Sexpr -- Bool )
   variant.tag 0 i.= ;
 
-: ssym? ( Sexpr -- Int )
+: ssym? ( Sexpr -- Bool )
   variant.tag 1 i.= ;
 
-: slist? ( Sexpr -- Int )
+: slist? ( Sexpr -- Bool )
   variant.tag 2 i.= ;
 
-: snil? ( SexprList -- Int )
+: snil? ( SexprList -- Bool )
   variant.tag 0 i.= ;
 
 # ============================================

--- a/examples/lisp/tokenizer.seq
+++ b/examples/lisp/tokenizer.seq
@@ -25,7 +25,7 @@ union TokState {
 : tcons ( String TokenList -- TokenList )
   Make-TCons ;
 
-: tnil? ( TokenList -- Int )
+: tnil? ( TokenList -- Bool )
   variant.tag 0 i.= ;
 
 : tcar ( TokenList -- String )


### PR DESCRIPTION
  CI Status: All 113 integration tests pass, all 291 Rust unit tests pass.

  Changes Made This Session:

  json.seq:
  - Fixed pstate-char-at, pstate-pos, pstate-scan-for-quote, pstate-find-number-end, pstate-find-number-end-loop - changed return type from Bool to Int (they return positions/char codes)
  - Fixed json-parse-value - changed 0 to false for failure returns
  - Updated comment for json-parse

  json_tree.seq:
  - Changed 0 i.= if to not if for checking json-parse failure

  builtins.rs:
  - os.path-parent, os.path-filename: Int → Bool
  - chan.send-safe, chan.receive-safe: Int → Bool
  - file.slurp-safe, file.for-each-line+: Int → Bool

  Runtime files:
  - os.rs: Fixed patch_seq_path_parent, patch_seq_path_filename to return Value::Bool
  - channel.rs: Fixed send_safe, receive_safe + updated tests
  - file.rs: Fixed file_slurp_safe, file_for_each_line_plus + updated tests
  - list_ops.rs: Fixed list_filter to expect Value::Bool instead of Value::Int, updated test helper