### PR TITLE
Phase 3 is done

### DIFF
--- a/crates/core/src/stack_new.rs
+++ b/crates/core/src/stack_new.rs
@@ -626,6 +626,20 @@ fn print_stack_value(sv: StackValue) {
     print!("{}", son);
 }
 
+// ============================================================================
+// Short Aliases for Internal/Test Use
+// ============================================================================
+
+pub use patch_seq_2dup as two_dup;
+pub use patch_seq_dup as dup;
+pub use patch_seq_nip as nip;
+pub use patch_seq_over as over;
+pub use patch_seq_pick_op as pick;
+pub use patch_seq_roll as roll;
+pub use patch_seq_rot as rot;
+pub use patch_seq_swap as swap;
+pub use patch_seq_tuck as tuck;
+
 #[macro_export]
 macro_rules! test_stack {
     () => {{ $crate::stack::alloc_test_stack() }};

--- a/crates/runtime/src/arithmetic.rs
+++ b/crates/runtime/src/arithmetic.rs
@@ -21,8 +21,7 @@
 //!
 //! This matches the behavior of Forth and Factor, providing consistency for low-level code.
 
-use crate::stack::DISC_INT;
-use crate::stack::{Stack, peek_sv, pop, pop_two, push};
+use crate::stack::{Stack, peek, pop, pop_two, push};
 use crate::value::Value;
 
 /// Push an integer literal onto the stack (for compiler-generated code)
@@ -525,15 +524,11 @@ pub unsafe extern "C" fn patch_seq_int_bits(stack: Stack) -> Stack {
 pub unsafe extern "C" fn patch_seq_peek_int_value(stack: Stack) -> i64 {
     assert!(!stack.is_null(), "peek_int_value: stack is empty");
 
-    // Stack points to next push location, so top is at stack - 1
-    let sv = unsafe { peek_sv(stack) };
-    if sv.slot0 == DISC_INT {
-        sv.slot1 as i64
-    } else {
-        panic!(
-            "peek_int_value: expected Int on stack, got discriminant {}",
-            sv.slot0
-        )
+    // Peek and extract — use pop/push-free path via peek()
+    let val = unsafe { peek(stack) };
+    match val {
+        Value::Int(i) => i,
+        other => panic!("peek_int_value: expected Int on stack, got {:?}", other),
     }
 }
 
@@ -543,18 +538,12 @@ pub unsafe extern "C" fn patch_seq_peek_int_value(stack: Stack) -> i64 {
 /// Stack must have a Bool value on top
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn patch_seq_peek_bool_value(stack: Stack) -> bool {
-    use crate::stack::DISC_BOOL;
     assert!(!stack.is_null(), "peek_bool_value: stack is empty");
 
-    // Stack points to next push location, so top is at stack - 1
-    let sv = unsafe { peek_sv(stack) };
-    if sv.slot0 == DISC_BOOL {
-        sv.slot1 != 0
-    } else {
-        panic!(
-            "peek_bool_value: expected Bool on stack, got discriminant {}",
-            sv.slot0
-        )
+    let val = unsafe { peek(stack) };
+    match val {
+        Value::Bool(b) => b,
+        other => panic!("peek_bool_value: expected Bool on stack, got {:?}", other),
     }
 }
 
@@ -687,7 +676,8 @@ mod tests {
         }
     }
 
-    // This test uses i64::MAX and i64::MIN which are outside the 44-bit NaN-boxing range
+    // This test uses i64::MAX and i64::MIN which overflow the 63-bit tagged-ptr range
+    #[cfg(not(feature = "tagged-ptr"))]
     #[test]
     fn test_overflow_wrapping() {
         // Test that arithmetic uses wrapping semantics (defined overflow behavior)
@@ -750,7 +740,8 @@ mod tests {
         }
     }
 
-    // This test uses i64::MIN which is outside the 44-bit NaN-boxing range
+    // This test uses i64::MIN which overflows the 63-bit tagged-ptr range
+    #[cfg(not(feature = "tagged-ptr"))]
     #[test]
     fn test_division_overflow_edge_case() {
         // Critical edge case: i64::MIN / -1 would overflow

--- a/crates/runtime/src/float_ops.rs
+++ b/crates/runtime/src/float_ops.rs
@@ -523,7 +523,8 @@ mod tests {
         }
     }
 
-    // This test uses i64::MAX which is outside the 44-bit NaN-boxing range
+    // This test uses i64::MAX which overflows the 63-bit tagged-ptr range
+    #[cfg(not(feature = "tagged-ptr"))]
     #[test]
     fn test_float_to_int_overflow_positive() {
         unsafe {
@@ -537,7 +538,8 @@ mod tests {
         }
     }
 
-    // This test uses i64::MIN which is outside the 44-bit NaN-boxing range
+    // This test uses i64::MIN which overflows the 63-bit tagged-ptr range
+    #[cfg(not(feature = "tagged-ptr"))]
     #[test]
     fn test_float_to_int_overflow_negative() {
         unsafe {
@@ -564,7 +566,8 @@ mod tests {
         }
     }
 
-    // This test uses i64::MAX which is outside the 44-bit NaN-boxing range
+    // This test uses i64::MAX which overflows the 63-bit tagged-ptr range
+    #[cfg(not(feature = "tagged-ptr"))]
     #[test]
     fn test_float_to_int_infinity() {
         unsafe {

--- a/crates/runtime/src/string_ops.rs
+++ b/crates/runtime/src/string_ops.rs
@@ -631,20 +631,21 @@ pub use patch_seq_string_trim as string_trim;
 pub unsafe extern "C" fn patch_seq_string_to_cstring(stack: Stack, _out: *mut u8) -> *mut u8 {
     assert!(!stack.is_null(), "string_to_cstring: stack is empty");
 
-    use crate::stack::{DISC_STRING, peek_sv};
+    use crate::stack::peek;
+    use crate::value::Value;
 
     // Peek the string value (don't pop - caller will pop after we return)
-    let sv = unsafe { peek_sv(stack) };
-    if sv.slot0 != DISC_STRING {
-        panic!(
-            "string_to_cstring: expected String on stack, got discriminant {}",
-            sv.slot0
-        );
-    }
+    let val = unsafe { peek(stack) };
+    let s = match &val {
+        Value::String(s) => s,
+        other => panic!(
+            "string_to_cstring: expected String on stack, got {:?}",
+            other
+        ),
+    };
 
-    // Extract string data from StackValue slots
-    let str_ptr = sv.slot1 as *const u8;
-    let len = sv.slot2 as usize;
+    let str_ptr = s.as_ptr();
+    let len = s.len();
 
     // Guard against overflow: len + 1 for null terminator
     let alloc_size = len.checked_add(1).unwrap_or_else(|| {

--- a/crates/runtime/src/weave.rs
+++ b/crates/runtime/src/weave.rs
@@ -1213,6 +1213,8 @@ mod tests {
         }
     }
 
+    // This test uses i64::MIN/MAX which overflow the 63-bit tagged-ptr range
+    #[cfg(not(feature = "tagged-ptr"))]
     #[test]
     fn test_weave_yields_i64_min() {
         // Edge case: ensure i64::MIN can be yielded (no sentinel values)


### PR DESCRIPTION
  Phase 3 changes (seq-runtime):
  - arithmetic.rs — peek_int_value and peek_bool_value rewritten to use peek() → Value match instead of raw sv.slot0/sv.slot1 field access. Removed unused DISC_INT/peek_sv imports.
  - string_ops.rs — string_to_cstring rewritten to use peek() → Value::String match instead of raw slot access.
  - stack_new.rs — Added missing short aliases (dup, swap, rot, etc.) that the runtime tests depend on.
  - 6 edge-case tests gated with #[cfg(not(feature = "tagged-ptr"))] — they test i64::MIN/i64::MAX behavior that's incompatible with 63-bit integers.

  Results:
  - Default path: 414 runtime tests pass
  - tagged-ptr path: 408 runtime tests pass (6 range tests skipped)
  - Full CI: all checks pass, 433 integration tests pass

  All three phases are now complete behind the tagged-ptr feature flag:
  1. Phase 1 (seq-core): StackValue = u64, tagged encoding, conversion functions
  2. Phase 2 (seq-compiler): all codegen uses layout helpers, tagged_ptr flag ready to flip
  3. Phase 3 (seq-runtime): no direct StackValue field access, compiles clean under tagged-ptr