### PR TITLE
⏺ All tests pass. Let me provide a summary of the work completed:

### DIFF
--- a/crates/compiler/src/codegen/words.rs
+++ b/crates/compiler/src/codegen/words.rs
@@ -171,6 +171,8 @@ impl CodeGen {
                 if body.is_empty()
                     || !self.will_emit_tail_call(body.last().unwrap(), TailPosition::Tail)
                 {
+                    // Spill any remaining virtual registers before return (Issue #189)
+                    let stack_var = self.spill_virtual_stack(&stack_var)?;
                     writeln!(&mut self.output, "  ret ptr %{}", stack_var)?;
                 }
                 writeln!(&mut self.output, "}}")?;
@@ -241,6 +243,8 @@ impl CodeGen {
                 if body.is_empty()
                     || !self.will_emit_tail_call(body.last().unwrap(), TailPosition::Tail)
                 {
+                    // Spill any remaining virtual registers before return (Issue #189)
+                    let stack_var = self.spill_virtual_stack(&stack_var)?;
                     writeln!(&mut self.output, "  ret ptr %{}", stack_var)?;
                 }
                 writeln!(&mut self.output, "}}")?;

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -225,6 +225,11 @@ pub fn compile_file_with_config(
         ffi_bindings.add_manifest(&manifest)?;
     }
 
+    // RFC #345: Fix up type variables that should be union types
+    // After resolving includes, we know all union names and can convert
+    // Type::Var("UnionName") to Type::Union("UnionName") for proper nominal typing
+    program.fixup_union_types();
+
     // Generate constructor words for all union types (Make-VariantName)
     // Always done here to consolidate constructor generation in one place
     program.generate_constructors()?;

--- a/examples/projects/lisp/eval.seq
+++ b/examples/projects/lisp/eval.seq
@@ -14,24 +14,42 @@ include "parser"
 # Environment (Association List)
 #
 # Env is a list of (String, Value) bindings
-# Bindings use :Binding tag, closures use :Closure tag
+# Bindings use :Binding tag, env lists use :EnvCons/:EnvNil
+# Note: We use raw variant operations for env lists to keep them
+# separate from the typed Sexpr/SexprList unions.
 # ============================================
 
-: make-binding ( String Variant -- Variant )
+: make-binding ( Name Val -- Binding )
   :Binding variant.make-2 ;
 
-: binding-name ( Variant -- String )
+: binding-name ( Binding -- Name )
   0 variant.field-at ;
 
-: binding-value ( Variant -- Variant )
+: binding-value ( Binding -- Val )
   1 variant.field-at ;
 
-: env-empty ( -- Variant )
-  snil ;
+# Environment list operations (dynamic, not using typed SexprList)
+: env-nil ( -- EnvList )
+  :EnvNil variant.make-0 ;
 
-: env-extend ( String Variant Variant -- Variant )
+: env-nil? ( EnvList -- Bool )
+  variant.tag :EnvNil symbol.= ;
+
+: env-cons ( Binding EnvList -- EnvList2 )
+  :EnvCons variant.make-2 ;
+
+: env-car ( EnvList -- Binding )
+  0 variant.field-at ;
+
+: env-cdr ( EnvList -- EnvList2 )
+  1 variant.field-at ;
+
+: env-empty ( -- EnvList )
+  env-nil ;
+
+: env-extend ( Name Val EnvList -- EnvList2 )
   # Stack: Name Value Env
-  rot rot make-binding swap scons ;
+  rot rot make-binding swap env-cons ;
 
 # ============================================
 # Closure (Lambda Value)
@@ -42,35 +60,35 @@ include "parser"
 # - Field 2: Captured environment
 # ============================================
 
-: make-closure ( Variant Variant Variant -- Variant )
+: make-closure ( Params Body Env -- Clos )
   :Closure variant.make-3 ;
 
-: closure? ( Variant -- Bool )
+: closure? ( Clos -- Bool )
   variant.tag :Closure symbol.= ;
 
-: closure-params ( Variant -- Variant )
+: closure-params ( Clos -- Params )
   0 variant.field-at ;
 
-: closure-body ( Variant -- Variant )
+: closure-body ( Clos -- Body )
   1 variant.field-at ;
 
-: closure-env ( Variant -- Variant )
+: closure-env ( Clos -- Env )
   2 variant.field-at ;
 
-: env-lookup ( String Variant -- Variant )
+: env-lookup ( Name EnvList -- Result )
   # Stack: Name Env
   # Returns the value or snil wrapped as empty SList if not found
-  dup snil? if
+  dup env-nil? if
     # Not found - return empty list as error marker
     drop drop snil slist
   else
-    dup scar binding-name
+    dup env-car binding-name
     2 pick string.equal? if
       # Found it
-      nip scar binding-value
+      nip env-car binding-value
     else
       # Keep looking
-      scdr env-lookup
+      env-cdr env-lookup
     then
   then ;
 
@@ -79,11 +97,11 @@ include "parser"
 # ============================================
 
 # Simple eval without environment (for backward compatibility)
-: eval ( Variant -- Variant )
+: eval ( Expr -- Result )
   env-empty eval-with-env ;
 
 # Eval with explicit environment
-: eval-with-env ( Variant Variant -- Variant )
+: eval-with-env ( Expr Env -- Result )
   # Stack: Expr Env
   over
   match
@@ -108,13 +126,13 @@ include "parser"
 # ============================================
 
 # Evaluate a symbol in function position (builtin dispatch)
-: eval-sym-call ( Variant Variant Variant -- Variant )
+: eval-sym-call ( Env List Head -- Result )
   # Stack: Env List Head
   ssym-val swap rot eval-builtin-with-env
 ;
 
 # Evaluate a list in function position (lambda call)
-: eval-list-call ( Variant Variant Variant -- Variant )
+: eval-list-call ( Env List Head -- Result )
   # Stack: Env List Head
   2 pick eval-with-env  # -> Env List EvaledHead
   dup closure? if
@@ -127,7 +145,7 @@ include "parser"
 ;
 
 # Dispatch on function type
-: eval-func-call ( Variant Variant Variant -- Variant )
+: eval-func-call ( Env List Head -- Result )
   # Stack: Env List Head
   [ dup ssym? ]  [ eval-sym-call ]
   [ dup slist? ] [ eval-list-call ]
@@ -135,7 +153,7 @@ include "parser"
   3 cond
 ;
 
-: eval-list-with-env ( Variant Variant -- Variant )
+: eval-list-with-env ( Expr Env -- Result )
   # Stack: Expr Env
   swap slist-val
   dup snil? if
@@ -151,7 +169,7 @@ include "parser"
 # Built-in Function Dispatch
 # ============================================
 
-: eval-builtin-with-env ( String Variant Variant -- Variant )
+: eval-builtin-with-env ( FnName List Env -- Result )
   # Stack: FuncName List Env
   rot
   [ dup "+" string.equal? ]      [ drop eval-add-with-env ]
@@ -169,13 +187,13 @@ include "parser"
 # Arithmetic Operations
 # ============================================
 
-: eval-add-with-env ( Variant Variant -- Variant )
+: eval-add-with-env ( List Env -- Result )
   # Stack: List Env
   swap scdr swap  # Skip the + -> RestList Env
   0 swap eval-fold-add-with-env snum
 ;
 
-: eval-fold-add-with-env ( Variant Int Variant -- Int )
+: eval-fold-add-with-env ( List Acc Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -192,7 +210,7 @@ include "parser"
   then
 ;
 
-: eval-sub-with-env ( Variant Variant -- Variant )
+: eval-sub-with-env ( List Env -- Result )
   # Stack: List Env
   swap scdr
   dup snil? if
@@ -211,7 +229,7 @@ include "parser"
   then
 ;
 
-: eval-fold-sub-with-env ( Variant Int Variant -- Int )
+: eval-fold-sub-with-env ( List Acc Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -228,13 +246,13 @@ include "parser"
   then
 ;
 
-: eval-mul-with-env ( Variant Variant -- Variant )
+: eval-mul-with-env ( List Env -- Result )
   # Stack: List Env
   swap scdr swap  # Skip the * -> RestList Env
   1 swap eval-fold-mul-with-env snum
 ;
 
-: eval-fold-mul-with-env ( Variant Int Variant -- Int )
+: eval-fold-mul-with-env ( List Acc Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -251,7 +269,7 @@ include "parser"
   then
 ;
 
-: eval-div-with-env ( Variant Variant -- Variant )
+: eval-div-with-env ( List Env -- Result )
   # Stack: List Env
   swap scdr
   dup snil? if
@@ -268,7 +286,7 @@ include "parser"
   then
 ;
 
-: eval-fold-div-with-env ( Variant Int Variant -- Int )
+: eval-fold-div-with-env ( List Acc Env -- Int )
   # Stack: List Acc Env
   2 pick snil? if
     # List is empty, return Acc
@@ -289,7 +307,7 @@ include "parser"
 # Conditional (if)
 # ============================================
 
-: eval-if-with-env ( Variant Variant -- Variant )
+: eval-if-with-env ( List Env -- Result )
   # Stack: List Env
   # List is (if cond then-expr else-expr)
   swap scdr  # Skip the if -> Env Args
@@ -319,7 +337,7 @@ include "parser"
 # Let Binding
 # ============================================
 
-: eval-let-with-env ( Variant Variant -- Variant )
+: eval-let-with-env ( List Env -- Result )
   # Stack: List Env
   # List is (let name value body)
   swap scdr  # Skip the 'let' -> Env Args
@@ -341,7 +359,7 @@ include "parser"
 # Lambda
 # ============================================
 
-: eval-lambda-with-env ( Variant Variant -- Variant )
+: eval-lambda-with-env ( List Env -- Result )
   # Stack: List Env
   # List is (lambda (params) body)
   swap scdr  # Skip 'lambda' -> Env Args
@@ -356,7 +374,7 @@ include "parser"
 # Closure Application
 # ============================================
 
-: apply-closure ( Variant Variant Variant -- Variant )
+: apply-closure ( Clos Args CallerEnv -- Result )
   # Stack: Closure Args CallerEnv
   # For simplicity, support single-parameter lambdas
   # 1. Evaluate the single argument

--- a/tests/integration/src/test-union-type-safety.seq
+++ b/tests/integration/src/test-union-type-safety.seq
@@ -1,0 +1,47 @@
+# RFC #345: Test compile-time safety for union types
+# This file tests the type-safe accessor and predicate generation
+
+union Point { XY { x: Int, y: Int } }
+union Color { RGB { r: Int, g: Int, b: Int } }
+
+# Test: Constructors return correct union types and accessors work
+: test-constructor-and-accessors ( -- )
+  10 20 Make-XY
+  dup XY-x 10 test.assert-eq
+  XY-y 20 test.assert-eq
+
+  255 128 64 Make-RGB
+  dup RGB-r 255 test.assert-eq
+  dup RGB-g 128 test.assert-eq
+  RGB-b 64 test.assert-eq
+;
+
+# Test: Type predicates work correctly
+: test-type-predicates ( -- )
+  10 20 Make-XY
+  is-XY? test.assert
+
+  255 128 64 Make-RGB
+  is-RGB? test.assert
+;
+
+# Test: Multiple field access
+: test-multi-field-access ( -- )
+  1 2 3 Make-RGB
+  dup RGB-r swap
+  dup RGB-g swap
+  RGB-b
+  # Stack: 1 2 3
+  3 test.assert-eq
+  2 test.assert-eq
+  1 test.assert-eq
+;
+
+# Test: Field accessors with different types
+union Record { Data { id: Int, name: String } }
+
+: test-mixed-type-accessors ( -- )
+  42 "hello" Make-Data
+  dup Data-id 42 test.assert-eq
+  Data-name "hello" string.equal? test.assert
+;


### PR DESCRIPTION
  Summary

https://github.com/navicore/patch-seq/issues/345

  RFC #345 Implementation Complete

  Successfully implemented compile-time safety for union types with:

  1. Type-safe constructors - Make-VariantName now returns the specific union type instead of generic V
  2. Generated predicates - is-VariantName? for type checking at runtime
  3. Generated field accessors - VariantName-fieldname for type-safe field access

  Bug Fixes During Testing

  Fixed a pre-existing codegen bug in quotations (crates/compiler/src/codegen/words.rs):
  - Quotations that push values (like [ true ]) weren't spilling the virtual stack to memory before returning
  - This caused cond predicates to read stale values from the stack instead of the actual boolean result
  - Added spill_virtual_stack() calls before ret in both stateless quotations and closures

  Updated lisp example type annotations (examples/projects/lisp/eval.seq):
  - Changed repeated type variable names (Variant Variant Variant) to distinct names (Env List Head)
  - In Seq's type system, repeated type variable names must unify to the same type
  - Different type variables allow different types to be passed

  Test Results

  - All 376 integration tests pass
  - All 407+ unit tests pass
  - The cond example works correctly
  - The lisp evaluator and tokenizer work correctly