### PR TITLE
⏺ All CI passes. Summary of changes:

### DIFF
--- a/crates/compiler/src/main.rs
+++ b/crates/compiler/src/main.rs
@@ -350,9 +350,9 @@ fn run_test(paths: &[PathBuf], filter: Option<String>, verbose: bool) {
 
     runner.print_results(&summary);
 
-    if summary.failed > 0 {
+    if summary.has_failures() {
         process::exit(1);
-    } else if summary.total == 0 {
+    } else if summary.total == 0 && summary.compile_failures == 0 {
         eprintln!("No tests found");
         process::exit(2);
     }

--- a/crates/compiler/stdlib/json.seq
+++ b/crates/compiler/stdlib/json.seq
@@ -127,6 +127,11 @@
   :JsonNumber variant.make-1
 ;
 
+# Create a JSON number from an Int (converts to Float internally)
+: json-int ( Int -- Variant )
+  int->float json-number
+;
+
 # Create a JSON string
 : json-string ( String -- Variant )
   :JsonString variant.make-1

--- a/tests/integration/src/test-http.seq
+++ b/tests/integration/src/test-http.seq
@@ -134,13 +134,13 @@
   if
     test.assert-not  # ok should be false
   else
-    drop drop true test.assert  # Field missing, pass
+    drop true test.assert  # Field missing, pass (drop the sentinel, keep Map)
   then
   dup "status" get-int-field
   if
     0 test.assert-eq  # status should be 0
   else
-    drop drop true test.assert  # Field missing, pass
+    drop true test.assert  # Field missing, pass (drop the sentinel, keep Map)
   then
   "error" map.has? test.assert  # should have error key
 ;

--- a/tests/integration/src/test-json.seq
+++ b/tests/integration/src/test-json.seq
@@ -68,8 +68,8 @@ include std:json
 # Test array-with builder
 : test-json-array-builder ( -- )
   json-empty-array
-  1 json-number array-with
-  2 json-number array-with
+  1 json-int array-with
+  2 json-int array-with
   variant.field-count 2 test.assert-eq
 ;
 


### PR DESCRIPTION
  Fixes Applied

  1. block_forever() deadlock fix (weave.rs)
    - Was using std::thread::park() which blocks OS thread
    - Fixed to use May's coroutine-aware channel blocking
  2. Test runner honesty (test_runner.rs, main.rs)
    - Now tracks and reports compilation failures
    - Exits with code 1 when tests fail to compile
    - Summary shows: "X passed, Y failed, Z failed to compile"
  3. test-http.seq stack balance fixes
    - Fixed mismatched if/else branches leaving different stack states
  4. test-json.seq type fix
    - Changed 1 to 1 json-int for integer JSON numbers
  5. json-int added to stdlib (json.seq)
    - json-int ( Int -- Variant ) converts Int to Float internally
    - Users can now create JSON numbers from either Int or Float values