### PR TITLE
grammar

### DIFF
--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -45,7 +45,7 @@ word_def        = ":" IDENT [ stack_effect ] { statement } ";" ;
 stack_effect    = "(" type_list "--" type_list [ "|" effect_annotation { effect_annotation } ] ")" ;
 effect_annotation = "Yield" type ;
 type_list       = [ row_var ] { type } ;
-row_var         = ".." LOWER_IDENT ;
+row_var         = ".." ROW_VAR_NAME ;
 
 type            = base_type
                 | type_var
@@ -146,6 +146,12 @@ BOOL_LITERAL    = "true" | "false" ;
 SYMBOL_LITERAL  = ":" SYMBOL_NAME ;
 SYMBOL_NAME     = LETTER { LETTER | DIGIT | "-" | "_" | "." | "?" | "!" } ;
 
+(* `:` is a single-character delimiter token; whitespace after it is not
+   significant. Disambiguation between `word_def` and `SYMBOL_LITERAL` is
+   context-driven: a `:` at the top level starts a `word_def`, and a `:`
+   inside a word body (wherever a `statement` is expected) starts a
+   `SYMBOL_LITERAL`. *)
+
 STRING          = '"' { STRING_CHAR | ESCAPE_SEQ } '"' ;
 STRING_CHAR     = any character except '"' or '\' ;
 ESCAPE_SEQ      = '\' ( '"' | '\' | 'n' | 'r' | 't' )
@@ -154,8 +160,9 @@ ESCAPE_SEQ      = '\' ( '"' | '\' | 'n' | 'r' | 't' )
 
 The `\xNN` escape produces the Unicode code point `U+00NN`. For `NN` in
 `00..7F` this is a single ASCII byte (common use: `\x1b` for ANSI
-terminal escape sequences). For `NN` in `80..FF` the resulting character
-is encoded as multi-byte UTF-8.
+terminal escape sequences). For `NN` in `80..FF` the code point falls
+in the Latin-1 Supplement block (`U+0080..U+00FF`) and the resulting
+character is encoded as multi-byte UTF-8.
 
 ### Comments and Whitespace
 

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -40,7 +40,7 @@ field           = IDENT ":" type_name ;
 ### Word Definitions
 
 ```ebnf
-word_def        = ":" IDENT stack_effect { statement } ";" ;
+word_def        = ":" IDENT [ stack_effect ] { statement } ";" ;
 
 stack_effect    = "(" type_list "--" type_list [ "|" effect_annotation { effect_annotation } ] ")" ;
 effect_annotation = "Yield" type ;
@@ -58,6 +58,11 @@ quotation_type  = "[" type_list "--" type_list "]" ;
 closure_type    = "Closure" "[" type_list "--" type_list "]" ;
 ```
 
+`type_var` must not be the literal token `Quotation`: the parser rejects
+it explicitly with a hint pointing at the `[ .. -- .. ]` syntax. The
+name `Closure` is also reserved — it's handled as the start of
+`closure_type`, not as a type variable.
+
 ### Statements
 
 ```ebnf
@@ -70,7 +75,8 @@ statement       = literal
 literal         = INT_LITERAL
                 | FLOAT_LITERAL
                 | BOOL_LITERAL
-                | STRING ;
+                | STRING
+                | SYMBOL_LITERAL ;
 
 word_call       = IDENT ;
 
@@ -80,9 +86,14 @@ if_stmt         = "if" { statement } ( "then" | "else" { statement } "then" ) ;
 
 match_stmt      = "match" { match_arm } "end" ;
 match_arm       = pattern "->" { statement } ;
-pattern         = UPPER_IDENT [ "{" { binding } "}" ] ;
-binding         = ">" IDENT ;
+pattern         = UPPER_IDENT [ "{" { BINDING } "}" ] ;
+BINDING         = ">" IDENT ;
 ```
+
+`BINDING` is a single lexical token: `>` and the field name must not be
+separated by whitespace. `>value` is a binding; `> value` is two
+separate tokens (the word calls `>` and `value`) and the parser reports
+an error asking for the `>`-prefix form.
 
 ---
 
