### PR TITLE
typechecker compbinator safety fix

### DIFF
--- a/crates/compiler/src/unification.rs
+++ b/crates/compiler/src/unification.rs
@@ -510,4 +510,30 @@ mod tests {
         let stack = StackType::Empty.push(Type::Int).push(Type::String);
         assert!(!occurs_in_stack("a", &stack));
     }
+
+    #[test]
+    fn test_quotation_type_unification_stack_neutral() {
+        // Q[..a -- ..a] should NOT unify with Q[..b -- ..b Int]
+        // because the second quotation pushes a value
+        use crate::types::Effect;
+
+        let stack_neutral = Type::Quotation(Box::new(Effect::new(
+            StackType::RowVar("a".to_string()),
+            StackType::RowVar("a".to_string()),
+        )));
+
+        let pushes_int = Type::Quotation(Box::new(Effect::new(
+            StackType::RowVar("b".to_string()),
+            StackType::RowVar("b".to_string()).push(Type::Int),
+        )));
+
+        let result = unify_types(&stack_neutral, &pushes_int);
+        // This SHOULD fail because unifying outputs would require ..a = ..a Int
+        // which is an infinite type
+        assert!(
+            result.is_err(),
+            "Unifying stack-neutral with stack-pushing quotation should fail, got {:?}",
+            result
+        );
+    }
 }


### PR DESCRIPTION
⏺ All tests pass. Here's a summary of the fixes for issues #233 and #234:

  Summary

  Root Cause: In analyze_captures, when a quotation had an expected type from lookahead (e.g., while expecting Q[..a -- ..a]), the function blindly trusted the expected type without verifying the body effect was compatible. The body's actual effect (e.g., [1] pushing Int) was ignored.

  Fix 1 - Effect Verification (typechecker.rs:1322-1334):
  Added unification check in analyze_captures to verify the quotation body's actual effect is compatible with the expected effect. This catches:
  - Stack pollution: body pushes values when expected is stack-neutral
  - Stack underflow: body consumes values unexpectedly
  - Wrong return type: body returns Int when Bool expected

  Fix 2 - Prevent Leaking Expected Type (typechecker.rs:944-953):
  In infer_quotation, save and clear expected_quotation_type before inferring the body, then restore it for capture analysis. This ensures nested quotations don't inherit the outer quotation's expected type.

  Files Changed

  - crates/compiler/src/typechecker.rs - Core fix
  - crates/compiler/src/unification.rs - Added test

  Tests Updated

  - test_while_body_must_be_stack_neutral (renamed from gap test)
  - test_until_cond_must_return_bool (renamed from gap test)