### PR TITLE
⏺ All 293+ tests pass.

### DIFF
--- a/crates/compiler/src/codegen/specialization.rs
+++ b/crates/compiler/src/codegen/specialization.rs
@@ -216,22 +216,10 @@ impl RegisterContext {
         self.values.pop()
     }
 
-    /// Peek at the top value without removing it (for future use)
-    #[allow(dead_code)]
-    pub fn peek(&self) -> Option<&(String, RegisterType)> {
-        self.values.last()
-    }
-
     /// Get the number of values in the context
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn len(&self) -> usize {
         self.values.len()
-    }
-
-    /// Check if the context is empty (for future use)
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        self.values.is_empty()
     }
 
     /// Perform dup: ( a -- a a ) - duplicate top value


### PR DESCRIPTION
  ---
  Issue #316 Audit Complete

https://github.com/navicore/patch-seq/issues/316

  Files Audited (5 files, 3459 total lines):
  - runtime.rs (1434 lines): Clean
  - types.rs (126 lines): Clean
  - globals.rs (107 lines): Clean
  - virtual_stack.rs (114 lines): Clean
  - specialization.rs (1678 lines): 2 fixes applied

  Fixes Made:

  1. Removed RegisterContext::peek() (specialization.rs:219-223)
    - Method marked #[allow(dead_code)] with "for future use" comment
    - Never called anywhere in codebase
  2. Removed RegisterContext::is_empty() (specialization.rs:231-235)
    - Method marked #[allow(dead_code)] with "for future use" comment
    - Never called anywhere in codebase

  Notes:
  - RegisterContext::len() has conditional annotation #[cfg_attr(not(test), allow(dead_code))] which is correct - it's used in tests at line 1657, 1661, 1671, 1676
  - VirtualValue::Int { value, .. } in state.rs:112 is annotated for "constant folding in Phase 2" - left as-is since it's a data field for planned optimization work, not dead functionality