### PR TITLE
⏺ Summary

### DIFF
--- a/benchmarks/LATEST_RUN.txt
+++ b/benchmarks/LATEST_RUN.txt
@@ -1,5 +1,5 @@
 # Benchmark run record - DO NOT EDIT MANUALLY
 # This file is checked by CI to ensure benchmarks are run regularly
-timestamp: 2026-01-08T02:32:57Z
-commit: 8330bf8
+timestamp: 2026-01-09T02:39:27Z
+commit: b746522
 benchmarks_run: all

--- a/crates/compiler/src/codegen.rs
+++ b/crates/compiler/src/codegen.rs
@@ -3103,6 +3103,10 @@ impl CodeGen {
             // Boolean operations - values are in slot1, discriminant 2 (Bool)
             // and: ( a b -- a&&b )
             "and" => {
+                // Spill virtual registers (Issue #189)
+                let stack_var = self.spill_virtual_stack(stack_var)?;
+                let stack_var = stack_var.as_str();
+
                 // Get pointers to Value slots
                 let ptr_b = self.fresh_temp();
                 writeln!(
@@ -3179,6 +3183,10 @@ impl CodeGen {
 
             // or: ( a b -- a||b )
             "or" => {
+                // Spill virtual registers (Issue #189)
+                let stack_var = self.spill_virtual_stack(stack_var)?;
+                let stack_var = stack_var.as_str();
+
                 // Get pointers to Value slots
                 let ptr_b = self.fresh_temp();
                 writeln!(
@@ -3255,6 +3263,10 @@ impl CodeGen {
 
             // not: ( a -- !a )
             "not" => {
+                // Spill virtual registers (Issue #189)
+                let stack_var = self.spill_virtual_stack(stack_var)?;
+                let stack_var = stack_var.as_str();
+
                 // Get pointer to top Value
                 let top_ptr = self.fresh_temp();
                 writeln!(
@@ -3439,6 +3451,9 @@ impl CodeGen {
             // nip: ( a b -- b )
             // Must call runtime to properly drop the removed value
             "nip" => {
+                // Spill virtual registers before runtime call (Issue #189)
+                let stack_var = self.spill_virtual_stack(stack_var)?;
+
                 let result_var = self.fresh_temp();
                 writeln!(
                     &mut self.output,
@@ -3451,6 +3466,10 @@ impl CodeGen {
             // tuck: ( a b -- b a b )
             // Uses patch_seq_clone_value to properly clone heap values
             "tuck" => {
+                // Spill virtual registers (Issue #189)
+                let stack_var = self.spill_virtual_stack(stack_var)?;
+                let stack_var = stack_var.as_str();
+
                 let ptr_b = self.fresh_temp();
                 let ptr_a = self.fresh_temp();
                 let val_a = self.fresh_temp();
@@ -3508,6 +3527,10 @@ impl CodeGen {
             // 2dup: ( a b -- a b a b )
             // Uses patch_seq_clone_value to properly clone heap values
             "2dup" => {
+                // Spill virtual registers (Issue #189)
+                let stack_var = self.spill_virtual_stack(stack_var)?;
+                let stack_var = stack_var.as_str();
+
                 let ptr_b = self.fresh_temp();
                 let ptr_a = self.fresh_temp();
                 let new_ptr = self.fresh_temp();
@@ -4173,6 +4196,10 @@ impl CodeGen {
         stack_var: &str,
         llvm_op: &str,
     ) -> Result<Option<String>, CodeGenError> {
+        // Spill virtual registers (Issue #189)
+        let stack_var = self.spill_virtual_stack(stack_var)?;
+        let stack_var = stack_var.as_str();
+
         // Get pointers to Value slots
         let ptr_b = self.fresh_temp();
         writeln!(
@@ -4270,6 +4297,10 @@ impl CodeGen {
         stack_var: &str,
         fcmp_op: &str,
     ) -> Result<Option<String>, CodeGenError> {
+        // Spill virtual registers (Issue #189)
+        let stack_var = self.spill_virtual_stack(stack_var)?;
+        let stack_var = stack_var.as_str();
+
         // Get pointers to Value slots
         let ptr_b = self.fresh_temp();
         writeln!(

--- a/tests/integration/src/test-virtual-register-spill.seq
+++ b/tests/integration/src/test-virtual-register-spill.seq
@@ -1,0 +1,132 @@
+# Tests for virtual register spill correctness (Issue #189)
+#
+# These tests verify that operations correctly spill virtual registers
+# before accessing memory. Each test pushes integer literals (which use
+# virtual registers) followed by an operation that must spill first.
+#
+# Without proper spills, these tests would produce incorrect results
+# (typically zeros or garbage values).
+
+# Stack operation tests - these were broken before the fix
+
+: test-2dup-spills ( -- )
+  3 4 2dup
+  i.+ i.+ i.+   # 3 + 4 + 3 + 4 = 14
+  14 test.assert-eq
+;
+
+: test-tuck-spills ( -- )
+  3 4 tuck      # ( 3 4 -- 4 3 4 )
+  i.+ i.+       # 4 + 3 + 4 = 11
+  11 test.assert-eq
+;
+
+: test-nip-spills ( -- )
+  3 4 nip       # ( 3 4 -- 4 )
+  4 test.assert-eq
+;
+
+# Boolean operation tests
+
+: test-and-spills ( -- )
+  true true and
+  test.assert
+;
+
+: test-or-spills ( -- )
+  true false or
+  test.assert
+;
+
+: test-not-spills ( -- )
+  false not
+  test.assert
+;
+
+: test-and-with-comparison ( -- )
+  3 4 i.< 5 6 i.< and   # true and true
+  test.assert
+;
+
+: test-or-with-comparison ( -- )
+  3 4 i.> 5 6 i.< or    # false or true
+  test.assert
+;
+
+# Float arithmetic tests
+
+: test-f-add-spills ( -- )
+  1.5 2.5 f.+
+  4.0 f.= test.assert
+;
+
+: test-f-sub-spills ( -- )
+  5.0 3.0 f.-
+  2.0 f.= test.assert
+;
+
+: test-f-mul-spills ( -- )
+  2.0 3.0 f.*
+  6.0 f.= test.assert
+;
+
+: test-f-div-spills ( -- )
+  6.0 2.0 f./
+  3.0 f.= test.assert
+;
+
+# Float comparison tests
+
+: test-f-eq-spills ( -- )
+  3.0 3.0 f.=
+  test.assert
+;
+
+: test-f-lt-spills ( -- )
+  2.0 3.0 f.<
+  test.assert
+;
+
+: test-f-gt-spills ( -- )
+  3.0 2.0 f.>
+  test.assert
+;
+
+: test-f-lte-spills ( -- )
+  3.0 3.0 f.<=
+  test.assert
+;
+
+: test-f-gte-spills ( -- )
+  3.0 3.0 f.>=
+  test.assert
+;
+
+: test-f-neq-spills ( -- )
+  2.0 3.0 f.<>
+  test.assert
+;
+
+# Combined operations - ensure spill works with mixed operations
+
+: test-2dup-then-arithmetic ( -- )
+  # Stack: 10 20 → 2dup → 10 20 10 20 → i.* → 10 20 200 → swap → 10 200 20 → i.* → 10 4000 → i.+ → 4010
+  10 20 2dup i.* swap i.* i.+
+  4010 test.assert-eq
+;
+
+: test-multiple-literals-then-tuck ( -- )
+  1 2 3 tuck    # ( 1 2 3 -- 1 3 2 3 )
+  i.+ i.+ i.+   # 1 + 3 + 2 + 3 = 9
+  9 test.assert-eq
+;
+
+: test-chained-boolean-ops ( -- )
+  true true and true and
+  test.assert
+;
+
+: test-chained-float-comparisons ( -- )
+  1.0 2.0 f.< 2.0 3.0 f.< and
+  test.assert
+;


### PR DESCRIPTION
  Fixed 8 operations that were missing virtual register spills:
  ┌─────────────────────────────────┬──────────────────────┐
  │            Operation            │         Type         │
  ├─────────────────────────────────┼──────────────────────┤
  │ and                             │ Boolean              │
  ├─────────────────────────────────┼──────────────────────┤
  │ or                              │ Boolean              │
  ├─────────────────────────────────┼──────────────────────┤
  │ not                             │ Boolean              │
  ├─────────────────────────────────┼──────────────────────┤
  │ tuck                            │ Stack                │
  ├─────────────────────────────────┼──────────────────────┤
  │ 2dup                            │ Stack                │
  ├─────────────────────────────────┼──────────────────────┤
  │ nip                             │ Stack (runtime call) │
  ├─────────────────────────────────┼──────────────────────┤
  │ f.+, f.-, f.*, f./              │ Float arithmetic     │
  ├─────────────────────────────────┼──────────────────────┤
  │ f.=, f.<>, f.<, f.>, f.<=, f.>= │ Float comparison     │
  └─────────────────────────────────┴──────────────────────┘
  Added 22 new integration tests in tests/integration/src/test-virtual-register-spill.seq that specifically test integer literals followed by each operation. These tests would have caught the bug - they verify that 3 4 2dup produces 3 4 3 4 (not 0 0 3 4).

  All 199 tests pass (177 original + 22 new).