@@ -92,17 +103,26 @@ binding         = ">" IDENT ;
 
 ```ebnf
 IDENT           = IDENT_START { IDENT_CHAR } ;
-IDENT_START     = LETTER | "_" | "-" | "." | ">" | "<" | "=" | "?" | "!" | "+" | "*" | "/" ;
+IDENT_START     = LETTER | "_" | "-" | "." | ">" | "<" | "=" | "?" | "!" | "+" | "*" | "/" | "%" ;
 IDENT_CHAR      = IDENT_START | DIGIT ;
 
 UPPER_IDENT     = UPPER_LETTER { IDENT_CHAR } ;
 LOWER_IDENT     = LOWER_LETTER { IDENT_CHAR } ;
+
+ROW_VAR_NAME    = LOWER_LETTER { LETTER | DIGIT | "_" } ;
 
 LETTER          = UPPER_LETTER | LOWER_LETTER ;
 UPPER_LETTER    = "A" | "B" | ... | "Z" ;
 LOWER_LETTER    = "a" | "b" | ... | "z" ;
 DIGIT           = "0" | "1" | ... | "9" ;
 ```
+
+Row-variable names (`..rest`) use the stricter `ROW_VAR_NAME` rule: they
+must start with a lowercase letter and contain only letters, digits, and
+underscores. The broader `IDENT` punctuation characters (`- . > < = ? !
++ * / %`) are rejected. The names `Int`, `Bool`, `String` are reserved
+even though they're already excluded by the lowercase-start rule (the
+parser emits a dedicated error if you try to use them).
 
 ### Literals
 
@@ -123,17 +143,36 @@ EXPONENT        = ( "e" | "E" ) [ "+" | "-" ] DIGIT { DIGIT } ;
 
 BOOL_LITERAL    = "true" | "false" ;
 
+SYMBOL_LITERAL  = ":" SYMBOL_NAME ;
+SYMBOL_NAME     = LETTER { LETTER | DIGIT | "-" | "_" | "." | "?" | "!" } ;
+
 STRING          = '"' { STRING_CHAR | ESCAPE_SEQ } '"' ;
 STRING_CHAR     = any character except '"' or '\' ;
-ESCAPE_SEQ      = '\' ( '"' | '\' | 'n' | 'r' | 't' ) ;
+ESCAPE_SEQ      = '\' ( '"' | '\' | 'n' | 'r' | 't' )
+                | '\' 'x' HEX_DIGIT HEX_DIGIT ;
 ```
+
+The `\xNN` escape produces the Unicode code point `U+00NN`. For `NN` in
+`00..7F` this is a single ASCII byte (common use: `\x1b` for ANSI
+terminal escape sequences). For `NN` in `80..FF` the resulting character
+is encoded as multi-byte UTF-8.
 
 ### Comments and Whitespace
 
 ```ebnf
 COMMENT         = "#" { any character except newline } NEWLINE ;
+SHEBANG         = "#!" { any character except newline } NEWLINE ;
 WHITESPACE      = SPACE | TAB | NEWLINE ;
 ```
+
+A `SHEBANG` line (typically `#!/usr/bin/env seqc`) is accepted anywhere a
+`COMMENT` is, so scripts can be executed directly from the shell. The
+parser treats it as an ordinary comment.
+
+Comments matching the form `# seq:allow(lint-id)` are collected as lint
+allowances for the word definition that follows them. The text inside
+the parentheses is the lint rule id; multiple `seq:allow` comments
+before a word stack additively.
 
 ---
 
