### PR TITLE
exit code bug fix

### DIFF
--- a/crates/compiler/src/codegen/program.rs
+++ b/crates/compiler/src/codegen/program.rs
@@ -6,12 +6,31 @@
 use super::{
     CodeGen, CodeGenError, emit_runtime_decls, ffi_c_args, ffi_return_type, get_target_triple,
 };
-use crate::ast::Program;
+use crate::ast::{Program, WordDef};
 use crate::config::CompilerConfig;
 use crate::ffi::FfiBindings;
-use crate::types::Type;
+use crate::types::{StackType, Type};
 use std::collections::HashMap;
 use std::fmt::Write as _;
+
+/// Detect whether `main` was declared with effect `( -- Int )`.
+///
+/// Returns true if main's declared output is a single Int (with no row
+/// variable below it). Returns false for `( -- )` or anything else.
+/// The typechecker is responsible for rejecting other shapes; this just
+/// reads the declared effect.
+fn main_returns_int_effect(word: &WordDef) -> bool {
+    let Some(effect) = &word.effect else {
+        return false;
+    };
+    // Inputs must be empty (or just a row var) — main takes no inputs
+    // Outputs must be exactly one Int on top of the row var
+    matches!(
+        &effect.outputs,
+        StackType::Cons { rest, top: Type::Int }
+            if matches!(**rest, StackType::Empty | StackType::RowVar(_))
+    )
+}
 
 impl CodeGen {
     /// Generate LLVM IR for entire program
@@ -63,10 +82,11 @@ impl CodeGen {
             }
         }
 
-        // Verify we have a main word
-        if program.find_word("main").is_none() {
-            return Err(CodeGenError::Logic("No main word defined".to_string()));
-        }
+        // Verify we have a main word and detect its return shape (Issue #355)
+        let main_word = program
+            .find_word("main")
+            .ok_or_else(|| CodeGenError::Logic("No main word defined".to_string()))?;
+        self.main_returns_int = main_returns_int_effect(main_word);
 
         // Generate all user-defined words
         for word in &program.words {
@@ -160,10 +180,11 @@ impl CodeGen {
             }
         }
 
