### PR TITLE
  Phase 2 codegen wiring is now complete. Every codegen file that emi…

### DIFF
--- a/crates/compiler/src/codegen/inline/dispatch.rs
+++ b/crates/compiler/src/codegen/inline/dispatch.rs
@@ -22,6 +22,7 @@ impl CodeGen {
             // Must call runtime to properly drop heap values
             "drop" => {
                 let stack_var = self.spill_virtual_stack(stack_var)?;
+                let stack_var = stack_var.as_str();
                 let result_var = self.fresh_temp();
                 writeln!(
                     &mut self.output,
@@ -363,21 +364,8 @@ impl CodeGen {
                     neg_offset, offset
                 )?;
 
-                // Get pointer to the item to copy (dynamic GEP)
-                let src_ptr = self.fresh_temp();
-                if self.tagged_ptr {
-                    writeln!(
-                        &mut self.output,
-                        "  %{} = getelementptr i64, ptr %{}, i64 %{}",
-                        src_ptr, stack_var, neg_offset
-                    )?;
-                } else {
-                    writeln!(
-                        &mut self.output,
-                        "  %{} = getelementptr %Value, ptr %{}, i64 %{}",
-                        src_ptr, stack_var, neg_offset
-                    )?;
-                }
+                // Get pointer to the item to copy (dynamic offset)
+                let src_ptr = self.emit_dynamic_stack_gep(stack_var, &neg_offset)?;
 
                 // Clone value from src to n_ptr (replacing n)
                 writeln!(
@@ -419,20 +407,7 @@ impl CodeGen {
                 )?;
 
                 // Dynamic GEP to xn
-                let src_ptr = self.fresh_temp();
-                if self.tagged_ptr {
-                    writeln!(
-                        &mut self.output,
-                        "  %{} = getelementptr i64, ptr %{}, i64 %{}",
-                        src_ptr, popped_sp, neg_offset
-                    )?;
-                } else {
-                    writeln!(
-                        &mut self.output,
-                        "  %{} = getelementptr %Value, ptr %{}, i64 %{}",
-                        src_ptr, popped_sp, neg_offset
-                    )?;
-                }
+                let src_ptr = self.emit_dynamic_stack_gep(&popped_sp, &neg_offset)?;
 
                 // Load the value to roll
                 let rolled_val = self.emit_load_value(&src_ptr)?;
@@ -478,9 +453,9 @@ impl CodeGen {
 
                 self.current_aux_sp += 1;
 
-                // Decrement main stack SP
-                let result_var = top_ptr.clone();
-                Ok(Some(result_var))
+                // Reuse top_ptr as the new SP — it already points to sp-1
+                // (the slot we just consumed), so no additional GEP needed
+                Ok(Some(top_ptr))
             }
 
             // aux>: ( -- T ) move top of aux stack to main stack

--- a/crates/compiler/src/codegen/layout.rs
+++ b/crates/compiler/src/codegen/layout.rs
@@ -27,8 +27,6 @@
 use super::{CodeGen, CodeGenError};
 use std::fmt::Write as _;
 
-// These helpers are WIP — they'll be wired in as we migrate each codegen pattern.
-#[allow(dead_code)]
 impl CodeGen {
     // =========================================================================
     // Type definition
@@ -70,6 +68,30 @@ impl CodeGen {
                 &mut self.output,
                 "  %{} = getelementptr %Value, ptr %{}, i64 {}",
                 tmp, base, offset
+            )?;
+        }
+        Ok(tmp)
+    }
+
+    /// Emit a GEP with a dynamic (runtime) offset in an SSA variable.
+    /// Returns the temp variable name holding the resulting pointer.
+    pub(super) fn emit_dynamic_stack_gep(
+        &mut self,
+        base: &str,
+        offset_var: &str,
+    ) -> Result<String, CodeGenError> {
+        let tmp = self.fresh_temp();
+        if self.tagged_ptr {
+            writeln!(
+                &mut self.output,
+                "  %{} = getelementptr i64, ptr %{}, i64 %{}",
+                tmp, base, offset_var
+            )?;
+        } else {
+            writeln!(
+                &mut self.output,
+                "  %{} = getelementptr %Value, ptr %{}, i64 %{}",
+                tmp, base, offset_var
             )?;
         }
         Ok(tmp)
@@ -604,5 +626,60 @@ mod tests {
                 .to_string()
                 .contains("not yet implemented")
         );
+    }
+
+    #[test]
+    fn test_load_value_default() {
+        let mut cg = codegen_default();
+        let val = cg.emit_load_value("ptr_a").unwrap();
+        assert!(cg.output.contains("load %Value, ptr %ptr_a"));
+        assert!(!val.is_empty());
+    }
+
+    #[test]
+    fn test_load_value_tagged() {
+        let mut cg = codegen_tagged();
+        let val = cg.emit_load_value("ptr_a").unwrap();
+        assert!(cg.output.contains("load i64, ptr %ptr_a"));
+        assert!(!cg.output.contains("%Value"));
+        assert!(!val.is_empty());
+    }
+
+    #[test]
+    fn test_store_value_default() {
+        let mut cg = codegen_default();
+        cg.emit_store_value("ptr_a", "val").unwrap();
+        assert!(cg.output.contains("store %Value %val, ptr %ptr_a"));
+    }
+
+    #[test]
+    fn test_store_value_tagged() {
+        let mut cg = codegen_tagged();
+        cg.emit_store_value("ptr_a", "val").unwrap();
+        assert!(cg.output.contains("store i64 %val, ptr %ptr_a"));
+        assert!(!cg.output.contains("%Value"));
+    }
+
+    #[test]
+    fn test_dynamic_stack_gep_default() {
+        let mut cg = codegen_default();
+        let tmp = cg.emit_dynamic_stack_gep("sp", "offset").unwrap();
+        assert!(
+            cg.output
+                .contains("getelementptr %Value, ptr %sp, i64 %offset")
+        );
+        assert!(!tmp.is_empty());
+    }
+
+    #[test]
+    fn test_dynamic_stack_gep_tagged() {
+        let mut cg = codegen_tagged();
+        let tmp = cg.emit_dynamic_stack_gep("sp", "offset").unwrap();
+        assert!(
+            cg.output
+                .contains("getelementptr i64, ptr %sp, i64 %offset")
+        );
+        assert!(!cg.output.contains("%Value"));
+        assert!(!tmp.is_empty());
     }
 }


### PR DESCRIPTION
…tted layout-dependent IR now uses the layout.rs helpers:

  ┌────────────────────┬────────────────────────────────────────────┬────────────────────────────────────────────────┐
  │        File        │                   Status                   │                 GEPs replaced                  │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ program.rs         │ Done                                       │ 2 (type definition)                            │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ virtual_stack.rs   │ Done                                       │ 3 (spill logic)                                │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ inline/ops.rs      │ Done                                       │ ~30 (all arithmetic/comparison/bitwise)        │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ inline/dispatch.rs │ Done                                       │ ~60 (all stack ops, bool ops, pick, roll, aux) │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ control_flow.rs    │ Done                                       │ 3 (if/else condition)                          │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ statements.rs      │ Done                                       │ 2 (main exit code)                             │
  ├────────────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┤
  │ specialization.rs  │ No changes needed (already register-based) │                                                │
  └────────────────────┴────────────────────────────────────────────┴────────────────────────────────────────────────┘