### PR TITLE
fix: correct stack output in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ stack: 3 5
 seqr> : square ( Int -- Int ) dup i.* ;
 Defined.
 seqr> square
-stack: 9 25
+stack: 3 25
 ```
 
 **Commands:**


### PR DESCRIPTION
Fixes the bug in the "Stack persists across lines" example where the stack output incorrectly showed `stack: 9 25` instead of `stack: 3 25`.

The `square` function `( Int -- Int ) dup i.*` only operates on the top stack element (5), leaving the 3 untouched.

Fixes #152

---
Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/navicore/patch-seq/actions/runs/20604353618