### PR TITLE
⏺ Issue #211 complete.

### DIFF
--- a/crates/repl/src/app.rs
+++ b/crates/repl/src/app.rs
@@ -216,11 +216,11 @@ impl App {
     pub fn save_history(&self) {
         if let Some(path) = Self::history_file_path() {
             // Ensure parent directory exists
-            if let Some(parent) = path.parent() {
-                if let Err(e) = fs::create_dir_all(parent) {
-                    eprintln!("Warning: could not create history directory: {e}");
-                    return;
-                }
+            if let Some(parent) = path.parent()
+                && let Err(e) = fs::create_dir_all(parent)
+            {
+                eprintln!("Warning: could not create history directory: {e}");
+                return;
             }
 
             match fs::File::create(&path) {


### PR DESCRIPTION
  Fixed the save_history() function in crates/repl/src/app.rs to warn users instead of silently failing:
  
  https://github.com/navicore/patch-seq/issues/211

  - Directory creation errors now print: Warning: could not create history directory: <error>
  - File creation errors now print: Warning: could not create history file: <error>
  - Write errors now print: Warning: could not write history entry: <error>

  The audit found that the three let _ = patterns in save_history() (lines 220, 223, 227) were the only silent I/O failures that needed fixing. Other let _ = usages in the codebase are for cleanup operations where failure is acceptable.

  All 334+ tests pass.