@@ -160,6 +199,18 @@ This means `( -- )` preserves the stack (it's `( ..rest -- ..rest )`), not that 
 | `->` (arrow) | Type conversions | `int->string`, `float->int` |
 | `?` (question) | Predicates | `list.empty?`, `map.has?` |
 
+For each `union` definition, the compiler auto-generates helper words
+by convention. Given `union Shape { Circle { radius: Int } … }`:
+
+| Generated word | Shape | Example |
+|----------------|-------|---------|
+| `Make-<Variant>` | constructor | `5 Make-Circle` |
+| `is-<Variant>?` | predicate | `shape is-Circle?` |
+| `<Variant>-<field>` | field accessor | `circle Circle-radius` |
+
+These are ordinary `word_call`s at the grammar level; they're listed
+here so readers can predict the generated names.
+
 ### Reserved Words
 
 The following are reserved and cannot be used as word names:
@@ -171,6 +222,37 @@ The following are reserved and cannot be used as word names:
 ### Operator Precedence
 
 Seq has no operator precedence - all tokens are either literals or word calls. Evaluation is strictly left-to-right with stack-based semantics.
+
+### Quotations vs Closures
+
+A `quotation` (the surface syntax `[ … ]`) has two possible types:
+
+- `quotation_type` — if the body consumes only values pushed inside the
+  quotation itself (plus an implicit row variable).
+- `closure_type` — if the body references values from the enclosing
+  stack. The compiler captures those values into an environment at the
+  point the quotation is produced; the result is a `Closure[ … ]` at
+  the type level.
+
+There is no dedicated syntax for a closure — the parser always builds a
+quotation literal, and the type checker decides whether the result is a
+`quotation_type` or a `closure_type` based on what the body references.
+
+### Arithmetic Sugar
+
+The tokens `+`, `-`, `*`, `/`, `%`, `=`, `<`, `>`, `<=`, `>=`, and `<>` are
+ordinary identifiers at the grammar level but are resolved by the compiler
+to their typed counterparts based on the inferred stack types. For example:
+
+```seq
+3 4 +        # resolves to `i.+` — both operands are Int
+3.0 4.0 +    # resolves to `f.+` — both operands are Float
+```
+
+This is a compile-time rewrite, not dynamic dispatch: if the types can't
+be inferred unambiguously the program fails to type-check. Writing the
+explicit form (`i.+`, `f.<`, etc.) is always valid and suppresses the
+sugar resolution.
 
 ---
 

--- a/docs/design/done/GRAMMAR_AUDIT.md
+++ b/docs/design/done/GRAMMAR_AUDIT.md
@@ -1,0 +1,101 @@
+# Grammar Doc Audit — `docs/GRAMMAR.md`
+
+Status: design · 2026-04-23
+
+## Intent
+
+The BNF in `docs/GRAMMAR.md` was written early in the project and hasn't
+been systematically revisited since several features shipped that touch
+surface syntax: symbols (`:foo`), auto-capturing quotations, arithmetic
+sugar (`+ - * / % = < > <= >= <>`), loop combinators, `>aux`/`aux>`
+inside quotations, and shebang tolerance. We want to audit the grammar
+against current reality, file the gaps, and fix them — so the doc is
+accurate for new users, LSP/tool authors, and anyone writing Seq without
+reading the parser source.
+
+This is a plan for doing the audit. The audit itself (and the patches it
+produces) are separate work.
+
+## Constraints
+
+- **Grammar must match the parser, not the roadmap.** If a feature is
+  designed but not parsed yet, it doesn't belong in `GRAMMAR.md`. Cross-
+  check every proposed addition against `crates/compiler/src/parser.rs`.
+- **No speculative syntax.** Don't invent notation for features we
+  *might* ship. Keep the grammar descriptive of what seqc accepts today.
+- **Don't rewrite for style.** If a section is already accurate, leave it
+  alone — this is a gap-fill, not a rewrite.
+- **Preserve existing examples.** The worked example (safe-divide +
+  main + match) anchors the doc; don't reshape it just because newer
+  idioms exist.
+- **Out of scope:** rewording prose, adding a new "Semantic Notes"
+  section the parser can't enforce, pretty-printing EBNF, adding a
+  changelog. The audit produces a list of *missing productions* and
+  *wrong productions* — nothing more.
+
+## Approach
+
+Three-step gap hunt, done once end-to-end:
+
+1. **Catalog surface changes since the doc was written.** Walk
+   `git log -- crates/compiler/src/parser.rs` and the memory ledger
+   for language-level PRs. Build a short list of candidate syntax
+   additions (symbols, operator sugar, auto-capture, shebang, aux
+   shorthands, `variant.make-N`, constructor generation, any others
+   surfaced by the walk).
+2. **Cross-reference each candidate against the BNF.** For each item,
+   answer two questions: (a) is the surface syntax already derivable
+   from a current production (e.g. `>aux` matches `word_call` via
+   `IDENT`), or (b) is a new/modified production needed. Only case
+   (b) becomes a gap entry.
+3. **Write gaps as a punch list**, not prose. Each gap gets one line:
+   `<feature>` · current grammar says `<X>` · parser accepts `<Y>` ·
+   proposed fix `<Z>`. The punch list is the deliverable. The
+   follow-up PR applies the fixes.
+
+Open candidates to probe specifically:
+
+- `:foo` symbol literals — almost certainly missing from `literal`.
+- Arithmetic sugar operators — the identifier grammar already admits
+  `+`/`*`/`/`/`=`/`<`/`>` as identifier characters, so likely covered
+  by `word_call`, but worth confirming `<=` / `>=` / `<>` aren't
+  tokenized specially.
+- Auto-capture semantics — may belong under "Semantic Notes" not the
+  grammar itself.
+- Shebang line (`#!/usr/bin/env seqc`) — the LSP strips it; is the
+  parser lenient the same way, and does the grammar need a rule or
+  a prose note?
+- Quotation form of `>aux`/`aux>` — confirm these are plain word
+  calls, not special syntax.
+- Match binding syntax (`>name`) — verify it matches the parser's
+  current form (field order, optional trailing comma, ignore
+  wildcards).
+
+## Domain Events
+
+- **Audit produces a punch list** → a short markdown file (either a
+  tmp/ scratch or a new design doc section) with per-gap entries. No
+  commits, no grammar edits, no parser work.
+- **Punch list is reviewed** → user decides which gaps to close and
+  in what order. Fixes land as a normal PR touching `GRAMMAR.md`
+  (and possibly parser if any "wrong production" is actually a
+  parser bug, which would be logged separately, not folded into the
+  doc patch).
+- **Design doc lifecycle** → this file lives in `docs/design/` until
+  the audit-and-fix lands, then moves to `docs/design/done/` per the
+  standard design-doc flow.
+
+## Checkpoints
+
+Audit considered complete when:
+
+1. Every production in `GRAMMAR.md` has a corresponding parser rule
+   or an explicit "semantic, not syntactic" note. No orphans.
+2. Every surface form the parser accepts has a production (or an
+   explicit comment pointing at the prose that covers it). Verified
+   by spot-checking ~10 example programs — stdlib + examples — and
+   confirming each token sequence can be derived from the grammar.
+3. The worked example at the bottom of `GRAMMAR.md` still parses
+   cleanly against the updated grammar (no production references
+   `variant.make-N` or `:foo` without those being defined).
+4. `just ci` is untouched by this work — it's a doc-only PR.


### PR DESCRIPTION
  Production changes (grammar was strictly wrong):
  1. literal now includes SYMBOL_LITERAL; new SYMBOL_LITERAL + SYMBOL_NAME rules added.
  2. ESCAPE_SEQ extended with \x hex form + prose note on UTF-8 encoding.
  3. word_def stack_effect now [ stack_effect ] (optional).
  4. binding renamed to lexical-token BINDING with explicit note that > and the name form one token.

  Prose clarifications (grammar already correct, but easily misread):
  5. Shebang rule added to Comments section.
  6. Note that Quotation and Closure are reserved type-name tokens.
  7. New ROW_VAR_NAME rule + note that row variables are stricter than IDENT.

  Semantic Notes additions:
  8. Quotations vs Closures subsection.
  9. ADT auto-generated word names (Make-<V>, is-<V>?, <V>-<field>).
  10. # seq:allow(lint-id) convention for lint comments.
  11. (Arithmetic sugar — already landed in the previous commit.)

  just ci green. GRAMMAR_AUDIT.md moved to docs/design/done/.