### PR TITLE
⏺ Issue #313 audit is complete. Here's a summary of the changes made:

### DIFF
--- a/crates/compiler/src/lint.rs
+++ b/crates/compiler/src/lint.rs
@@ -37,17 +37,6 @@ pub enum Severity {
     Hint,
 }
 
-impl Severity {
-    /// Convert to LSP DiagnosticSeverity number
-    pub fn to_lsp_severity(&self) -> u32 {
-        match self {
-            Severity::Error => 1,
-            Severity::Warning => 2,
-            Severity::Hint => 4,
-        }
-    }
-}
-
 /// A single lint rule from configuration
 #[derive(Debug, Clone, Deserialize)]
 pub struct LintRule {


### PR DESCRIPTION
  lint.rs:

https://github.com/navicore/patch-seq/issues/313

  - Removed unused to_lsp_severity() method from Severity impl (the LSP crate handles this conversion directly)

  resource_lint.rs:
  - Changed 7 internal types from pub to pub(crate):
    - ResourceKind
    - TrackedResource
    - StackValue
    - StackState
    - BranchMergeResult
    - InconsistentResource
    - WordResourceInfo
  - Removed unused created_column field from TrackedResource
  - Updated push_resource() method signature and all 5 call sites to remove the column parameter

  Build completed with no warnings and all 293 tests pass. Ready for the next audit issue when you are.