### PR TITLE
⏺ Issue #151 implementation complete. Here's a summary:

### DIFF
--- a/crates/compiler/src/stdlib_embed.rs
+++ b/crates/compiler/src/stdlib_embed.rs
@@ -16,6 +16,7 @@ static STDLIB: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| 
     m.insert("http", include_str!("../stdlib/http.seq"));
     m.insert("stack-utils", include_str!("../stdlib/stack-utils.seq"));
     m.insert("result", include_str!("../stdlib/result.seq"));
+    m.insert("map", include_str!("../stdlib/map.seq"));
     m
 });
 

--- a/crates/compiler/stdlib/map.seq
+++ b/crates/compiler/stdlib/map.seq
@@ -1,0 +1,30 @@
+# Map utilities for Seq
+#
+# Provides convenient words for building and working with maps.
+#
+# ## Available Words
+#
+# Builder pattern (type-safe, recommended):
+# - map-of: ( -- Map ) - Create empty map, alias for map.make
+# - kv: ( Map k v -- Map ) - Add key-value pair, alias for map.set
+#
+# Examples:
+#   # Build a map with 2 entries using builder pattern
+#   map-of "name" "Alice" kv "age" 30 kv
+#
+#   # Chained operations
+#   map-of
+#     "host" "localhost" kv
+#     "port" 8080 kv
+#     "debug" true kv
+
+# Create an empty map (alias for map.make)
+: map-of ( -- Map )
+  map.make
+;
+
+# Add a key-value pair to a map (alias for map.set)
+# Returns the updated map for chaining
+: kv ( Map K V -- Map )
+  map.set
+;

--- a/tests/integration/src/test-kv-map.seq
+++ b/tests/integration/src/test-kv-map.seq
@@ -1,0 +1,53 @@
+# Tests for map.seq utilities (builder pattern)
+
+include std:map
+
+# Test basic map-of and kv with 2 pairs
+: test-map-builder-basic ( -- )
+  map-of "name" "Alice" kv "age" 30 kv
+  dup map.size 2 test.assert-eq
+  dup "name" map.get test.assert "Alice" string.equal? test.assert
+  "age" map.get test.assert 30 test.assert-eq
+;
+
+# Test map-of with 1 pair
+: test-map-builder-single ( -- )
+  map-of "key" "value" kv
+  dup map.size 1 test.assert-eq
+  "key" map.get test.assert "value" string.equal? test.assert
+;
+
+# Test map-of alone (empty map)
+: test-map-builder-empty ( -- )
+  map-of
+  map.size 0 test.assert-eq
+;
+
+# Test map-of with integer keys
+: test-map-builder-int-keys ( -- )
+  map-of 1 "one" kv 2 "two" kv 3 "three" kv
+  dup map.size 3 test.assert-eq
+  dup 1 map.get test.assert "one" string.equal? test.assert
+  dup 2 map.get test.assert "two" string.equal? test.assert
+  3 map.get test.assert "three" string.equal? test.assert
+;
+
+# Test chained kv operations
+: test-map-builder-chained ( -- )
+  map-of
+    "host" "localhost" kv
+    "port" 8080 kv
+    "timeout" 30 kv
+  dup map.size 3 test.assert-eq
+  dup "host" map.get test.assert "localhost" string.equal? test.assert
+  dup "port" map.get test.assert 8080 test.assert-eq
+  "timeout" map.get test.assert 30 test.assert-eq
+;
+
+# Test that kv overwrites duplicate keys
+: test-map-builder-duplicate-keys ( -- )
+  map-of "key" 100 kv "key" 200 kv
+  dup map.size 1 test.assert-eq
+  "key" map.get test.assert 200 test.assert-eq
+;
+


### PR DESCRIPTION
  Implementation Summary

https://github.com/navicore/patch-seq/issues/151

  Challenge: The original kv-map ( k1 v1 ... kN vN n -- Map ) design can't work with Seq's type system - it can't express consuming a variable number of stack items based on a runtime value.

  Solution: Builder pattern with two simple words:

  include std:map

  # Build a map with chained operations
  map-of "name" "Alice" kv "age" 30 kv

  # Multi-line style
  map-of
    "host" "localhost" kv
    "port" 8080 kv
    "debug" true kv

  Files created/modified:
  - crates/compiler/stdlib/map.seq - new stdlib module with map-of and kv
  - crates/compiler/src/stdlib_embed.rs - registered the map module
  - tests/integration/src/test-kv-map.seq - 6 passing tests

  CI status: All 233 compiler tests + 291 runtime tests + 6 new tests pass.