### PR TITLE
⏺ All 293+ tests pass.

### DIFF
--- a/crates/compiler/src/ffi.rs
+++ b/crates/compiler/src/ffi.rs
@@ -383,11 +383,6 @@ impl FfiBindings {
         self.functions.contains_key(name)
     }
 
-    /// Get FFI function info
-    pub fn get_function(&self, name: &str) -> Option<&FfiFunctionInfo> {
-        self.functions.get(name)
-    }
-
     /// Get all FFI function names for AST validation
     pub fn function_names(&self) -> Vec<&str> {
         self.functions.keys().map(|s| s.as_str()).collect()


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/317

  ---
  Issue #317 Audit Complete

  Files Audited (3 files, 1176 total lines):
  - ffi_wrappers.rs (411 lines): Clean - well-structured LLVM IR generation for C interop
  - platform.rs (67 lines): Clean - platform detection and FFI type helpers
  - ffi.rs (698 lines): 1 fix applied

  Fix Made:

  1. Removed FfiBindings::get_function() (ffi.rs:386-389)
    - Method was defined but never called
    - Codebase accesses .functions HashMap directly instead
    - Removed 5 lines of dead code

  Notes:
  - All other public functions verified as used:
    - get_target_triple() → program.rs:75, 161
    - ffi_c_args() → program.rs:193
    - ffi_return_type() → ffi_wrappers.rs:356
    - get_ffi_manifest() → lib.rs:203
    - has_ffi_manifest() → resolver.rs:142
    - list_ffi_manifests() → resolver.rs:146
    - FfiBindings::is_ffi_function() → words.rs:275, statements.rs:55
    - FfiBindings::function_names() → lib.rs:246
  - Good security validation in manifest parsing (linker flag injection prevention)
  - Comprehensive test coverage with 17 validation tests