### PR TITLE
⏺ The leibniz_pi benchmark uses many constant-N operations that will …

### DIFF
--- a/benchmarks/LATEST_RUN.txt
+++ b/benchmarks/LATEST_RUN.txt
@@ -1,5 +1,5 @@
 # Benchmark run record - DO NOT EDIT MANUALLY
 # This file is checked by CI to ensure benchmarks are run regularly
-timestamp: 2026-01-07T03:01:01Z
-commit: c133ba9
+timestamp: 2026-01-07T04:23:27Z
+commit: edd4851
 benchmarks_run: all


### PR DESCRIPTION
…benefit:

https://github.com/navicore/patch-seq/issues/192

  - 3 pick (line 21)
  - 4 roll (line 27)
  - 3 roll 3 roll 3 roll (line 34)

  Each of these now uses constant offsets instead of dynamic calculations.

  Summary: Issue #192 Optimizations

  Implemented:
  1. Constant-N roll specialization (codegen_roll_constant):
    - 0 roll → no-op (just pop the 0)
    - 1 roll → inline swap code
    - 2 roll → inline rot code (3 loads, 3 stores)
    - n≥3 roll → memmove with constant offsets
  2. Constant-N pick specialization (codegen_pick_constant):
    - All cases use constant offset getelementptr instead of dynamic calculation

  Benefits:
  - No dynamic offset calculation (eliminates add/sub instructions)
  - No dynamic load of N from stack for constant cases
  - Small N (0-2) for roll avoids memmove entirely
  - LLVM can better optimize constant offsets

  Files changed:
  - crates/compiler/src/codegen.rs: Added prev_stmt_int_value tracking, codegen_roll_constant, codegen_pick_constant, and tests

  Still pending (separate optimization):
  - Peephole optimization for rot rot → -rot pattern (requires cross-statement pattern matching)

  The code is ready for PR.