### PR TITLE
⏺ Issue #140 is complete. Here's a summary of what was implemented:

### DIFF
--- a/crates/runtime/src/stack.rs
+++ b/crates/runtime/src/stack.rs
@@ -120,7 +120,7 @@ pub fn value_to_stack_value(value: Value) -> StackValue {
             yield_chan,
             resume_chan,
         } => {
-            // Store both Arc<ChannelData> as raw pointers
+            // Store both Arc<WeaveChannelData> as raw pointers
             let yield_ptr = Arc::into_raw(yield_chan) as u64;
             let resume_ptr = Arc::into_raw(resume_chan) as u64;
             StackValue {
@@ -182,9 +182,9 @@ pub unsafe fn stack_value_to_value(sv: StackValue) -> Value {
                 Value::Channel(arc)
             }
             DISC_WEAVECTX => {
-                use crate::value::ChannelData;
-                let yield_chan = Arc::from_raw(sv.slot1 as *const ChannelData);
-                let resume_chan = Arc::from_raw(sv.slot2 as *const ChannelData);
+                use crate::value::WeaveChannelData;
+                let yield_chan = Arc::from_raw(sv.slot1 as *const WeaveChannelData);
+                let resume_chan = Arc::from_raw(sv.slot2 as *const WeaveChannelData);
                 Value::WeaveCtx {
                     yield_chan,
                     resume_chan,
@@ -330,9 +330,9 @@ pub unsafe fn clone_stack_value(sv: &StackValue) -> StackValue {
             }
             DISC_WEAVECTX => {
                 // Arc refcount increment for both channels - O(1) clone
-                use crate::value::ChannelData;
-                let yield_ptr = sv.slot1 as *const ChannelData;
-                let resume_ptr = sv.slot2 as *const ChannelData;
+                use crate::value::WeaveChannelData;
+                let yield_ptr = sv.slot1 as *const WeaveChannelData;
+                let resume_ptr = sv.slot2 as *const WeaveChannelData;
                 debug_assert!(!yield_ptr.is_null(), "WeaveCtx yield pointer is null");
                 debug_assert!(!resume_ptr.is_null(), "WeaveCtx resume pointer is null");
                 let yield_arc = Arc::from_raw(yield_ptr);
@@ -393,9 +393,9 @@ pub unsafe fn drop_stack_value(sv: StackValue) {
                 let _ = Arc::from_raw(sv.slot1 as *const ChannelData);
             }
             DISC_WEAVECTX => {
-                use crate::value::ChannelData;
-                let _ = Arc::from_raw(sv.slot1 as *const ChannelData);
-                let _ = Arc::from_raw(sv.slot2 as *const ChannelData);
+                use crate::value::WeaveChannelData;
+                let _ = Arc::from_raw(sv.slot1 as *const WeaveChannelData);
+                let _ = Arc::from_raw(sv.slot2 as *const WeaveChannelData);
             }
             _ => panic!("Invalid discriminant for drop: {}", sv.slot0),
         }

--- a/tests/integration/src/test-weave.seq
+++ b/tests/integration/src/test-weave.seq
@@ -78,3 +78,29 @@
 
 # NOTE: String yields would require explicit context threading for the string type.
 # The type signature ( Ctx a -- Ctx a ) means yielded and resumed values have same type.
+
+# Generator that yields extreme Int values (i64::MIN and i64::MIN+1)
+# These were previously reserved as sentinels but are now valid user values
+: extreme-values ( Ctx Int -- Ctx | Yield Int )
+  drop                            # ignore initial resume value
+  -9223372036854775808 yield drop # i64::MIN
+  -9223372036854775807 yield drop # i64::MIN + 1
+  9223372036854775807 yield drop  # i64::MAX
+;
+
+# Test that i64::MIN can be yielded (was previously a sentinel limitation)
+: test-yield-i64-min ( -- )
+  [ extreme-values ] strand.weave
+  0 strand.resume
+  test.assert                              # should have more
+  -9223372036854775808 test.assert-eq      # should be exactly i64::MIN
+  0 strand.resume
+  test.assert
+  -9223372036854775807 test.assert-eq      # i64::MIN + 1
+  0 strand.resume
+  test.assert
+  9223372036854775807 test.assert-eq       # i64::MAX
+  0 strand.resume
+  test.assert-not                          # weave should complete
+  drop drop
+;


### PR DESCRIPTION
  Summary
  
  https://github.com/navicore/patch-seq/issues/140

  Replaced sentinel values with type-safe ADT for weave control flow

  Changes Made:

  1. crates/runtime/src/value.rs - Added new types:
    - WeaveMessage enum with Value(Value), Done, and Cancel variants
    - WeaveChannelData struct using mpmc::Sender/Receiver<WeaveMessage>
    - Updated Value::WeaveCtx to use Arc<WeaveChannelData>
  2. crates/runtime/src/weave.rs - Updated all weave functions:
    - patch_seq_weave: Creates WeaveChannelData channels
    - patch_seq_resume: Matches on WeaveMessage instead of sentinel values
    - patch_seq_yield: Wraps/unwraps values in WeaveMessage::Value
    - patch_seq_weave_cancel: Sends WeaveMessage::Cancel
    - Updated documentation to remove limitations section
  3. crates/runtime/src/stack.rs - Fixed FFI conversion:
    - Updated stack_value_to_value, clone_stack_value, and drop_stack_value to use WeaveChannelData
  4. tests/integration/src/test-weave.seq - Added edge case test:
    - test-yield-i64-min that successfully yields i64::MIN, i64::MIN+1, and i64::MAX

  Result:

  - Any Value can now be safely yielded/resumed, including edge cases like i64::MIN
  - Type-safe protocol eliminates collision risk between user values and control signals
  - All 492 tests pass