### PR TITLE
issue fix

### DIFF
--- a/crates/compiler/src/ast/program.rs
+++ b/crates/compiler/src/ast/program.rs
@@ -310,6 +310,7 @@ impl Program {
             "string->float",
             // Test framework operations
             "test.init",
+            "test.set-name",
             "test.finish",
             "test.has-failures",
             "test.assert",

--- a/crates/compiler/src/builtins/diagnostics.rs
+++ b/crates/compiler/src/builtins/diagnostics.rs
@@ -12,6 +12,7 @@ pub(super) fn add_signatures(sigs: &mut HashMap<String, Effect>) {
     // =========================================================================
 
     builtin!(sigs, "test.init", (a String -- a));
+    builtin!(sigs, "test.set-name", (a String -- a));
     // Identity effect ( a -- a ). See note in concurrency.rs on chan.yield.
     sigs.insert(
         "test.finish".to_string(),
@@ -54,6 +55,11 @@ pub(super) fn add_docs(docs: &mut HashMap<&'static str, &'static str>) {
     docs.insert(
         "test.init",
         "Initialize the test framework with a test name.",
+    );
+    docs.insert(
+        "test.set-name",
+        "Update the current test's display name without clearing assertion state. \
+         Used by the `seqc test` runner to reassert the word-level name for output attribution.",
     );
     docs.insert("test.finish", "Finish testing and print results.");
     docs.insert("test.has-failures", "Check if any tests have failed.");

--- a/crates/compiler/src/codegen/runtime/test_time.rs
+++ b/crates/compiler/src/codegen/runtime/test_time.rs
@@ -9,6 +9,10 @@ pub(super) static DECLS: &[RuntimeDecl] = &[
         category: Some("; Test framework operations"),
     },
     RuntimeDecl {
+        decl: "declare ptr @patch_seq_test_set_name(ptr)",
+        category: None,
+    },
+    RuntimeDecl {
         decl: "declare ptr @patch_seq_test_finish(ptr)",
         category: None,
     },
@@ -67,6 +71,7 @@ pub(super) static DECLS: &[RuntimeDecl] = &[
 pub(super) static SYMBOLS: &[(&str, &str)] = &[
     // Test framework operations
     ("test.init", "patch_seq_test_init"),
+    ("test.set-name", "patch_seq_test_set_name"),
     ("test.finish", "patch_seq_test_finish"),
     ("test.has-failures", "patch_seq_test_has_failures"),
     ("test.assert", "patch_seq_test_assert"),

--- a/crates/compiler/src/test_runner.rs
+++ b/crates/compiler/src/test_runner.rs
@@ -193,12 +193,18 @@ impl TestRunner {
     ) -> FileTestResults {
         let start = Instant::now();
 
-        // Generate wrapper main that runs ALL tests in sequence
+        // Generate wrapper main that runs ALL tests in sequence.
+        //
+        // `test.set-name` after the user's test word guarantees the
+        // `test.finish` header matches the word name the parser discovered,
+        // even if the user called `test.init` with a different friendly
+        // name inside their test word. Without this, `collect_failure_block`
+        // (which keys on the word name) would orphan detail lines.
         let mut test_calls = String::new();
         for test_name in test_names {
             test_calls.push_str(&format!(
-                "  \"{}\" test.init {} test.finish\n",
-                test_name, test_name
+                "  \"{0}\" test.init {0} \"{0}\" test.set-name test.finish\n",
+                test_name
             ));
         }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -310,6 +310,7 @@ pub use test::{
     patch_seq_test_fail_count as test_fail_count, patch_seq_test_finish as test_finish,
     patch_seq_test_has_failures as test_has_failures, patch_seq_test_init as test_init,
     patch_seq_test_pass_count as test_pass_count, patch_seq_test_set_line as test_set_line,
+    patch_seq_test_set_name as test_set_name,
 };
 
 // Time operations (exported for LLVM linking)

--- a/crates/runtime/src/test.rs
+++ b/crates/runtime/src/test.rs
@@ -127,6 +127,32 @@ pub unsafe extern "C" fn patch_seq_test_set_line(line: i64) {
     };
 }
 
+/// Set the current test's display name without touching any other state.
+///
+/// Used by the `seqc test` runner to reassert the word-level test name
+/// after the user's test word has run, in case the user called
+/// `test.init "friendly name"` internally and overwrote the header.
+/// Unlike `test.init`, this does NOT clear `failures`, `passes`, or
+/// `current_line`.
+///
+/// Stack effect: ( ..a String -- ..a )
+///
+/// # Safety
+/// Stack must have a String (test name) on top.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_test_set_name(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, name_val) = pop(stack);
+        let name = match name_val {
+            Value::String(s) => s.as_str().to_string(),
+            _ => panic!("test.set-name: expected String (test name) on stack"),
+        };
+        let mut ctx = TEST_CONTEXT.lock().unwrap();
+        ctx.current_test = Some(name);
+        stack
+    }
+}
+
 /// Initialize test context for a new test
 ///
 /// Stack effect: ( name -- )


### PR DESCRIPTION
  Summary of the fix:

https://github.com/navicore/patch-seq/issues/424

  - New runtime FFI patch_seq_test_set_name in crates/runtime/src/test.rs — takes a String off the stack, updates only ctx.current_test, does NOT clear failures / passes / current_line. Re-exported from runtime/src/lib.rs.
  - New Seq builtin test.set-name with signature ( ..a String -- ..a ) registered in builtins/diagnostics.rs, in the codegen/runtime/test_time.rs DECLS + SYMBOLS tables, and in the ast/program.rs word-call validator's builtin list.
  - Runner wrapper in test_runner.rs now emits "{name}" test.init {name} "{name}" test.set-name test.finish, which guarantees the test.finish header matches the word name regardless of whether the user called test.init with a different friendly name inside their test word.

  No user-visible API change — test.set-name is documented as a
  runner-internal helper but exists on the Seq surface (it's called from
  the generated wrapper, which is compiled as normal Seq). test.init still
   accepts and honors a user-supplied friendly name for standalone test
  files (no runner wrapper).