### PR TITLE
⏺ auto capture

### DIFF
--- a/crates/compiler/src/capture_analysis.rs
+++ b/crates/compiler/src/capture_analysis.rs
@@ -68,6 +68,11 @@ pub fn calculate_captures(body_effect: &Effect, call_effect: &Effect) -> Result<
     // Captures are the first N types (bottom of stack)
     // Example: body needs [Int, String] (bottom to top), call provides [String]
     // Captures: [Int] (the bottom type)
+    //
+    // TODO: verify that body_inputs[capture_count..] structurally matches
+    // call_inputs. Currently the topmost types are not checked here — the
+    // mismatch would be caught downstream by unification or at runtime,
+    // but catching it here would give clearer error messages.
     Ok(body_inputs[0..capture_count].to_vec())
 }
 

--- a/crates/compiler/src/capture_analysis.rs
+++ b/crates/compiler/src/capture_analysis.rs
@@ -65,14 +65,30 @@ pub fn calculate_captures(body_effect: &Effect, call_effect: &Effect) -> Result<
     // Calculate how many to capture (from bottom of stack)
     let capture_count = body_inputs.len() - call_inputs.len();
 
+    // Verify the topmost body inputs (the non-captured ones) align with
+    // what the call site provides. If they don't match, the body is
+    // incompatible with the combinator regardless of captures.
+    let body_provided = &body_inputs[capture_count..];
+    for (i, (body_type, call_type)) in body_provided.iter().zip(call_inputs.iter()).enumerate() {
+        if body_type != call_type {
+            // Type variables (like Acc, T from row polymorphism) won't match
+            // concrete types here — that's expected, because the body's types
+            // are inferred from a seeded row-variable stack. Skip the check
+            // for type variables; they'll be verified by downstream unification.
+            let is_var = matches!(body_type, Type::Var(_)) || matches!(call_type, Type::Var(_));
+            if !is_var {
+                return Err(format!(
+                    "Closure capture error: body input at position {} (from top) is {}, \
+                     but combinator provides {}. The non-captured inputs must match.",
+                    i, body_type, call_type
+                ));
+            }
+        }
+    }
+
     // Captures are the first N types (bottom of stack)
     // Example: body needs [Int, String] (bottom to top), call provides [String]
     // Captures: [Int] (the bottom type)
-    //
-    // TODO: verify that body_inputs[capture_count..] structurally matches
-    // call_inputs. Currently the topmost types are not checked here — the
-    // mismatch would be caught downstream by unification or at runtime,
-    // but catching it here would give clearer error messages.
     Ok(body_inputs[0..capture_count].to_vec())
 }
 

--- a/crates/compiler/src/typechecker.rs
+++ b/crates/compiler/src/typechecker.rs
@@ -6,7 +6,7 @@
 use crate::ast::{Program, Statement, WordDef};
 use crate::builtins::builtin_signature;
 use crate::call_graph::CallGraph;
-use crate::capture_analysis::calculate_captures;
+use crate::capture_analysis::{calculate_captures, extract_concrete_types};
 use crate::types::{
     Effect, SideEffect, StackType, Type, UnionTypeInfo, VariantFieldInfo, VariantInfo,
 };
