### PR TITLE
⏺ Done. Looking at issue #302, all three items are addressed:

### DIFF
--- a/crates/compiler/src/codegen/specialization.rs
+++ b/crates/compiler/src/codegen/specialization.rs
@@ -635,7 +635,10 @@ impl CodeGen {
 
             Statement::FloatLiteral(f) => {
                 let var = self.fresh_temp();
-                // Use hexadecimal float format for exact representation
+                // Use bitcast from integer bits for exact IEEE 754 representation.
+                // This avoids precision loss from decimal string conversion (e.g., 0.1
+                // cannot be exactly represented in binary floating point). By storing
+                // the raw bit pattern and using bitcast, we preserve the exact value.
                 let bits = f.to_bits();
                 writeln!(
                     &mut self.output,


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/302

  1. Integer overflow comment - Already exists at lines 787-788: // Integer arithmetic - uses LLVM's default wrapping behavior (no nsw/nuw flags). // This matches the runtime's wrapping_add/sub/mul semantics for defined overflow.
  2. Shift bounds checking extraction - Already done. emit_specialized_safe_shift helper handles both shl and shr via the is_left parameter (lines 846-851 call it).
  3. Float literal comment - Expanded to explain why bitcast is used for exact IEEE 754 representation.

  The only change needed was expanding the float literal comment. The code was already well-organized for items 1 and 2.