### PR TITLE
⏺ The fix is complete. Here's a summary:

### DIFF
--- a/crates/repl/src/app.rs
+++ b/crates/repl/src/app.rs
@@ -588,6 +588,14 @@ impl App {
 
     /// Append an expression to main (before stack.dump)
     fn append_expression(&mut self, expr: &str) -> bool {
+        // Don't persist stack.dump - it's an introspection command that should only
+        // run once. The auto-appended stack.dump at the end of main will show the
+        // current stack state. This fixes issue #193 where user-typed stack.dump
+        // accumulated in the session file, causing multiple "stack:" lines.
+        if expr.trim() == "stack.dump" {
+            return true; // Skip appending but allow compile/run to proceed
+        }
+
         let content = match fs::read_to_string(&self.session_path) {
             Ok(c) => c,
             Err(_) => return false,


### PR DESCRIPTION
  Issue #193 Fix: stack.dump pollutes the stack

  https://github.com/navicore/patch-seq/issues/193

  Root Cause:
  When the user typed stack.dump in the REPL, it was being appended to the session file like any other expression. Since the REPL already auto-appends stack.dump at the end of main, the find("  stack.dump") call would find the user's stack.dump first, not the auto-appended one. This caused subsequent user-typed stack.dump calls to accumulate in the session file, each printing an empty "stack:" line when the session was re-run.

  Fix:
  Skip persisting stack.dump to the session file. It's an introspection command that should only run once. The auto-appended stack.dump at the end of main will show the current stack state.

  Changes:
  - crates/repl/src/app.rs:590-597: Added early return in append_expression() when expr.trim() == "stack.dump" to skip appending while still allowing compile/run to proceed.

  Testing:
  - All 63 REPL tests pass
  - Full CI passes (236 compiler tests, 24 LSP tests, 312 runtime tests)

⏺ The fix for issue #193 is complete. The change is in crates/repl/src/app.rs - when the user types stack.dump, it no longer gets persisted to the session file. The auto-appended stack.dump at the end of main handles displaying the current stack state.