@@ -2123,8 +2123,6 @@ impl TypeChecker {
             Some(Type::Quotation(expected_effect)) => {
                 // Check if we need to auto-create a closure by comparing the
                 // body's concrete input count against what the combinator provides.
-                use crate::capture_analysis::extract_concrete_types;
-
                 let body_inputs = extract_concrete_types(&body_effect.inputs);
                 let expected_inputs = extract_concrete_types(&expected_effect.inputs);
 

--- a/crates/compiler/src/typechecker.rs
+++ b/crates/compiler/src/typechecker.rs
@@ -1320,8 +1320,8 @@ impl TypeChecker {
                     let (new_stack, actual_type) = self.pop_type(&stack, "closure capture")?;
                     unify_types(&actual_type, expected_type).map_err(|e| {
                         format!(
-                            "closure capture type mismatch at position {}: \
-                             expected {}, got {}: {}",
+                            "closure capture type mismatch at capture {} \
+                             (0 = bottommost): expected {}, got {}: {}",
                             i, expected_type, actual_type, e
                         )
                     })?;
@@ -2127,12 +2127,11 @@ impl TypeChecker {
                 let expected_inputs = extract_concrete_types(&expected_effect.inputs);
 
                 // Auto-capture triggers when the body needs more concrete inputs
-                // than the expected provides. Two sub-cases:
+                // than the expected provides. Three branches:
                 // (a) Expected is empty (strand.spawn): body needs any inputs → capture all.
                 // (b) Expected has concrete inputs (list.fold): body has MORE → capture excess.
-                // We skip auto-capture when expected has ONLY a row variable and no
-                // concrete inputs — that's the strand.weave case where the body's
-                // row-variable inputs should unify with the expected, not be captured.
+                // (c) Expected has ONLY a row variable and no concrete inputs
+                //     (strand.weave): don't capture, fall through to unification.
                 let expected_is_empty = matches!(expected_effect.inputs, StackType::Empty);
                 let should_capture = if expected_is_empty {
                     !body_inputs.is_empty()

--- a/crates/compiler/src/typechecker.rs
+++ b/crates/compiler/src/typechecker.rs
@@ -1309,10 +1309,22 @@ impl TypeChecker {
                 current_stack.push(quot_type)
             }
             Type::Closure { captures, .. } => {
-                // Pop captured values from stack, then push closure
+                // Pop captured values from stack, then push closure.
+                // Captures are bottom-to-top, but we pop top-down from the
+                // stack, so iterate in reverse to match positions correctly.
+                // Verify each popped type unifies with the expected capture
+                // type — this catches type mismatches at the capture site
+                // rather than letting them through to runtime. (Issue #395)
                 let mut stack = current_stack.clone();
-                for _ in 0..captures.len() {
-                    let (new_stack, _value) = self.pop_type(&stack, "closure capture")?;
+                for (i, expected_type) in captures.iter().enumerate().rev() {
+                    let (new_stack, actual_type) = self.pop_type(&stack, "closure capture")?;
+                    unify_types(&actual_type, expected_type).map_err(|e| {
+                        format!(
+                            "closure capture type mismatch at position {}: \
+                             expected {}, got {}: {}",
+                            i, expected_type, actual_type, e
+                        )
+                    })?;
                     stack = new_stack;
                 }
                 stack.push(quot_type)
@@ -2109,25 +2121,49 @@ impl TypeChecker {
                 Ok(Type::Closure { effect, captures })
             }
             Some(Type::Quotation(expected_effect)) => {
-                // User declared quotation type - check if we need to auto-create closure
-                // Auto-create closure only when:
-                // 1. Expected effect has empty inputs (like spawn's ( -- ))
-                // 2. Body effect has non-empty inputs (needs values to execute)
+                // Check if we need to auto-create a closure by comparing the
+                // body's concrete input count against what the combinator provides.
+                use crate::capture_analysis::extract_concrete_types;
 
+                let body_inputs = extract_concrete_types(&body_effect.inputs);
+                let expected_inputs = extract_concrete_types(&expected_effect.inputs);
+
+                // Auto-capture triggers when the body needs more concrete inputs
+                // than the expected provides. Two sub-cases:
+                // (a) Expected is empty (strand.spawn): body needs any inputs → capture all.
+                // (b) Expected has concrete inputs (list.fold): body has MORE → capture excess.
+                // We skip auto-capture when expected has ONLY a row variable and no
+                // concrete inputs — that's the strand.weave case where the body's
+                // row-variable inputs should unify with the expected, not be captured.
                 let expected_is_empty = matches!(expected_effect.inputs, StackType::Empty);
-                let body_needs_inputs = !matches!(body_effect.inputs, StackType::Empty);
+                let should_capture = if expected_is_empty {
+                    !body_inputs.is_empty()
+                } else if !expected_inputs.is_empty() {
+                    body_inputs.len() > expected_inputs.len()
+                } else {
+                    false // row-variable-only expected — don't capture, unify instead
+                };
 
-                if expected_is_empty && body_needs_inputs {
-                    // Body needs inputs but expected provides none
-                    // Auto-create closure to capture the inputs
+                if should_capture {
+                    // Body needs more inputs than the combinator provides.
+                    // The excess (bottommost) become captures; the topmost must
+                    // align with what the combinator provides.
+                    //
+                    // Example: list.fold expects ( ..b Acc T -- ..b Acc ).
+                    // Body inferred as ( ..b X Acc T -- ..b Acc ).
+                    // expected_inputs = [Acc, T], body_inputs = [X, Acc, T].
+                    // Captures = [X]. Topmost 2 of body must match expected's 2.
+                    //
+                    // Issue #395: this extends the empty-input auto-capture
+                    // (used by strand.spawn) to the non-empty case.
                     let captures = calculate_captures(body_effect, &expected_effect)?;
                     Ok(Type::Closure {
                         effect: expected_effect,
                         captures,
                     })
                 } else {
-                    // Verify the body effect is compatible with the expected effect
-                    // by unifying the quotation types. This catches:
+                    // Body has same or fewer inputs — standard unification path.
+                    // This catches:
                     // - Stack pollution: body pushes values when expected is stack-neutral
                     // - Stack underflow: body consumes values when expected is stack-neutral
                     // - Wrong return type: body returns Int when Bool expected

--- a/examples/projects/sss.seq
+++ b/examples/projects/sss.seq
@@ -1,34 +1,19 @@
 # ============================================================================
 # Shamir's Secret Sharing — Tutorial Implementation in Seq
 #
-# ⚠ STATUS: WORK IN PROGRESS — DO NOT USE FOR REAL SECRETS ⚠
+# ⚠ DO NOT USE FOR REAL SECRETS ⚠
 #
-# This is a tutorial / language showcase, not production code. It runs
-# end-to-end and reconstructs secrets correctly under the test inputs,
-# but several pieces are not yet idiomatic Seq because the language is
-# missing features:
+# This is a tutorial / language showcase, not production code. The
+# cryptography is correct (GF(256) arithmetic, Lagrange interpolation
+# in the field, information-theoretic security properties), but this
+# has not been audited and should not be used in real applications.
+# Use a vetted SSS library written in a language with mature crypto
+# tooling.
 #
-#   - `eval-poly` is implemented as a manual recursive loop with
-#     pick/roll stack juggling. The natural form is `list.fold` with
-#     the evaluation point `x` auto-captured into the fold quotation.
-#     That requires Issue #395 (auto-capture for combinator quotations).
-#     Until #395 lands, the recursive form is the only option.
-#
-#   - Lagrange interpolation has the same constraint: the natural form
-#     folds the share list with the current x-index captured into the
-#     quotation. Same blocker as above.
-#
-#   - This file is kept as a real example because the *cryptography* is
-#     correct (GF(256) arithmetic, Lagrange interpolation in the field,
-#     information-theoretic security properties), and it pressures the
-#     language with realistic requirements. The non-idiomatic loops are
-#     a documented limitation, not a recommendation.
-#
-# Tracking: see docs/design/AUTO_CAPTURE_COMBINATORS.md and
-#           https://github.com/navicore/patch-seq/issues/395
-#
-# Do not copy this code into a real cryptographic application. Use a
-# vetted SSS library written in a language with mature crypto tooling.
+# The Lagrange interpolation outer loop still uses manual recursion
+# with deep `pick` access because it needs both the xs and ys lists
+# in scope at every iteration. This will improve when the outer loop
+# can be converted to a fold with multiple captured values.
 # ============================================================================
 #
 # Implements SSS over GF(256), the same finite field used by AES.
@@ -112,27 +97,23 @@ include std:list
 # ============================================================================
 # Horner's method: p(x) = c0 + x*(c1 + x*(c2 + ...))
 #
-# ⚠ NON-IDIOMATIC: this is implemented as a manual recursive loop with
-# pick/roll stack juggling because the natural form requires auto-capture
-# of `x` into a `list.fold` quotation. See Issue #395 / the file header.
-# When #395 lands, this should become a single `list.fold` call.
-
-# Stack: ( coeffs x idx acc -- result )
-: eval-poly-loop ( List Int Int Int -- Int )
-  over 0 i.< if
-    nip nip nip
-  else
-    2 pick gf256-mul
-    3 pick 2 pick list.get drop
-    gf256-add
-    swap 1 i.- swap
-    eval-poly-loop
-  then
-;
+# Coefficients are stored low-to-high [c0, c1, ...], so we reverse for
+# Horner left-to-right processing. The evaluation point `x` is auto-captured
+# into the fold quotation (Issue #395), and aux stashes it during each step.
 
 : eval-poly ( List Int -- Int )
-  over list.length 1 i.-
-  0 eval-poly-loop
+  swap list.reverse swap        # ( reversed_coeffs x )
+  >aux                          # stash x in word-level aux: ( reversed_coeffs )
+  0                             # initial accumulator: ( reversed_coeffs 0 )
+  aux>                          # retrieve x: ( reversed_coeffs 0 x )
+  [
+    # Fold body: ( acc coeff x ) — x on top (auto-captured)
+    # Horner step: acc * x + coeff
+    >aux                        # stash x in quotation-level aux
+    swap                        # ( coeff acc )
+    aux> gf256-mul              # ( coeff acc*x )  — using GF(256) multiply
+    gf256-add                   # ( coeff + acc*x )
+  ] list.fold
 ;
 
 # ============================================================================

--- a/tests/integration/src/test-auto-capture.seq
+++ b/tests/integration/src/test-auto-capture.seq
@@ -1,0 +1,86 @@
+# Integration tests for auto-capture in combinator quotations (Issue #395)
+
+include std:list
+
+# --------------------------------------------------------------------------
+# list.fold with one captured value
+# --------------------------------------------------------------------------
+
+# Body receives (acc, elem) from fold, plus captured 'mult' on top.
+# Uses aux to stash the captured value during computation.
+: test-fold-capture-one ( -- )
+  list-of 1 lv 2 lv 3 lv
+  0     # acc
+  10    # multiplier — auto-captured
+  [
+    >aux              # stash captured mult
+    aux> i.* i.+      # acc + elem * mult
+  ] list.fold
+  60 test.assert-eq   # 1*10 + 2*10 + 3*10 = 60
+;
+
+# --------------------------------------------------------------------------
+# list.map with captured value
+# --------------------------------------------------------------------------
+
+: test-map-capture ( -- )
+  list-of 1 lv 2 lv 3 lv
+  100    # base — auto-captured
+  [
+    # Stack: ( elem base ) — base on top (captured)
+    i.+
+  ] list.map
+  # Result is a list of [101, 102, 103]
+  0 list.get drop 101 test.assert-eq
+;
+
+# --------------------------------------------------------------------------
+# list.filter with captured threshold
+# --------------------------------------------------------------------------
+
+: test-filter-capture ( -- )
+  list-of 1 lv 5 lv 3 lv 7 lv 2 lv
+  4    # threshold — auto-captured
+  [
+    # Stack: ( elem threshold ) — threshold on top (captured)
+    >aux aux> i.<     # elem < threshold
+  ] list.filter
+  # Should keep [1, 3, 2] — three elements less than 4
+  list.length 3 test.assert-eq
+;
+
+# --------------------------------------------------------------------------
+# list.each with captured value (side effects)
+# --------------------------------------------------------------------------
+
+: test-each-capture ( -- )
+  # Just verify it compiles and runs without crashing.
+  # list.each has no return value to assert on.
+  list-of 1 lv 2 lv 3 lv
+  0    # base — auto-captured
+  [
+    # Stack: ( elem base ) — base on top
+    i.+ drop   # compute elem + base, discard
+  ] list.each
+;
+
+# --------------------------------------------------------------------------
+# Horner polynomial evaluation via fold with capture
+# --------------------------------------------------------------------------
+
+: test-horner-poly ( -- )
+  # p(x) = 2 + 1*x + 4*x^2 evaluated at x=3
+  # Horner left-to-right: ((0*3+2)*3+1)*3+4 = 25
+  list-of 2 lv 1 lv 4 lv
+  0     # acc
+  3     # x — auto-captured
+  [
+    # Stack: ( acc coeff x ) — x on top (captured)
+    # Horner step: acc * x + coeff
+    >aux              # stash x
+    swap              # ( coeff acc )
+    aux> i.*          # ( coeff acc*x )
+    i.+               # ( coeff + acc*x )
+  ] list.fold
+  25 test.assert-eq
+;

--- a/tests/integration/src/test-auto-capture.seq
+++ b/tests/integration/src/test-auto-capture.seq
@@ -43,7 +43,7 @@ include std:list
   4    # threshold — auto-captured
   [
     # Stack: ( elem threshold ) — threshold on top (captured)
-    >aux aux> i.<     # elem < threshold
+    i.<               # elem < threshold
   ] list.filter
   # Should keep [1, 3, 2] — three elements less than 4
   list.length 3 test.assert-eq
@@ -69,7 +69,7 @@ include std:list
 # --------------------------------------------------------------------------
 
 : test-horner-poly ( -- )
-  # p(x) = 2 + 1*x + 4*x^2 evaluated at x=3
+  # p(x) = 2*x^2 + x + 4 (coefficients high-to-low: [2, 1, 4]) at x=3
   # Horner left-to-right: ((0*3+2)*3+1)*3+4 = 25
   list-of 2 lv 1 lv 4 lv
   0     # acc

--- a/tests/integration/src/test-auto-capture.seq
+++ b/tests/integration/src/test-auto-capture.seq
@@ -54,8 +54,8 @@ include std:list
 # --------------------------------------------------------------------------
 
 : test-each-capture ( -- )
-  # Just verify it compiles and runs without crashing.
-  # list.each has no return value to assert on.
+  # No value to assert — list.each discards results. This test only
+  # checks that auto-capture compiles and executes without crashing.
   list-of 1 lv 2 lv 3 lv
   0    # base — auto-captured
   [
@@ -69,6 +69,11 @@ include std:list
 # --------------------------------------------------------------------------
 
 : test-horner-poly ( -- )
+  # Tests the auto-capture mechanism with a Horner-style fold using regular
+  # integer arithmetic. The actual `eval-poly` word in sss.seq uses GF(256)
+  # field arithmetic and is validated end-to-end by the Shamir example's
+  # "SUCCESS — secret recovered!" assertion during `just ci`.
+  #
   # p(x) = 2*x^2 + x + 4 (coefficients high-to-low: [2, 1, 4]) at x=3
   # Horner left-to-right: ((0*3+2)*3+1)*3+4 = 25
   list-of 2 lv 1 lv 4 lv


### PR DESCRIPTION
  Issue #395 — auto-capture for quotations passed to combinators — is implemented.
https://github.com/navicore/patch-seq/issues/395

  What changed

  File: crates/compiler/src/typechecker.rs
  Change: analyze_captures: Extended to fire auto-capture when the body has more concrete inputs than the expected quotation type provides. Three sub-cases:

    (a) expected is empty (strand.spawn, unchanged), (b) expected has concrete inputs and body has more (new — list.fold etc.), (c) expected has only
    row-variable inputs (strand.weave — no capture, unify). infer_quotation: Closure pop loop now unifies each popped type against the expected capture
  type
     (soundness fix).
  ────────────────────────────────────────
  File: tests/integration/src/test-auto-capture.seq
  Change: New — 5 integration tests: fold+capture, map+capture, filter+capture, each+capture, Horner polynomial
  ────────────────────────────────────────
  File: examples/projects/sss.seq
  Change: Rewritten eval-poly: manual recursive loop → list.fold with auto-captured evaluation point. Removed eval-poly-loop. Updated header comments.
  Secret
    reconstruction still passes.

  What works

  - list.fold with one auto-captured value: fold body receives (acc, coeff, captured_x) with captured value on top
  - list.map with captured offset: 100 [ i.+ ] list.map auto-captures 100
  - list.filter with captured threshold: 4 [ >aux aux> i.< ] list.filter auto-captures 4
  - list.each with captured value
  - Auto-capture + aux-in-quotations compose: stash the captured value on quotation-level aux while doing fold work
  - strand.spawn existing auto-capture: unchanged, still works
  - strand.weave yield quotations: unchanged, still pass
  - Shamir's Secret Sharing: eval-poly rewritten, "SUCCESS — secret recovered!" confirmed

  Key convention

  Captured values appear on top of the combinator-provided values at runtime. The body must be written accordingly: ( acc coeff captured_x ) with x on top
  for a fold body that auto-captures one value.