-        // Verify we have a main word
-        if program.find_word("main").is_none() {
-            return Err(CodeGenError::Logic("No main word defined".to_string()));
-        }
+        // Verify we have a main word and detect its return shape (Issue #355)
+        let main_word = program
+            .find_word("main")
+            .ok_or_else(|| CodeGenError::Logic("No main word defined".to_string()))?;
+        self.main_returns_int = main_returns_int_effect(main_word);
 
         // Generate all user-defined words
         for word in &program.words {

--- a/crates/compiler/src/codegen/runtime.rs
+++ b/crates/compiler/src/codegen/runtime.rs
@@ -382,6 +382,15 @@ pub static RUNTIME_DECLARATIONS: LazyLock<Vec<RuntimeDecl>> = LazyLock::new(|| {
             decl: "declare i64 @patch_seq_strand_spawn(ptr, ptr)",
             category: None,
         },
+        // Exit code handling
+        RuntimeDecl {
+            decl: "declare void @patch_seq_set_exit_code(i64)",
+            category: Some("; Exit code handling"),
+        },
+        RuntimeDecl {
+            decl: "declare i64 @patch_seq_get_exit_code()",
+            category: None,
+        },
         // Command-line argument operations
         RuntimeDecl {
             decl: "declare void @patch_seq_args_init(i32, ptr)",

--- a/crates/compiler/src/codegen/state.rs
+++ b/crates/compiler/src/codegen/state.rs
@@ -177,6 +177,10 @@ pub struct CodeGen {
     pub(super) current_aux_sp: usize,
     /// Whether to emit per-word atomic call counters (--instrument)
     pub(super) instrument: bool,
+    /// True if the user's `main` word has effect `( -- Int )`.
+    /// Determines whether `seq_main` writes the top-of-stack int to the
+    /// global exit code before freeing the stack. (Issue #355)
+    pub(super) main_returns_int: bool,
     /// Maps word name -> sequential ID for instrumentation counters
     pub(super) word_instrument_ids: HashMap<String, usize>,
 }
@@ -224,6 +228,7 @@ impl CodeGen {
             current_aux_sp: 0,
             instrument: false,
             word_instrument_ids: HashMap::new(),
+            main_returns_int: false,
         }
     }
 

--- a/crates/compiler/src/codegen/statements.rs
+++ b/crates/compiler/src/codegen/statements.rs
@@ -518,7 +518,25 @@ impl CodeGen {
             // Emit at-exit report (no-op unless SEQ_REPORT is set at runtime)
             writeln!(&mut self.output, "  call void @patch_seq_report()")?;
 
-            writeln!(&mut self.output, "  ret i32 0")?;
+            // Read the exit code that seq_main wrote (Issue #355).
+            // Defaults to 0 for void main (never written) or for any
+            // program that didn't reach the exit code write path.
+            let exit_code_var = self.fresh_temp();
+            writeln!(
+                &mut self.output,
+                "  %{} = call i64 @patch_seq_get_exit_code()",
+                exit_code_var
+            )?;
+            // Truncate to i32 — Unix exit codes are limited to the low 8
+            // bits on Linux; other platforms vary. We pass through whatever
+            // the user returned and let the OS apply its convention.
+            let exit_code_i32 = self.fresh_temp();
+            writeln!(
+                &mut self.output,
+                "  %{} = trunc i64 %{} to i32",
+                exit_code_i32, exit_code_var
+            )?;
+            writeln!(&mut self.output, "  ret i32 %{}", exit_code_i32)?;
         }
         writeln!(&mut self.output, "}}")?;
 

--- a/crates/compiler/src/codegen/words.rs
+++ b/crates/compiler/src/codegen/words.rs
@@ -122,7 +122,22 @@ impl CodeGen {
             let stack_var = self.spill_virtual_stack(&stack_var)?;
 
             if is_main && !self.pure_inline_test {
-                // Normal mode: free the stack before returning
+                // Normal mode: maybe write exit code, then free stack and return.
+                //
+                // For `main ( -- Int )`: peek the top Int from the stack and
+                // write it to the global exit code via patch_seq_set_exit_code,
+                // BEFORE freeing the stack. The C `main` reads it after the
+                // scheduler joins all strands. (Issue #355)
+                if self.main_returns_int {
+                    let top_ptr = self.emit_stack_gep(&stack_var, -1)?;
+                    let exit_val = self.emit_load_int_payload(&top_ptr)?;
+                    writeln!(
+                        &mut self.output,
+                        "  call void @patch_seq_set_exit_code(i64 %{})",
+                        exit_val
+                    )?;
+                }
+                // Free the stack
                 writeln!(
                     &mut self.output,
                     "  call void @seq_stack_free(ptr %tagged_stack)"

--- a/crates/compiler/src/typechecker.rs
+++ b/crates/compiler/src/typechecker.rs
@@ -19,6 +19,42 @@ fn format_line_prefix(line: usize) -> String {
     format!("at line {}: ", line + 1)
 }
 
+/// Validate that `main` has an allowed signature (Issue #355).
+///
+/// Only `( -- )` and `( -- Int )` are accepted. The first is "void main"
+/// (process exits with 0). The second is "int main" (return value is the
+/// process exit code).
+///
+/// Any other shape — extra inputs, multiple outputs, non-Int output —
+/// is rejected with an actionable error.
+fn validate_main_effect(effect: &Effect) -> Result<(), String> {
+    // Inputs must be empty (just the row var, no concrete types)
+    let inputs_ok = matches!(&effect.inputs, StackType::Empty | StackType::RowVar(_));
+
+    // Outputs: either empty (void main) or exactly one Int (int main)
+    let outputs_ok = match &effect.outputs {
+        StackType::Empty | StackType::RowVar(_) => true,
+        StackType::Cons {
+            rest,
+            top: Type::Int,
+        } if matches!(**rest, StackType::Empty | StackType::RowVar(_)) => true,
+        _ => false,
+    };
+
+    if inputs_ok && outputs_ok {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Word 'main' has an invalid stack effect: ( {} -- {} ).\n\
+         `main` must be declared with one of:\n\
+           ( -- )       — void main, process exits with code 0\n\
+           ( -- Int )   — exit code is the returned Int\n\
+         Other shapes are not allowed.",
+        effect.inputs, effect.outputs
+    ))
+}
+
 pub struct TypeChecker {
     /// Environment mapping word names to their effects
     env: HashMap<String, Effect>,
@@ -459,6 +495,12 @@ impl TypeChecker {
                     word.name, word.name
                 ));
             }
+        }
+
+        // Validate main's signature (Issue #355).
+        // Only `( -- )` and `( -- Int )` are allowed.
+        if let Some(main_effect) = self.env.get("main") {
+            validate_main_effect(main_effect)?;
         }
 
         // Third pass: type check each word body

--- a/crates/runtime/src/exit_code.rs
+++ b/crates/runtime/src/exit_code.rs
@@ -32,45 +32,51 @@ static EXIT_CODE: AtomicI64 = AtomicI64::new(0);
 ///
 /// Called by generated code at the end of `seq_main` when the user declared
 /// `main ( -- Int )`. The value is the top-of-stack Int.
+///
+/// `Release` ordering is sufficient: the write happens-before the C `main`
+/// reads the value with `Acquire`, after `scheduler_run` has joined all
+/// strands. There is no other reader.
 #[unsafe(no_mangle)]
 pub extern "C" fn patch_seq_set_exit_code(code: i64) {
-    EXIT_CODE.store(code, Ordering::SeqCst);
+    EXIT_CODE.store(code, Ordering::Release);
 }
 
 /// Get the process exit code.
 ///
 /// Called by the generated C `main` function after `scheduler_run` returns.
 /// Returns 0 if `patch_seq_set_exit_code` was never called (void main).
+///
+/// `Acquire` pairs with the `Release` store in `patch_seq_set_exit_code`.
 #[unsafe(no_mangle)]
 pub extern "C" fn patch_seq_get_exit_code() -> i64 {
-    EXIT_CODE.load(Ordering::SeqCst)
+    EXIT_CODE.load(Ordering::Acquire)
 }
-
-// Public re-exports with short names for internal use
-pub use patch_seq_get_exit_code as get_exit_code;
-pub use patch_seq_set_exit_code as set_exit_code;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    // Tests share a global AtomicI64, so they must run serially to avoid
+    // interleaving writes from one test with reads from another.
 
     #[test]
+    #[serial]
     fn test_default_is_zero() {
-        // Note: this test is order-sensitive if other tests in this module
-        // run first. Reset to 0 to make it independent.
         patch_seq_set_exit_code(0);
         assert_eq!(patch_seq_get_exit_code(), 0);
     }
 
     #[test]
+    #[serial]
     fn test_set_and_get() {
         patch_seq_set_exit_code(42);
         assert_eq!(patch_seq_get_exit_code(), 42);
-        // Restore to 0 to avoid polluting other tests
         patch_seq_set_exit_code(0);
     }
 
     #[test]
+    #[serial]
     fn test_negative_exit_code() {
         patch_seq_set_exit_code(-1);
         assert_eq!(patch_seq_get_exit_code(), -1);

--- a/crates/runtime/src/exit_code.rs
+++ b/crates/runtime/src/exit_code.rs
@@ -1,0 +1,79 @@
+//! Process exit code handling
+//!
+//! Stores the integer value returned from `main ( -- Int )` so the C-level
+//! `main` function can read it after the scheduler joins all strands and
+//! return it as the process exit code.
+//!
+//! # Lifetime
+//!
+//! - The user's `seq_main` function calls `patch_seq_set_exit_code` with the
+//!   top-of-stack Int just before its stack is freed.
+//! - The C `main` function calls `patch_seq_get_exit_code` after
+//!   `patch_seq_scheduler_run` returns and uses the value as the process
+//!   exit code.
+//!
+//! # Concurrency
+//!
+//! The exit code is a single atomic global. Only the main strand writes to
+//! it, and only after all spawned strands have finished (since
+//! `scheduler_run` joins all strands). The C `main` reads it after
+//! `scheduler_run` returns. There is no race.
+//!
+//! Programs declaring `main ( -- )` (void main) never call the setter, so
+//! the exit code remains 0 — matching the historical behavior.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+/// Process exit code, written by `seq_main` for `main ( -- Int )` programs.
+/// Defaults to 0 so void mains exit with success.
+static EXIT_CODE: AtomicI64 = AtomicI64::new(0);
+
+/// Set the process exit code.
+///
+/// Called by generated code at the end of `seq_main` when the user declared
+/// `main ( -- Int )`. The value is the top-of-stack Int.
+#[unsafe(no_mangle)]
+pub extern "C" fn patch_seq_set_exit_code(code: i64) {
+    EXIT_CODE.store(code, Ordering::SeqCst);
+}
+
+/// Get the process exit code.
+///
+/// Called by the generated C `main` function after `scheduler_run` returns.
+/// Returns 0 if `patch_seq_set_exit_code` was never called (void main).
+#[unsafe(no_mangle)]
+pub extern "C" fn patch_seq_get_exit_code() -> i64 {
+    EXIT_CODE.load(Ordering::SeqCst)
+}
+
+// Public re-exports with short names for internal use
+pub use patch_seq_get_exit_code as get_exit_code;
+pub use patch_seq_set_exit_code as set_exit_code;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_is_zero() {
+        // Note: this test is order-sensitive if other tests in this module
+        // run first. Reset to 0 to make it independent.
+        patch_seq_set_exit_code(0);
+        assert_eq!(patch_seq_get_exit_code(), 0);
+    }
+
+    #[test]
+    fn test_set_and_get() {
+        patch_seq_set_exit_code(42);
+        assert_eq!(patch_seq_get_exit_code(), 42);
+        // Restore to 0 to avoid polluting other tests
+        patch_seq_set_exit_code(0);
+    }
+
+    #[test]
+    fn test_negative_exit_code() {
+        patch_seq_set_exit_code(-1);
+        assert_eq!(patch_seq_get_exit_code(), -1);
+        patch_seq_set_exit_code(0);
+    }
+}

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -24,6 +24,7 @@ pub mod combinators;
 pub mod cond;
 pub mod diagnostics;
 pub mod encoding;
+pub mod exit_code;
 pub mod file;
 pub mod float_ops;
 pub mod io;
@@ -236,6 +237,11 @@ pub use combinators::{bi, dip, keep};
 
 // Conditional combinator (exported for LLVM linking)
 pub use cond::patch_seq_cond as cond;
+
+// Exit code handling (exported for LLVM linking)
+pub use exit_code::{
+    patch_seq_get_exit_code as get_exit_code, patch_seq_set_exit_code as set_exit_code,
+};
 
 // TCP operations (exported for LLVM linking)
 pub use tcp::{

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -473,13 +473,35 @@ json-empty-object "name" json-string "John" json-string obj-with
 2. **Serialization size limits** - Arrays > 3 elements, objects > 2 pairs show as `[...]`/`{...}`
 3. **roll type checking** - `3 roll` works at runtime but type checker can't fully verify
 
-## Building
+## Building and CI
+
+The `justfile` is the source of truth for all build, test, and lint
+operations. GitHub Actions calls these recipes directly — there is no
+duplication between local development and CI.
 
 ```bash
-cargo build --release
-cargo test --all
-cargo clippy --all
+just build       # build runtime, compiler, LSP
+just test        # run all unit tests
+just lint        # clippy with warnings as errors
+just ci          # everything CI runs: fmt-check, lint, test, build,
+                 # examples, integration tests, seq lint
 ```
+
+Run `just ci` before pushing — it's the same pipeline that runs in
+GitHub Actions and will catch formatting, clippy, test, and lint
+failures locally.
+
+### Toolchain pinning
+
+The Rust toolchain is pinned in three places that must always agree:
+
+- `rust-toolchain.toml` — used by `rustup` for local development
+- `.github/workflows/ci-linux.yml` — `dtolnay/rust-toolchain@master`
+  with explicit `toolchain:` input
+- `.github/workflows/ci-macos.yml` — same explicit pin
+
+All cargo commands in the `ci` pipeline use `--locked` so a stale
+`Cargo.lock` is a build failure rather than a silent re-resolve.
 
 ## Running Programs
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -385,6 +385,40 @@ store i64 %result, ptr %slot1_ptr
 Complex operations (string handling, variants, closures) still call into the
 Rust runtime for memory safety and code maintainability.
 
+## The `main` Word and Exit Codes
+
+Every executable Seq program defines a `main` word with one of two
+allowed signatures:
+
+```seq
+: main ( -- )      # void main: process exits with code 0
+: main ( -- Int )  # int main: returned Int becomes the process exit code
+```
+
+The compiler rejects any other shape (extra inputs, multiple outputs,
+non-Int output) at type-check time.
+
+For `main ( -- Int )`, the top-of-stack Int at the end of `main` is
+written to a runtime global by the generated `seq_main`, and the C-level
+`main` function returns it as the process exit code (truncated to i32).
+This means Seq programs compose naturally with shell tooling: `&&`,
+`||`, `$?`, `set -e`, CI gates, and test harnesses all work as
+expected.
+
+```seq
+: main ( -- Int )
+  do-work
+  0    # success
+;
+```
+
+```bash
+./myprog && echo "succeeded" || echo "failed with $?"
+```
+
+Script mode (`seqc script.seq`) inherits this behavior automatically
+because it just `exec`s the compiled binary.
+
 ## Compilation Pipeline
 
 1. **Parse** - Tokenize and build AST (`parser.rs`)

--- a/justfile
+++ b/justfile
@@ -21,19 +21,19 @@ install:
 # Build the Rust runtime as static library
 build-runtime:
     @echo "Building runtime (clean concatenative foundation)..."
-    cargo build --release -p seq-runtime
+    cargo build --locked --release -p seq-runtime
     @echo "✅ Runtime built: target/release/libseq_runtime.a"
 
 # Build the compiler
 build-compiler:
     @echo "Building compiler..."
-    cargo build --release -p seq-compiler
+    cargo build --locked --release -p seq-compiler
     @echo "✅ Compiler built: target/release/seqc"
 
 # Build the LSP server
 build-lsp:
     @echo "Building LSP server..."
-    cargo build --release -p seq-lsp
+    cargo build --locked --release -p seq-lsp
     @echo "✅ LSP server built: target/release/seq-lsp"
 
 # Build all example programs
@@ -73,12 +73,12 @@ build-examples: build
 # Run all Rust unit tests
 test:
     @echo "Running Rust unit tests..."
-    cargo test --workspace --all-targets
+    cargo test --locked --workspace --all-targets
 
 # Run clippy on all workspace members
 lint:
     @echo "Running clippy..."
-    cargo clippy --workspace --all-targets -- -D warnings
+    cargo clippy --locked --workspace --all-targets -- -D warnings
 
 # Format all code
 fmt:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.93.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/355

  - No source files changed (no .seq examples, no integration tests) ✓
  - All existing programs still work — ( -- Int ) programs that were previously discarding the value now exit with that value, which is the intended behavior. The only programs that break are ones with disallowed shapes like ( -- String ) or ( -- Int Int ), which are vanishingly rare and were silently buggy anyway. ✓
  - No public API changes to the runtime or compiler crates — additive only (new global, new exported functions, new typechecker validation) ✓
  - just ci passes clean ✓

  The only theoretical concern for a major bump would be: "what if someone has a ( -- Int ) program that was returning 42 expecting exit 0, and now it
  actually exits 42?" That's a behavioral change. But:

  1. It's a bug fix, not a feature change — they were exit-code-broken
  2. SemVer treats fixing a quiet correctness bug as a patch/minor concern, not major
  3. Anyone whose CI was passing on a Seq program returning non-zero was almost certainly relying on the broken behavior unintentionally