### PR TITLE
⏺ All tests pass. Here's a summary of the vim-line cursor positioning…

### DIFF
--- a/crates/repl/src/app.rs
+++ b/crates/repl/src/app.rs
@@ -1246,9 +1246,9 @@ mod tests {
         app.handle_key(KeyEvent::from(KeyCode::Char('h')));
         assert_eq!(app.repl_state.cursor, 0);
 
-        // $ goes to end
+        // $ goes to end (ON last char, not past it - vim normal mode behavior)
         app.handle_key(KeyEvent::from(KeyCode::Char('$')));
-        assert_eq!(app.repl_state.cursor, 5);
+        assert_eq!(app.repl_state.cursor, 4); // 'o' is at index 4
         Ok(())
     }
 

--- a/crates/vim-line/README.md
+++ b/crates/vim-line/README.md
@@ -1,10 +1,14 @@
 # vim-line
 
-A vim-style single-line editor library for Rust TUI applications. Provides modal editing with normal and insert modes, common vim motions, and customizable keybindings.
+A vim-style single-line editor library for Rust TUI applications. Provides modal
+editing with normal and insert modes, common vim motions, and customizable
+keybindings.
 
 ## Part of the Seq Workspace
 
-This crate is part of the [Seq programming language](https://github.com/navicore/patch-seq) project, but can be used independently in any Rust TUI application.
+This crate is part of the [Seq programming
+language](https://github.com/navicore/patch-seq) project, but can be used
+independently in any Rust TUI application.
 
 ### Related Crates
 


### PR DESCRIPTION
… fixes:

  Changes made:

  1. Fixed test_basic_motion (vim.rs:935): Updated to expect cursor at 10 instead of 11 after $ on "hello world"
  2. Added new test test_dollar_cursor_on_last_char: Verifies $ positions cursor ON the last character (not past it), matching correct vim Normal mode behavior
  3. Added new test test_x_delete_last_char_moves_cursor_left: Verifies x moves cursor left when deleting the last character on a line
  4. Added new test test_x_delete_middle_char_cursor_stays: Verifies x keeps cursor in place when not deleting the last character
  5. Fixed test_normal_mode_navigation (app.rs:1251): Updated to expect cursor at 4 instead of 5 after $ on "hello"

  All 754+ tests across the workspace now pass. The vim-line editor now correctly implements vim's Normal mode cursor model where the cursor is always ON a character (indices 0 to len-1), not past the end.