### PR TITLE
i-309

### DIFF
--- a/crates/core/src/arena.rs
+++ b/crates/core/src/arena.rs
@@ -22,10 +22,10 @@
 //! - Arena A still contains the strings from earlier allocation
 //!
 //! **Why this is safe:**
-//! - Arena reset only happens on strand exit (see `scheduler.rs:203`)
+//! - Arena reset only happens on strand exit (see `scheduler.rs:512-525`)
 //! - A migrated strand continues executing, doesn't trigger reset of Arena A
 //! - Arena A will be reset when the *next* strand on Thread A exits
-//! - Channel sends clone to global allocator (see `cemstring.rs:73-76`)
+//! - Channel sends clone to global allocator (see `seqstring.rs:123-132`)
 //!
 //! **Performance impact:**
 //! - Minimal in practice - May rarely migrates strands
@@ -118,7 +118,6 @@ fn should_reset() -> bool {
 }
 
 /// Get current arena statistics
-#[allow(dead_code)]
 pub fn arena_stats() -> ArenaStats {
     // Read from our tracked bytes instead of Bump's internal state
     // This ensures consistency with arena_reset() which sets ARENA_BYTES_ALLOCATED to 0

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -60,17 +60,6 @@ pub fn clear_runtime_error() {
     ERROR_CSTRING.with(|e| *e.borrow_mut() = None);
 }
 
-/// Format a panic payload into an error message
-pub fn format_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = payload.downcast_ref::<&str>() {
-        s.to_string()
-    } else if let Some(s) = payload.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        "unknown panic".to_string()
-    }
-}
-
 // FFI-safe error access functions
 
 /// Check if there's a pending runtime error (FFI-safe)
@@ -166,14 +155,5 @@ mod tests {
         clear_runtime_error();
         assert!(!has_runtime_error());
         assert!(take_runtime_error().is_none());
-    }
-
-    #[test]
-    fn test_format_panic_payload() {
-        let payload: Box<dyn std::any::Any + Send> = Box::new("panic message");
-        assert_eq!(format_panic_payload(&payload), "panic message");
-
-        let payload: Box<dyn std::any::Any + Send> = Box::new("owned panic".to_string());
-        assert_eq!(format_panic_payload(&payload), "owned panic");
     }
 }


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/309

  Here's a summary of all changes made:

  arena.rs - 3 fixes:
  1. Line 26: Updated scheduler.rs:203 → scheduler.rs:512-525
  2. Line 28: Updated cemstring.rs:73-76 → seqstring.rs:123-132
  3. Removed #[allow(dead_code)] from arena_stats() (it IS used externally)

  error.rs - removed dead code:
  - Removed format_panic_payload() function
  - Removed test_format_panic_payload test

  memory_stats.rs - removed dead code:
  - Removed per_thread_stats() method
  - Removed ThreadMemoryStats struct
  - Removed test_per_thread_stats test