### PR TITLE
⏺ All tests pass. The new deep-nesting lint is now active.

### DIFF
--- a/crates/compiler/src/lint.rs
+++ b/crates/compiler/src/lint.rs
@@ -275,22 +275,30 @@ impl Linter {
     /// Calculate if/else nesting depth for a single statement
     fn if_nesting_depth(stmt: &Statement, current_depth: usize) -> usize {
         match stmt {
-            Statement::If { then_branch, else_branch } => {
+            Statement::If {
+                then_branch,
+                else_branch,
+            } => {
                 // This if adds one level of nesting
                 let new_depth = current_depth + 1;
 
                 // Check then branch for further nesting
-                let then_max = then_branch.iter()
+                let then_max = then_branch
+                    .iter()
                     .map(|s| Self::if_nesting_depth(s, new_depth))
                     .max()
                     .unwrap_or(new_depth);
 
                 // Check else branch - nested ifs in else are the classic "else if" chain
-                let else_max = else_branch.as_ref()
-                    .map(|stmts| stmts.iter()
-                        .map(|s| Self::if_nesting_depth(s, new_depth))
-                        .max()
-                        .unwrap_or(new_depth))
+                let else_max = else_branch
+                    .as_ref()
+                    .map(|stmts| {
+                        stmts
+                            .iter()
+                            .map(|s| Self::if_nesting_depth(s, new_depth))
+                            .max()
+                            .unwrap_or(new_depth)
+                    })
                     .unwrap_or(new_depth);
 
                 then_max.max(else_max)


### PR DESCRIPTION
  Summary:
  - Added MAX_NESTING_DEPTH = 4 constant
  - Added structural analysis that counts if/else nesting depth in the AST
  - Triggers a hint when nesting reaches 4+ levels
  - Found 4 issues in the lisp examples, including the 7-level monster in eval-builtin-with-env

  The lint suggests using cond or extracting to helper words. That 7-level function is a perfect candidate for cond:

  # Current (7 levels of if/else):
  dup "+" string.equal? if drop eval-add-with-env else
    dup "-" string.equal? if drop eval-sub-with-env else ...7 levels deep... then then

  # With cond (flat):
  [ dup "+" string.equal? ]  [ drop eval-add-with-env ]
  [ dup "-" string.equal? ]  [ drop eval-sub-with-env ]
  [ dup "*" string.equal? ]  [ drop eval-mul-with-env ]
  ...
  [ true ]                    [ drop drop slist ]
  7 cond