### PR TITLE
⏺ Done! Summary of changes for issue #180:

### DIFF
--- a/crates/repl/src/main.rs
+++ b/crates/repl/src/main.rs
@@ -120,8 +120,6 @@ fn run_app(
                 Event::Mouse(mouse) => match mouse.kind {
                     MouseEventKind::ScrollDown => app.scroll_ir(1),
                     MouseEventKind::ScrollUp => app.scroll_ir(-1),
-                    MouseEventKind::ScrollRight => app.swipe_right(),
-                    MouseEventKind::ScrollLeft => app.swipe_left(),
                     _ => {}
                 },
                 _ => {}


### PR DESCRIPTION
  New shortcuts:
  | Key | Action               |
  |-----|----------------------|
  | F1  | Toggle Stack Effects |
  | F2  | Toggle Typed AST     |
  | F3  | Toggle LLVM IR       |

  Behavior: Press to show, press same key to hide, press different key to switch.

  Removed:
  - Swipe gesture code (swipe_right, swipe_left, swipe_accumulator)
  - Mouse scroll left/right handling

  Updated:
  - :help now shows F1/F2/F3 shortcuts
  
  https://github.com/navicore/patch-seq/issues/180