### PR TITLE
⏺ Done. Bumped the variant field limit from 4 to 12. All tests pass.

### DIFF
--- a/crates/compiler/src/ast.rs
+++ b/crates/compiler/src/ast.rs
@@ -658,7 +658,7 @@ impl Program {
     /// Generate constructor words for all union definitions
     ///
     /// Maximum number of fields a variant can have (limited by runtime support)
-    pub const MAX_VARIANT_FIELDS: usize = 4;
+    pub const MAX_VARIANT_FIELDS: usize = 12;
 
     /// For each union variant, generates a `Make-VariantName` word that:
     /// 1. Takes the variant's field values from the stack

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -653,6 +653,16 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
     builtin!(sigs, "variant.make-2", (a T1 T2 Symbol -- a V));
     builtin!(sigs, "variant.make-3", (a T1 T2 T3 Symbol -- a V));
     builtin!(sigs, "variant.make-4", (a T1 T2 T3 T4 Symbol -- a V));
+    // variant.make-5 through variant.make-12 defined manually (macro only supports up to 5 inputs)
+    for n in 5..=12 {
+        let mut input = StackType::RowVar("a".to_string());
+        for i in 1..=n {
+            input = input.push(Type::Var(format!("T{}", i)));
+        }
+        input = input.push(Type::Symbol);
+        let output = StackType::RowVar("a".to_string()).push(Type::Var("V".to_string()));
+        sigs.insert(format!("variant.make-{}", n), Effect::new(input, output));
+    }
 
     // Aliases for dynamic variant construction (SON-friendly names)
     builtin!(sigs, "wrap-0", (a Symbol -- a V));
@@ -660,6 +670,16 @@ pub fn builtin_signatures() -> HashMap<String, Effect> {
     builtin!(sigs, "wrap-2", (a T1 T2 Symbol -- a V));
     builtin!(sigs, "wrap-3", (a T1 T2 T3 Symbol -- a V));
     builtin!(sigs, "wrap-4", (a T1 T2 T3 T4 Symbol -- a V));
+    // wrap-5 through wrap-12 defined manually
+    for n in 5..=12 {
+        let mut input = StackType::RowVar("a".to_string());
+        for i in 1..=n {
+            input = input.push(Type::Var(format!("T{}", i)));
+        }
+        input = input.push(Type::Symbol);
+        let output = StackType::RowVar("a".to_string()).push(Type::Var("V".to_string()));
+        sigs.insert(format!("wrap-{}", n), Effect::new(input, output));
+    }
 
     // =========================================================================
     // List Operations (Higher-order combinators for Variants)
@@ -1316,11 +1336,27 @@ static BUILTIN_DOCS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::n
     docs.insert("variant.make-2", "Create a variant with 2 fields.");
     docs.insert("variant.make-3", "Create a variant with 3 fields.");
     docs.insert("variant.make-4", "Create a variant with 4 fields.");
+    docs.insert("variant.make-5", "Create a variant with 5 fields.");
+    docs.insert("variant.make-6", "Create a variant with 6 fields.");
+    docs.insert("variant.make-7", "Create a variant with 7 fields.");
+    docs.insert("variant.make-8", "Create a variant with 8 fields.");
+    docs.insert("variant.make-9", "Create a variant with 9 fields.");
+    docs.insert("variant.make-10", "Create a variant with 10 fields.");
+    docs.insert("variant.make-11", "Create a variant with 11 fields.");
+    docs.insert("variant.make-12", "Create a variant with 12 fields.");
     docs.insert("wrap-0", "Create a variant with 0 fields (alias).");
     docs.insert("wrap-1", "Create a variant with 1 field (alias).");
     docs.insert("wrap-2", "Create a variant with 2 fields (alias).");
     docs.insert("wrap-3", "Create a variant with 3 fields (alias).");
     docs.insert("wrap-4", "Create a variant with 4 fields (alias).");
+    docs.insert("wrap-5", "Create a variant with 5 fields (alias).");
+    docs.insert("wrap-6", "Create a variant with 6 fields (alias).");
+    docs.insert("wrap-7", "Create a variant with 7 fields (alias).");
+    docs.insert("wrap-8", "Create a variant with 8 fields (alias).");
+    docs.insert("wrap-9", "Create a variant with 9 fields (alias).");
+    docs.insert("wrap-10", "Create a variant with 10 fields (alias).");
+    docs.insert("wrap-11", "Create a variant with 11 fields (alias).");
+    docs.insert("wrap-12", "Create a variant with 12 fields (alias).");
 
     // List Operations
     docs.insert("list.make", "Create an empty list.");

--- a/crates/compiler/src/codegen/runtime.rs
+++ b/crates/compiler/src/codegen/runtime.rs
@@ -849,6 +849,38 @@ pub static RUNTIME_DECLARATIONS: LazyLock<Vec<RuntimeDecl>> = LazyLock::new(|| {
             category: None,
         },
         RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_5(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_6(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_7(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_8(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_9(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_10(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_11(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
+            decl: "declare ptr @patch_seq_make_variant_12(ptr)",
+            category: None,
+        },
+        RuntimeDecl {
             decl: "declare ptr @patch_seq_unpack_variant(ptr, i64)",
             category: None,
         },
@@ -1319,12 +1351,28 @@ pub static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = Lazy
         ("variant.make-2", "patch_seq_make_variant_2"),
         ("variant.make-3", "patch_seq_make_variant_3"),
         ("variant.make-4", "patch_seq_make_variant_4"),
+        ("variant.make-5", "patch_seq_make_variant_5"),
+        ("variant.make-6", "patch_seq_make_variant_6"),
+        ("variant.make-7", "patch_seq_make_variant_7"),
+        ("variant.make-8", "patch_seq_make_variant_8"),
+        ("variant.make-9", "patch_seq_make_variant_9"),
+        ("variant.make-10", "patch_seq_make_variant_10"),
+        ("variant.make-11", "patch_seq_make_variant_11"),
+        ("variant.make-12", "patch_seq_make_variant_12"),
         // wrap-N aliases for dynamic variant construction (SON)
         ("wrap-0", "patch_seq_make_variant_0"),
         ("wrap-1", "patch_seq_make_variant_1"),
         ("wrap-2", "patch_seq_make_variant_2"),
         ("wrap-3", "patch_seq_make_variant_3"),
         ("wrap-4", "patch_seq_make_variant_4"),
+        ("wrap-5", "patch_seq_make_variant_5"),
+        ("wrap-6", "patch_seq_make_variant_6"),
+        ("wrap-7", "patch_seq_make_variant_7"),
+        ("wrap-8", "patch_seq_make_variant_8"),
+        ("wrap-9", "patch_seq_make_variant_9"),
+        ("wrap-10", "patch_seq_make_variant_10"),
+        ("wrap-11", "patch_seq_make_variant_11"),
+        ("wrap-12", "patch_seq_make_variant_12"),
         // Float arithmetic
         ("f.add", "patch_seq_f_add"),
         ("f.subtract", "patch_seq_f_subtract"),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -248,7 +248,11 @@ pub use os::{
 pub use variant_ops::{
     patch_seq_make_variant_0 as make_variant_0, patch_seq_make_variant_1 as make_variant_1,
     patch_seq_make_variant_2 as make_variant_2, patch_seq_make_variant_3 as make_variant_3,
-    patch_seq_make_variant_4 as make_variant_4, patch_seq_unpack_variant as unpack_variant,
+    patch_seq_make_variant_4 as make_variant_4, patch_seq_make_variant_5 as make_variant_5,
+    patch_seq_make_variant_6 as make_variant_6, patch_seq_make_variant_7 as make_variant_7,
+    patch_seq_make_variant_8 as make_variant_8, patch_seq_make_variant_9 as make_variant_9,
+    patch_seq_make_variant_10 as make_variant_10, patch_seq_make_variant_11 as make_variant_11,
+    patch_seq_make_variant_12 as make_variant_12, patch_seq_unpack_variant as unpack_variant,
     patch_seq_variant_field_at as variant_field_at,
     patch_seq_variant_field_count as variant_field_count, patch_seq_variant_tag as variant_tag,
 };

--- a/crates/runtime/src/variant_ops.rs
+++ b/crates/runtime/src/variant_ops.rs
@@ -259,12 +259,300 @@ pub unsafe extern "C" fn patch_seq_make_variant_4(stack: Stack) -> Stack {
     }
 }
 
+/// Create a variant with 5 fields
+///
+/// Stack effect: ( field1 field2 field3 field4 field5 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 5 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_5(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-5: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![field1, field2, field3, field4, field5],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 6 fields
+///
+/// Stack effect: ( field1 field2 field3 field4 field5 field6 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 6 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_6(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-6: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![field1, field2, field3, field4, field5, field6],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 7 fields
+///
+/// Stack effect: ( field1 field2 field3 field4 field5 field6 field7 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 7 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_7(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-7: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field7) = pop(stack);
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![field1, field2, field3, field4, field5, field6, field7],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 8 fields
+///
+/// Stack effect: ( field1 field2 field3 field4 field5 field6 field7 field8 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 8 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_8(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-8: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field8) = pop(stack);
+        let (stack, field7) = pop(stack);
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![
+                field1, field2, field3, field4, field5, field6, field7, field8,
+            ],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 9 fields
+///
+/// Stack effect: ( field1 ... field9 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 9 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_9(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-9: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field9) = pop(stack);
+        let (stack, field8) = pop(stack);
+        let (stack, field7) = pop(stack);
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![
+                field1, field2, field3, field4, field5, field6, field7, field8, field9,
+            ],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 10 fields
+///
+/// Stack effect: ( field1 ... field10 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 10 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_10(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-10: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field10) = pop(stack);
+        let (stack, field9) = pop(stack);
+        let (stack, field8) = pop(stack);
+        let (stack, field7) = pop(stack);
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![
+                field1, field2, field3, field4, field5, field6, field7, field8, field9, field10,
+            ],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 11 fields
+///
+/// Stack effect: ( field1 ... field11 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 11 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_11(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-11: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field11) = pop(stack);
+        let (stack, field10) = pop(stack);
+        let (stack, field9) = pop(stack);
+        let (stack, field8) = pop(stack);
+        let (stack, field7) = pop(stack);
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![
+                field1, field2, field3, field4, field5, field6, field7, field8, field9, field10,
+                field11,
+            ],
+        )));
+        push(stack, variant)
+    }
+}
+
+/// Create a variant with 12 fields
+///
+/// Stack effect: ( field1 ... field12 Symbol -- Variant )
+///
+/// # Safety
+/// Stack must have 12 fields and Symbol tag on top
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_make_variant_12(stack: Stack) -> Stack {
+    use crate::value::VariantData;
+
+    unsafe {
+        let (stack, tag_val) = pop(stack);
+        let tag = match tag_val {
+            Value::Symbol(s) => s,
+            _ => panic!("make-variant-12: expected Symbol (tag), got {:?}", tag_val),
+        };
+
+        let (stack, field12) = pop(stack);
+        let (stack, field11) = pop(stack);
+        let (stack, field10) = pop(stack);
+        let (stack, field9) = pop(stack);
+        let (stack, field8) = pop(stack);
+        let (stack, field7) = pop(stack);
+        let (stack, field6) = pop(stack);
+        let (stack, field5) = pop(stack);
+        let (stack, field4) = pop(stack);
+        let (stack, field3) = pop(stack);
+        let (stack, field2) = pop(stack);
+        let (stack, field1) = pop(stack);
+        let variant = Value::Variant(Arc::new(VariantData::new(
+            tag,
+            vec![
+                field1, field2, field3, field4, field5, field6, field7, field8, field9, field10,
+                field11, field12,
+            ],
+        )));
+        push(stack, variant)
+    }
+}
+
 // Re-exports for internal use
 pub use patch_seq_make_variant_0 as make_variant_0;
 pub use patch_seq_make_variant_1 as make_variant_1;
 pub use patch_seq_make_variant_2 as make_variant_2;
 pub use patch_seq_make_variant_3 as make_variant_3;
 pub use patch_seq_make_variant_4 as make_variant_4;
+pub use patch_seq_make_variant_5 as make_variant_5;
+pub use patch_seq_make_variant_6 as make_variant_6;
+pub use patch_seq_make_variant_7 as make_variant_7;
+pub use patch_seq_make_variant_8 as make_variant_8;
+pub use patch_seq_make_variant_9 as make_variant_9;
+pub use patch_seq_make_variant_10 as make_variant_10;
+pub use patch_seq_make_variant_11 as make_variant_11;
+pub use patch_seq_make_variant_12 as make_variant_12;
 
 /// Append a value to a variant, returning a new variant
 ///

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ Types are inferred at compile time. The type checker:
 Variants are tagged unions with N fields:
 
 ```seq
-# Create using typed constructors (0-4 fields)
+# Create using typed constructors (0-12 fields)
 42 "hello" 1 make-variant-2    # Tag 1 with fields [42, "hello"]
 5 make-variant-0               # Tag 5 with no fields
 

--- a/docs/STDLIB_REFERENCE.md
+++ b/docs/STDLIB_REFERENCE.md
@@ -296,8 +296,8 @@ Complete reference for all 152 built-in operations.
 | `variant.make-0` / `wrap-0` | `( Symbol -- Variant )` | Create variant with 0 fields |
 | `variant.make-1` / `wrap-1` | `( T Symbol -- Variant )` | Create variant with 1 field |
 | `variant.make-2` / `wrap-2` | `( T T Symbol -- Variant )` | Create variant with 2 fields |
-| `variant.make-3` / `wrap-3` | `( T T T Symbol -- Variant )` | Create variant with 3 fields |
-| `variant.make-4` / `wrap-4` | `( T T T T Symbol -- Variant )` | Create variant with 4 fields |
+| ... | ... | ... |
+| `variant.make-12` / `wrap-12` | `( T ... T Symbol -- Variant )` | Create variant with 12 fields |
 
 ## List Operations
 

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -286,7 +286,7 @@ Seq's `union` is similar to Rust's `enum` - each variant can carry multiple name
 
 | Feature | C++ `std::variant` | Rust `enum` | Seq `union` |
 |---------|-------------------|-------------|-------------|
-| Multiple fields per variant | No (single type) | Yes | Yes (max 4) |
+| Multiple fields per variant | No (single type) | Yes | Yes (max 12) |
 | Named fields | No | Yes | Yes |
 | Exhaustive matching | `std::visit` | `match` | `match` |
 
@@ -320,11 +320,12 @@ union Bad { Foo { x: Unknown } }  # Error: Unknown type 'Unknown'
 ```
 Valid field types: `Int`, `Float`, `Bool`, `String`, or another defined union.
 
-**Variant arity limit** - Maximum 4 fields per variant:
+**Variant arity limit** - Maximum 12 fields per variant:
 ```seq
-union TooBig { V { a: Int, b: Int, c: Int, d: Int, e: Int } }
-# Error: Variant 'V' has 5 fields, maximum is 4.
-# Consider grouping fields into nested union types.
+union TooBig { V { a: Int, b: Int, c: Int, d: Int, e: Int, f: Int,
+                   g: Int, h: Int, i: Int, j: Int, k: Int, l: Int, m: Int } }
+# Error: Variant 'V' has 13 fields, maximum is 12.
+# Consider using a Map or grouping fields into nested union types.
 ```
 
 ### Pattern Matching


### PR DESCRIPTION
  Changes made:

  1. Runtime (crates/runtime/src/variant_ops.rs):
    - Added patch_seq_make_variant_5 through patch_seq_make_variant_12
    - Added re-exports for internal use
  2. Runtime exports (crates/runtime/src/lib.rs):
    - Added exports for new make_variant functions
  3. Builtin signatures (crates/compiler/src/builtins.rs):
    - Added signatures for variant.make-5 through variant.make-12 (using a loop since the macro only supports up to 5 inputs)
    - Added signatures for wrap-5 through wrap-12
    - Added docs for all new builtins
  4. Codegen (crates/compiler/src/codegen/runtime.rs):
    - Added LLVM declarations for new runtime functions
    - Added builtin-to-runtime mappings
  5. AST (crates/compiler/src/ast.rs):
    - Changed MAX_VARIANT_FIELDS from 4 to 12
  6. Documentation:
    - Updated language-guide.md (comparison table, error example)
    - Updated STDLIB_REFERENCE.md (variant constructors table)
    - Updated ARCHITECTURE.md (comment about field count)