### PR TITLE
⏺ Phase 4 FFI Boundaries - Summary

### DIFF
--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -23,7 +23,7 @@ toml.workspace = true
 
 [build-dependencies]
 # Version must EXACTLY match workspace version - enforced by build.rs and CI
-seq-runtime = { path = "../runtime", version = "=0.19.10" }
+seq-runtime = { path = "../runtime", version = "=0.19.10", optional = true }
 toml.workspace = true
 
 [lib]
@@ -34,7 +34,10 @@ path = "src/lib.rs"
 # Feature enabled when building on docs.rs to skip runtime embedding
 docsrs = []
 # Enable NaN-boxing mode (8-byte values instead of 40-byte)
-nanbox = []
+# This MUST forward to seq-runtime to ensure compiler and runtime use same representation
+nanbox = ["seq-runtime/nanbox"]
+# Default: include seq-runtime for building
+default = ["seq-runtime"]
 
 [package.metadata.docs.rs]
 # Enable the docsrs feature when building on docs.rs


### PR DESCRIPTION
  Fixed several critical issues in the nanbox codegen:

  https://github.com/navicore/patch-seq/issues/188

  1. Feature flag forwarding - Updated compiler/Cargo.toml to forward nanbox feature to seq-runtime dependency: nanbox = ["seq-runtime/nanbox"]
  2. Bool literal codegen - Added nanbox-aware codegen_bool_literal (words.rs:680-711):
    - Non-nanbox: stores discriminant + value in two slots
    - Nanbox: stores single NaN-boxed i64 with TAG_BOOL
  3. Float literal codegen - Added nanbox-aware codegen_float_literal (words.rs:640-677):
    - Non-nanbox: stores discriminant + float bits
    - Nanbox: stores float bits directly (with NaN canonicalization)
  4. Bool peek/pop for conditionals - Added nanbox-aware codegen_peek_pop_bool (inline/ops.rs:865-909):
    - Non-nanbox: reads slot1 for boolean value
    - Nanbox: loads entire nanboxed value, extracts payload

  Test Results:
  - Non-nanbox mode: 199/199 integration tests pass, all CI checks pass
  - Nanbox mode: 154/157 integration tests pass
    - 3 failures are expected: shift edge cases with values outside 47-bit range (1 63 shl, etc.)

  The nanbox feature is now functional! The only limitation is the 47-bit integer range (±70 trillion), which causes expected failures for edge case tests involving i64::MIN/i64::MAX.