### PR TITLE
⏺ Implementation of issue #251 (Ed25519 digital signatures) is complete.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +512,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +590,16 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -636,6 +685,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +755,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -1649,6 +1729,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,6 +2140,7 @@ dependencies = [
  "base64",
  "bincode",
  "bumpalo",
+ "ed25519-dalek",
  "flate2",
  "hex",
  "hmac",
@@ -2191,6 +2282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2332,16 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ uuid = { version = "1.11", features = ["v4"] }
 subtle = "2.6"  # Constant-time comparison
 aes-gcm = "0.10"  # AES-256-GCM authenticated encryption
 pbkdf2 = "0.12"   # Password-based key derivation
+ed25519-dalek = { version = "2.1", features = ["rand_core"] }  # Ed25519 digital signatures
 
 # HTTP client
 ureq = { version = "2.12", features = ["tls"] }

--- a/benchmarks/LATEST_RUN.txt
+++ b/benchmarks/LATEST_RUN.txt
@@ -1,5 +1,5 @@
 # Benchmark run record - DO NOT EDIT MANUALLY
 # This file is checked by CI to ensure benchmarks are run regularly
-timestamp: 2026-01-14T01:31:25Z
-commit: d19c215
+timestamp: 2026-01-14T21:37:36Z
+commit: c23d128
 benchmarks_run: all

--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -365,6 +365,9 @@ impl Program {
             "crypto.aes-gcm-encrypt",
             "crypto.aes-gcm-decrypt",
             "crypto.pbkdf2-sha256",
+            "crypto.ed25519-keypair",
+            "crypto.ed25519-sign",
+            "crypto.ed25519-verify",
             // HTTP client operations
             "http.get",
             "http.post",

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -616,6 +616,9 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
     builtin!(sigs, "crypto.aes-gcm-encrypt", (a String String -- a String Bool));
     builtin!(sigs, "crypto.aes-gcm-decrypt", (a String String -- a String Bool));
     builtin!(sigs, "crypto.pbkdf2-sha256", (a String String Int -- a String Bool));
+    builtin!(sigs, "crypto.ed25519-keypair", (a -- a String String));
+    builtin!(sigs, "crypto.ed25519-sign", (a String String -- a String Bool));
+    builtin!(sigs, "crypto.ed25519-verify", (a String String String -- a Bool));
 
     // =========================================================================
     // HTTP Client Operations
@@ -1149,6 +1152,18 @@ static BUILTIN_DOCS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::n
     docs.insert(
         "crypto.pbkdf2-sha256",
         "Derive key from password. ( password salt iterations -- hex-key success ) Min 1000 iterations, 100000+ recommended.",
+    );
+    docs.insert(
+        "crypto.ed25519-keypair",
+        "Generate Ed25519 keypair. ( -- public-key private-key ) Both as 64-char hex strings.",
+    );
+    docs.insert(
+        "crypto.ed25519-sign",
+        "Sign message with Ed25519 private key. ( message private-key -- signature success ) Signature is 128-char hex.",
+    );
+    docs.insert(
+        "crypto.ed25519-verify",
+        "Verify Ed25519 signature. ( message signature public-key -- valid )",
     );
 
     // HTTP Client Operations

--- a/crates/compiler/src/codegen/runtime.rs
+++ b/crates/compiler/src/codegen/runtime.rs
@@ -691,6 +691,18 @@ pub static RUNTIME_DECLARATIONS: LazyLock<Vec<RuntimeDecl>> = LazyLock::new(|| {
             decl: "declare ptr @patch_seq_crypto_pbkdf2_sha256(ptr)",
             category: None,
         },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_crypto_ed25519_keypair(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_crypto_ed25519_sign(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_crypto_ed25519_verify(ptr)",
+            category: None,
+        },
         // HTTP client operations
         RuntimeDecl {
             decl: "declare ptr @patch_seq_http_get(ptr)",
@@ -1142,6 +1154,9 @@ pub static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = Lazy
         ("crypto.aes-gcm-encrypt", "patch_seq_crypto_aes_gcm_encrypt"),
         ("crypto.aes-gcm-decrypt", "patch_seq_crypto_aes_gcm_decrypt"),
         ("crypto.pbkdf2-sha256", "patch_seq_crypto_pbkdf2_sha256"),
+        ("crypto.ed25519-keypair", "patch_seq_crypto_ed25519_keypair"),
+        ("crypto.ed25519-sign", "patch_seq_crypto_ed25519_sign"),
+        ("crypto.ed25519-verify", "patch_seq_crypto_ed25519_verify"),
         // HTTP client operations
         ("http.get", "patch_seq_http_get"),
         ("http.post", "patch_seq_http_post"),

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -46,6 +46,7 @@ uuid.workspace = true
 subtle.workspace = true
 aes-gcm.workspace = true
 pbkdf2.workspace = true
+ed25519-dalek.workspace = true
 
 # HTTP client
 ureq.workspace = true

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -139,6 +139,9 @@ pub use crypto::{
     patch_seq_constant_time_eq as constant_time_eq,
     patch_seq_crypto_aes_gcm_decrypt as crypto_aes_gcm_decrypt,
     patch_seq_crypto_aes_gcm_encrypt as crypto_aes_gcm_encrypt,
+    patch_seq_crypto_ed25519_keypair as crypto_ed25519_keypair,
+    patch_seq_crypto_ed25519_sign as crypto_ed25519_sign,
+    patch_seq_crypto_ed25519_verify as crypto_ed25519_verify,
     patch_seq_crypto_pbkdf2_sha256 as crypto_pbkdf2_sha256, patch_seq_hmac_sha256 as hmac_sha256,
     patch_seq_random_bytes as random_bytes, patch_seq_sha256 as sha256, patch_seq_uuid4 as uuid4,
 };

--- a/examples/crypto.seq
+++ b/examples/crypto.seq
@@ -182,6 +182,42 @@
   "" io.write-line
 ;
 
+# Ed25519 Digital Signatures
+: demo-signatures ( -- )
+  "=== Ed25519 Digital Signatures ===" io.write-line
+  "" io.write-line
+
+  # Generate a keypair
+  crypto.ed25519-keypair
+  # Stack: public-key private-key
+  dup "Private key: " show
+  over "Public key:  " show
+
+  # Sign a message
+  "This is an important message that needs authentication."
+  dup "  Message: " show
+  # Stack: public-key private-key message
+  swap crypto.ed25519-sign
+  # Stack: public-key signature success
+  if
+    dup "  Signature: " show
+    # Stack: public-key signature
+
+    # Verify the signature
+    swap "This is an important message that needs authentication." rot rot
+    crypto.ed25519-verify
+    if
+      "  Verification: VALID" io.write-line
+    else
+      "  Verification: INVALID" io.write-line
+    then
+  else
+    drop drop "  Signing failed" io.write-line
+  then
+
+  "" io.write-line
+;
+
 # Run all demos
 : main ( -- )
   demo-sha256
@@ -190,4 +226,5 @@
   demo-uuid
   demo-encryption
   demo-pbkdf2
+  demo-signatures
 ;

--- a/tests/integration/src/test-signatures.seq
+++ b/tests/integration/src/test-signatures.seq
@@ -1,0 +1,90 @@
+# Test Ed25519 digital signatures
+
+# Test keypair generation
+: test-ed25519-keypair ( -- )
+  crypto.ed25519-keypair
+  # Stack: public-key private-key
+  string.byte-length 64 i.eq test.assert  # private key is 64 hex chars
+  string.byte-length 64 i.eq test.assert  # public key is 64 hex chars
+;
+
+# Test sign and verify roundtrip
+: test-ed25519-sign-verify ( -- )
+  # Generate keypair
+  crypto.ed25519-keypair
+  # Stack: public-key private-key
+
+  # Sign a message
+  "Hello, World!" swap crypto.ed25519-sign
+  # Stack: public-key signature success
+  test.assert  # sign success
+
+  # Stack: public-key signature
+  # Verify the signature (message signature public-key -- valid)
+  swap "Hello, World!" rot rot crypto.ed25519-verify
+  test.assert  # verify should succeed
+;
+
+# Test verification fails with wrong message
+: test-ed25519-wrong-message ( -- )
+  crypto.ed25519-keypair
+  # Stack: public-key private-key
+
+  "Original message" swap crypto.ed25519-sign
+  test.assert  # sign success
+  # Stack: public-key signature
+
+  # Verify with different message should fail
+  swap "Different message" rot rot crypto.ed25519-verify
+  test.assert-not  # should fail
+;
+
+# Test verification fails with wrong key
+: test-ed25519-wrong-key ( -- )
+  # Generate keypair and sign
+  crypto.ed25519-keypair
+  "Test message" swap crypto.ed25519-sign
+  test.assert  # sign success
+  # Stack: public-key signature
+
+  # Generate a different keypair (wrong key)
+  crypto.ed25519-keypair drop  # just get the public key, drop private
+  # Stack: public-key signature wrong-public-key
+
+  # Verify with wrong public key: (message signature public-key -- valid)
+  "Test message" rot rot crypto.ed25519-verify
+  # Stack: public-key valid
+  test.assert-not  # should fail
+  drop  # drop correct public-key
+;
+
+# Test sign with invalid key fails
+: test-ed25519-invalid-key ( -- )
+  "Test message" "tooshort" crypto.ed25519-sign
+  test.assert-not  # should fail
+  drop  # drop empty signature
+;
+
+# Test verify with invalid signature format
+: test-ed25519-invalid-signature ( -- )
+  crypto.ed25519-keypair
+  drop  # drop private key
+  # Stack: public-key
+
+  "Test message" "invalid-signature" rot crypto.ed25519-verify
+  test.assert-not  # should fail
+;
+
+# Test signing empty message works
+: test-ed25519-empty-message ( -- )
+  crypto.ed25519-keypair
+  # Stack: public-key private-key
+
+  "" swap crypto.ed25519-sign
+  test.assert  # sign success
+  # Stack: public-key signature
+
+  swap "" rot rot crypto.ed25519-verify
+  test.assert  # verify should succeed
+;
+


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/251

    Added builtins:
  - crypto.ed25519-keypair - ( -- String String ) - Generate public/private keypair
  - crypto.ed25519-sign - ( String String -- String Bool ) - Sign message with private key
  - crypto.ed25519-verify - ( String String String -- Bool ) - Verify signature

  Key implementation details:
  - Keys are 64 hex chars (32 bytes)
  - Signatures are 128 hex chars (64 bytes)
  - Uses ed25519-dalek v2.1 crate (audited, widely used)
  - Consistent error handling with Bool return

  Tests:
  - 9 unit tests in crypto.rs (30 total crypto tests)
  - 7 integration tests in test-signatures.seq
  - 293 total integration tests passing

  Files modified:
  - Cargo.toml - added ed25519-dalek
  - crates/runtime/Cargo.toml - added workspace dep
  - crates/runtime/src/crypto.rs - FFI implementations + tests
  - crates/runtime/src/lib.rs - exports
  - crates/compiler/src/builtins.rs - signatures + docs
  - crates/compiler/src/codegen/runtime.rs - LLVM declarations
  - crates/compiler/src/ast.rs - validation list
  - tests/integration/src/test-signatures.seq - new tests
  - examples/crypto.seq - updated with signature demo
  - docs/BATTERIES_INCLUDED.md - updated documentation