### PR TITLE
⏺ Part A (compile-time) is done end-to-end:

### DIFF
--- a/crates/compiler/src/builtins/adt.rs
+++ b/crates/compiler/src/builtins/adt.rs
@@ -11,19 +11,19 @@ pub(super) fn add_signatures(sigs: &mut HashMap<String, Effect>) {
     // Variant Operations
     // =========================================================================
 
-    builtin!(sigs, "variant.field-count", (a V -- a Int));
-    builtin!(sigs, "variant.tag", (a V -- a Symbol));
-    builtin!(sigs, "variant.field-at", (a V Int -- a T));
-    builtin!(sigs, "variant.append", (a V T -- a V2));
-    builtin!(sigs, "variant.last", (a V -- a T));
-    builtin!(sigs, "variant.init", (a V -- a V2));
+    builtin!(sigs, "variant.field-count", (a Variant -- a Int));
+    builtin!(sigs, "variant.tag", (a Variant -- a Symbol));
+    builtin!(sigs, "variant.field-at", (a Variant Int -- a T));
+    builtin!(sigs, "variant.append", (a Variant T -- a Variant));
+    builtin!(sigs, "variant.last", (a Variant -- a T));
+    builtin!(sigs, "variant.init", (a Variant -- a Variant));
 
     // Type-safe variant constructors with fixed arity (symbol tags for SON support)
-    builtin!(sigs, "variant.make-0", (a Symbol -- a V));
-    builtin!(sigs, "variant.make-1", (a T1 Symbol -- a V));
-    builtin!(sigs, "variant.make-2", (a T1 T2 Symbol -- a V));
-    builtin!(sigs, "variant.make-3", (a T1 T2 T3 Symbol -- a V));
-    builtin!(sigs, "variant.make-4", (a T1 T2 T3 T4 Symbol -- a V));
+    builtin!(sigs, "variant.make-0", (a Symbol -- a Variant));
+    builtin!(sigs, "variant.make-1", (a T1 Symbol -- a Variant));
+    builtin!(sigs, "variant.make-2", (a T1 T2 Symbol -- a Variant));
+    builtin!(sigs, "variant.make-3", (a T1 T2 T3 Symbol -- a Variant));
+    builtin!(sigs, "variant.make-4", (a T1 T2 T3 T4 Symbol -- a Variant));
     // variant.make-5 through variant.make-12 defined manually (macro only supports up to 5 inputs)
     for n in 5..=12 {
         let mut input = StackType::RowVar("a".to_string());
@@ -31,16 +31,16 @@ pub(super) fn add_signatures(sigs: &mut HashMap<String, Effect>) {
             input = input.push(Type::Var(format!("T{}", i)));
         }
         input = input.push(Type::Symbol);
-        let output = StackType::RowVar("a".to_string()).push(Type::Var("V".to_string()));
+        let output = StackType::RowVar("a".to_string()).push(Type::Variant);
         sigs.insert(format!("variant.make-{}", n), Effect::new(input, output));
     }
 
     // Aliases for dynamic variant construction (SON-friendly names)
-    builtin!(sigs, "wrap-0", (a Symbol -- a V));
-    builtin!(sigs, "wrap-1", (a T1 Symbol -- a V));
-    builtin!(sigs, "wrap-2", (a T1 T2 Symbol -- a V));
-    builtin!(sigs, "wrap-3", (a T1 T2 T3 Symbol -- a V));
-    builtin!(sigs, "wrap-4", (a T1 T2 T3 T4 Symbol -- a V));
+    builtin!(sigs, "wrap-0", (a Symbol -- a Variant));
+    builtin!(sigs, "wrap-1", (a T1 Symbol -- a Variant));
+    builtin!(sigs, "wrap-2", (a T1 T2 Symbol -- a Variant));
+    builtin!(sigs, "wrap-3", (a T1 T2 T3 Symbol -- a Variant));
+    builtin!(sigs, "wrap-4", (a T1 T2 T3 T4 Symbol -- a Variant));
     // wrap-5 through wrap-12 defined manually
     for n in 5..=12 {
         let mut input = StackType::RowVar("a".to_string());
@@ -48,7 +48,7 @@ pub(super) fn add_signatures(sigs: &mut HashMap<String, Effect>) {
             input = input.push(Type::Var(format!("T{}", i)));
         }
         input = input.push(Type::Symbol);
-        let output = StackType::RowVar("a".to_string()).push(Type::Var("V".to_string()));
+        let output = StackType::RowVar("a".to_string()).push(Type::Variant);
         sigs.insert(format!("wrap-{}", n), Effect::new(input, output));
     }
 }

--- a/crates/compiler/src/builtins/macros.rs
+++ b/crates/compiler/src/builtins/macros.rs
@@ -24,6 +24,9 @@ macro_rules! ty {
     (Channel) => {
         Type::Channel
     };
+    (Variant) => {
+        Type::Variant
+    };
     // Single uppercase letter = type variable
     (T) => {
         Type::Var("T".to_string())

--- a/crates/compiler/src/codegen/debug_info.rs
+++ b/crates/compiler/src/codegen/debug_info.rs
@@ -57,6 +57,10 @@ impl CodeGen {
         let file_id = self.dbg_alloc_id();
         let cu_id = self.dbg_alloc_id();
         let sub_ty_id = self.dbg_alloc_id();
+        // Reserve module-flag IDs through the same counter so they never
+        // collide with later subprogram/location records on big programs.
+        let dwarf_ver_id = self.dbg_alloc_id();
+        let debug_info_ver_id = self.dbg_alloc_id();
 
         let _ = writeln!(
             &mut self.dbg_metadata,
@@ -81,6 +85,7 @@ impl CodeGen {
         self.dbg_file_id = Some(file_id);
         self.dbg_cu_id = Some(cu_id);
         self.dbg_subroutine_type_id = Some(sub_ty_id);
+        self.dbg_module_flag_ids = Some((dwarf_ver_id, debug_info_ver_id));
     }
 
     /// Allocate a `DISubprogram` for the function currently being emitted.
@@ -136,12 +141,12 @@ impl CodeGen {
     /// back to the originating .seq line. Returns `""` when debug info is
     /// disabled, no subprogram is open, or the statement has no span.
     pub(super) fn dbg_call_suffix(&mut self, span: Option<&Span>) -> String {
-        let (Some(scope), Some(sp)) = (self.current_dbg_subprogram_id, span) else {
-            return String::new();
-        };
         if !self.dbg_enabled() {
             return String::new();
         }
+        let (Some(scope), Some(sp)) = (self.current_dbg_subprogram_id, span) else {
+            return String::new();
+        };
         let loc_id = self.dbg_alloc_id();
         let _ = writeln!(
             &mut self.dbg_metadata,
@@ -158,10 +163,14 @@ impl CodeGen {
     /// Called once at the end of `codegen_program*` after `self.output`
     /// has been concatenated.
     pub(super) fn dbg_emit_module_metadata(&self, ir: &mut String) {
-        if !self.dbg_enabled() || self.dbg_cu_id.is_none() {
+        let (Some(cu_id), Some((dwarf_ver_id, debug_info_ver_id))) =
+            (self.dbg_cu_id, self.dbg_module_flag_ids)
+        else {
+            return;
+        };
+        if !self.dbg_enabled() {
             return;
         }
-        let cu_id = self.dbg_cu_id.unwrap();
         let _ = writeln!(ir);
         let _ = writeln!(ir, "!llvm.dbg.cu = !{{!{}}}", cu_id);
         // Dwarf Version + Debug Info Version are required by the verifier
@@ -169,18 +178,17 @@ impl CodeGen {
         let _ = writeln!(
             ir,
             "!llvm.module.flags = !{{!{}, !{}}}",
-            cu_id + 1000,
-            cu_id + 1001,
+            dwarf_ver_id, debug_info_ver_id,
         );
         let _ = writeln!(
             ir,
             "!{} = !{{i32 7, !\"Dwarf Version\", i32 4}}",
-            cu_id + 1000
+            dwarf_ver_id,
         );
         let _ = writeln!(
             ir,
             "!{} = !{{i32 2, !\"Debug Info Version\", i32 3}}",
-            cu_id + 1001,
+            debug_info_ver_id,
         );
         ir.push_str(&self.dbg_metadata);
     }

--- a/crates/compiler/src/codegen/debug_info.rs
+++ b/crates/compiler/src/codegen/debug_info.rs
@@ -1,0 +1,194 @@
+//! DWARF debug info generation.
+//!
+//! Emits LLVM `!DICompileUnit`, `!DIFile`, `!DISubprogram`, and `!DILocation`
+//! metadata records so a runtime panic backtrace resolves Seq frames to
+//! `.seq:line:col`. The cost is metadata-only — no runtime overhead.
+//!
+//! Lifecycle within a program emission:
+//!
+//! 1. `dbg_init_program` — at the start of `codegen_program*`, allocate the
+//!    compile unit, file, and shared subroutine type.
+//! 2. `dbg_open_subprogram` — at the start of each emitted function, allocate
+//!    a `DISubprogram` and stash its id in `current_dbg_subprogram_id`. The
+//!    caller appends the returned `!dbg !N` suffix to the `define` line.
+//! 3. `dbg_call_suffix` — for each emitted `call` with a span, allocates a
+//!    `DILocation` and returns the `, !dbg !N` suffix to append.
+//! 4. `dbg_close_subprogram` — clears `current_dbg_subprogram_id` after a
+//!    function is fully emitted.
+//! 5. `dbg_emit_module_metadata` — at the end of IR emission, dumps all
+//!    accumulated metadata records and the module flags.
+//!
+//! When `dbg_source` is `None`, every method is a no-op and the IR is
+//! identical to a build without debug info.
+
+use super::CodeGen;
+use crate::ast::Span;
+use std::fmt::Write as _;
+
+impl CodeGen {
+    /// True when debug info should be emitted. Cheap, called per call-site.
+    pub(super) fn dbg_enabled(&self) -> bool {
+        self.dbg_source.is_some()
+    }
+
+    /// Allocate the next metadata id.
+    fn dbg_alloc_id(&mut self) -> usize {
+        self.dbg_md_counter += 1;
+        self.dbg_md_counter
+    }
+
+    /// Initialise the compile unit, file, and shared subroutine type.
+    /// Idempotent — safe to call once per program emission.
+    pub(super) fn dbg_init_program(&mut self) {
+        if !self.dbg_enabled() || self.dbg_cu_id.is_some() {
+            return;
+        }
+
+        let source = self.dbg_source.as_ref().expect("dbg_enabled checked");
+        let abs = std::fs::canonicalize(source).unwrap_or_else(|_| source.clone());
+        let (filename, directory) = match (abs.file_name(), abs.parent()) {
+            (Some(name), Some(dir)) => (
+                name.to_string_lossy().into_owned(),
+                dir.to_string_lossy().into_owned(),
+            ),
+            _ => (abs.to_string_lossy().into_owned(), String::new()),
+        };
+
+        let file_id = self.dbg_alloc_id();
+        let cu_id = self.dbg_alloc_id();
+        let sub_ty_id = self.dbg_alloc_id();
+
+        let _ = writeln!(
+            &mut self.dbg_metadata,
+            "!{} = !DIFile(filename: \"{}\", directory: \"{}\")",
+            file_id,
+            escape_md(&filename),
+            escape_md(&directory),
+        );
+        let _ = writeln!(
+            &mut self.dbg_metadata,
+            "!{} = distinct !DICompileUnit(language: DW_LANG_C, file: !{}, \
+             producer: \"seqc\", isOptimized: false, runtimeVersion: 0, \
+             emissionKind: FullDebug)",
+            cu_id, file_id,
+        );
+        let _ = writeln!(
+            &mut self.dbg_metadata,
+            "!{} = !DISubroutineType(types: !{{null}})",
+            sub_ty_id,
+        );
+
+        self.dbg_file_id = Some(file_id);
+        self.dbg_cu_id = Some(cu_id);
+        self.dbg_subroutine_type_id = Some(sub_ty_id);
+    }
+
+    /// Allocate a `DISubprogram` for the function currently being emitted.
+    ///
+    /// Returns the suffix to append to the `define` header line — either
+    /// ` !dbg !N` or `""` when debug info is disabled. Stashes the id in
+    /// `current_dbg_subprogram_id` so subsequent call-site emissions can
+    /// reference it as their scope.
+    pub(super) fn dbg_open_subprogram(&mut self, name: &str, line: usize) -> String {
+        if !self.dbg_enabled() {
+            return String::new();
+        }
+        // Bootstrap on first use — keeps callers from having to remember.
+        self.dbg_init_program();
+
+        let (Some(file_id), Some(cu_id), Some(sub_ty_id)) = (
+            self.dbg_file_id,
+            self.dbg_cu_id,
+            self.dbg_subroutine_type_id,
+        ) else {
+            return String::new();
+        };
+
+        let sp_id = self.dbg_alloc_id();
+        // DWARF lines are 1-indexed; spans are 0-indexed internally.
+        let dwarf_line = line.saturating_add(1);
+        let _ = writeln!(
+            &mut self.dbg_metadata,
+            "!{} = distinct !DISubprogram(name: \"{}\", scope: !{}, \
+             file: !{}, line: {}, type: !{}, scopeLine: {}, \
+             spFlags: DISPFlagDefinition, unit: !{})",
+            sp_id,
+            escape_md(name),
+            file_id,
+            file_id,
+            dwarf_line,
+            sub_ty_id,
+            dwarf_line,
+            cu_id,
+        );
+
+        self.current_dbg_subprogram_id = Some(sp_id);
+        format!(" !dbg !{}", sp_id)
+    }
+
+    /// Clear the current subprogram. Called when a function definition is
+    /// fully emitted.
+    pub(super) fn dbg_close_subprogram(&mut self) {
+        self.current_dbg_subprogram_id = None;
+    }
+
+    /// Suffix to append to a `call` instruction so its address resolves
+    /// back to the originating .seq line. Returns `""` when debug info is
+    /// disabled, no subprogram is open, or the statement has no span.
+    pub(super) fn dbg_call_suffix(&mut self, span: Option<&Span>) -> String {
+        let (Some(scope), Some(sp)) = (self.current_dbg_subprogram_id, span) else {
+            return String::new();
+        };
+        if !self.dbg_enabled() {
+            return String::new();
+        }
+        let loc_id = self.dbg_alloc_id();
+        let _ = writeln!(
+            &mut self.dbg_metadata,
+            "!{} = !DILocation(line: {}, column: {}, scope: !{})",
+            loc_id,
+            sp.line.saturating_add(1),
+            sp.column.saturating_add(1),
+            scope,
+        );
+        format!(", !dbg !{}", loc_id)
+    }
+
+    /// Append accumulated debug metadata and module flags to the final IR.
+    /// Called once at the end of `codegen_program*` after `self.output`
+    /// has been concatenated.
+    pub(super) fn dbg_emit_module_metadata(&self, ir: &mut String) {
+        if !self.dbg_enabled() || self.dbg_cu_id.is_none() {
+            return;
+        }
+        let cu_id = self.dbg_cu_id.unwrap();
+        let _ = writeln!(ir);
+        let _ = writeln!(ir, "!llvm.dbg.cu = !{{!{}}}", cu_id);
+        // Dwarf Version + Debug Info Version are required by the verifier
+        // when any !dbg metadata exists in the module.
+        let _ = writeln!(
+            ir,
+            "!llvm.module.flags = !{{!{}, !{}}}",
+            cu_id + 1000,
+            cu_id + 1001,
+        );
+        let _ = writeln!(
+            ir,
+            "!{} = !{{i32 7, !\"Dwarf Version\", i32 4}}",
+            cu_id + 1000
+        );
+        let _ = writeln!(
+            ir,
+            "!{} = !{{i32 2, !\"Debug Info Version\", i32 3}}",
+            cu_id + 1001,
+        );
+        ir.push_str(&self.dbg_metadata);
+    }
+}
+
+/// Escape a string for embedding as a metadata string literal.
+/// LLVM IR strings use C-style escapes; backslashes and quotes are the
+/// two characters we have to be careful about for paths.
+fn escape_md(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/crates/compiler/src/codegen/mod.rs
+++ b/crates/compiler/src/codegen/mod.rs
@@ -75,6 +75,7 @@
 
 // Submodules
 mod control_flow;
+mod debug_info;
 mod error;
 mod ffi_wrappers;
 mod globals;

--- a/crates/compiler/src/codegen/program.rs
+++ b/crates/compiler/src/codegen/program.rs
@@ -69,6 +69,7 @@ impl CodeGen {
         self.emit_external_builtins(&mut ir)?;
         self.emit_quotation_functions(&mut ir)?;
         ir.push_str(&self.output);
+        self.dbg_emit_module_metadata(&mut ir);
         Ok(ir)
     }
 
@@ -98,6 +99,7 @@ impl CodeGen {
         self.emit_ffi_wrappers_section(&mut ir)?;
         self.emit_quotation_functions(&mut ir)?;
         ir.push_str(&self.output);
+        self.dbg_emit_module_metadata(&mut ir);
         Ok(ir)
     }
 

--- a/crates/compiler/src/codegen/state.rs
+++ b/crates/compiler/src/codegen/state.rs
@@ -7,6 +7,7 @@ use crate::ast::UnionDef;
 use crate::ffi::FfiBindings;
 use crate::types::Type;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use super::specialization::SpecSignature;
 
@@ -109,6 +110,11 @@ pub(super) struct QuotationScope {
     pub word_name: Option<String>,
     pub aux_slots: Vec<String>,
     pub aux_sp: usize,
+    /// Snapshot of the enclosing word's DISubprogram. Cleared while a
+    /// quotation body is being emitted (the quotation lives in its own
+    /// LLVM function with no subprogram, so any `!dbg` attached inside
+    /// would be unverifiable), and restored when the scope exits.
+    pub dbg_subprogram_id: Option<usize>,
 }
 
 /// A value held in an LLVM virtual register instead of memory (Issue #189).
@@ -198,6 +204,36 @@ pub struct CodeGen {
     pub(super) main_returns_int: bool,
     /// Maps word name -> sequential ID for instrumentation counters
     pub(super) word_instrument_ids: HashMap<String, usize>,
+    // -------------------------------------------------------------------
+    // Debug info (DWARF) — see codegen/debug_info.rs.
+    //
+    // When enabled, emits LLVM `!DICompileUnit`, `!DIFile`, `!DISubprogram`,
+    // and per-call `!DILocation` metadata so panics in the runtime resolve
+    // back to .seq source lines via the standard Rust backtrace path.
+    // Zero runtime cost — pure metadata. The clang invocation must pass
+    // `-g` to preserve these into the final binary's DWARF section.
+    // -------------------------------------------------------------------
+    /// Source file the program was compiled from (for DIFile). When
+    /// `None`, debug info is disabled.
+    pub(super) dbg_source: Option<PathBuf>,
+    /// Accumulated DWARF metadata definitions (`!N = !DI...`). Appended to
+    /// the end of the IR file alongside the module flags.
+    pub(super) dbg_metadata: String,
+    /// Counter for unique metadata IDs. Started at 1000 to leave headroom
+    /// for any future module-level metadata that may want lower ids.
+    pub(super) dbg_md_counter: usize,
+    /// ID of the per-program `!DICompileUnit`. Set during program prologue
+    /// when debug info is enabled.
+    pub(super) dbg_cu_id: Option<usize>,
+    /// ID of the shared `!DIFile` for the source file.
+    pub(super) dbg_file_id: Option<usize>,
+    /// ID of the shared `!DISubroutineType` reused by every subprogram —
+    /// our generated functions all have the same opaque ptr-in/ptr-out
+    /// signature from a debugger's point of view.
+    pub(super) dbg_subroutine_type_id: Option<usize>,
+    /// `!DISubprogram` ID for the function currently being emitted, if any.
+    /// Call sites use this as the scope for their `!DILocation` records.
+    pub(super) current_dbg_subprogram_id: Option<usize>,
 }
 
 impl Default for CodeGen {
@@ -245,7 +281,24 @@ impl CodeGen {
             instrument: false,
             word_instrument_ids: HashMap::new(),
             main_returns_int: false,
+            dbg_source: None,
+            dbg_metadata: String::new(),
+            dbg_md_counter: 1000,
+            dbg_cu_id: None,
+            dbg_file_id: None,
+            dbg_subroutine_type_id: None,
+            current_dbg_subprogram_id: None,
         }
+    }
+
+    /// Enable DWARF debug info generation, anchored at the given source file.
+    ///
+    /// Must be called before `codegen_program*`. With debug info enabled,
+    /// every user-defined word gets a `!DISubprogram` and every call site
+    /// with a span gets a `!DILocation` — so a runtime panic backtrace
+    /// resolves the Seq frame to `.seq:line:col`. Zero runtime overhead.
+    pub fn set_source_file(&mut self, path: PathBuf) {
+        self.dbg_source = Some(path);
     }
 
     /// Create a CodeGen for pure inline testing.

--- a/crates/compiler/src/codegen/state.rs
+++ b/crates/compiler/src/codegen/state.rs
@@ -234,6 +234,10 @@ pub struct CodeGen {
     /// `!DISubprogram` ID for the function currently being emitted, if any.
     /// Call sites use this as the scope for their `!DILocation` records.
     pub(super) current_dbg_subprogram_id: Option<usize>,
+    /// IDs of the two `!llvm.module.flags` records ("Dwarf Version",
+    /// "Debug Info Version"). Allocated through `dbg_alloc_id` at program
+    /// init so they never collide with later subprogram/location records.
+    pub(super) dbg_module_flag_ids: Option<(usize, usize)>,
 }
 
 impl Default for CodeGen {
@@ -288,6 +292,7 @@ impl CodeGen {
             dbg_file_id: None,
             dbg_subroutine_type_id: None,
             current_dbg_subprogram_id: None,
+            dbg_module_flag_ids: None,
         }
     }
 

--- a/crates/compiler/src/codegen/statements.rs
+++ b/crates/compiler/src/codegen/statements.rs
@@ -88,7 +88,10 @@ impl CodeGen {
                 "  %{} = musttail call tailcc ptr @{}(ptr %{}){}",
                 result_var, function_name, stack_var, dbg
             )?;
-            writeln!(&mut self.output, "  ret ptr %{}{}", result_var, dbg)?;
+            // Leave the `ret` bare. `musttail` requires the ret to mirror the
+            // call exactly; the !dbg on the call is enough for backtrace
+            // resolution (the call-site address is what gets symbolised).
+            writeln!(&mut self.output, "  ret ptr %{}", result_var)?;
         } else if is_seq_word {
             // Non-tail call to user-defined word: must use tailcc calling convention
             writeln!(

--- a/crates/compiler/src/codegen/statements.rs
+++ b/crates/compiler/src/codegen/statements.rs
@@ -75,21 +75,26 @@ impl CodeGen {
             return self.codegen_tail_call_quotation(stack_var, &result_var);
         }
 
+        // Allocate a DILocation for this call site so a runtime panic
+        // here resolves back to .seq:line:col in the backtrace. No-op when
+        // debug info is disabled or the statement has no span.
+        let dbg = self.dbg_call_suffix(span);
+
         if can_tail_call {
             // Yield check before tail call to prevent starvation in tight loops
             writeln!(&mut self.output, "  call void @patch_seq_maybe_yield()")?;
             writeln!(
                 &mut self.output,
-                "  %{} = musttail call tailcc ptr @{}(ptr %{})",
-                result_var, function_name, stack_var
+                "  %{} = musttail call tailcc ptr @{}(ptr %{}){}",
+                result_var, function_name, stack_var, dbg
             )?;
-            writeln!(&mut self.output, "  ret ptr %{}", result_var)?;
+            writeln!(&mut self.output, "  ret ptr %{}{}", result_var, dbg)?;
         } else if is_seq_word {
             // Non-tail call to user-defined word: must use tailcc calling convention
             writeln!(
                 &mut self.output,
-                "  %{} = call tailcc ptr @{}(ptr %{})",
-                result_var, function_name, stack_var
+                "  %{} = call tailcc ptr @{}(ptr %{}){}",
+                result_var, function_name, stack_var, dbg
             )?;
         } else {
             // Call to builtin (C calling convention).
@@ -110,8 +115,8 @@ impl CodeGen {
             }
             writeln!(
                 &mut self.output,
-                "  %{} = call ptr @{}(ptr %{})",
-                result_var, function_name, stack_var
+                "  %{} = call ptr @{}(ptr %{}){}",
+                result_var, function_name, stack_var, dbg
             )?;
         }
         Ok(result_var)

--- a/crates/compiler/src/codegen/words.rs
+++ b/crates/compiler/src/codegen/words.rs
@@ -37,17 +37,22 @@ impl CodeGen {
             ""
         };
 
+        // Open a DISubprogram so backtraces resolve to .seq:line. Anchor
+        // at the word's source line if known, else line 0.
+        let dbg_line = word.source.as_ref().map(|s| s.start_line).unwrap_or(0);
+        let dbg_attr = self.dbg_open_subprogram(&word.name, dbg_line);
+
         if is_main {
             writeln!(
                 &mut self.output,
-                "define ptr @{}(ptr %stack) {{",
-                function_name
+                "define ptr @{}(ptr %stack){} {{",
+                function_name, dbg_attr
             )?;
         } else {
             writeln!(
                 &mut self.output,
-                "define tailcc ptr @{}(ptr %stack){} {{",
-                function_name, inline_attr
+                "define tailcc ptr @{}(ptr %stack){}{} {{",
+                function_name, inline_attr, dbg_attr
             )?;
         }
         writeln!(&mut self.output, "entry:")?;
@@ -147,6 +152,7 @@ impl CodeGen {
         writeln!(&mut self.output, "}}")?;
         writeln!(&mut self.output)?;
 
+        self.dbg_close_subprogram();
         self.inside_main = false;
         Ok(())
     }
@@ -295,6 +301,7 @@ impl CodeGen {
             word_name: self.current_word_name.take(),
             aux_slots: std::mem::take(&mut self.current_aux_slots),
             aux_sp: self.current_aux_sp,
+            dbg_subprogram_id: self.current_dbg_subprogram_id.take(),
         };
         self.current_aux_sp = 0;
         scope
@@ -309,6 +316,7 @@ impl CodeGen {
         self.current_word_name = scope.word_name;
         self.current_aux_slots = scope.aux_slots;
         self.current_aux_sp = scope.aux_sp;
+        self.current_dbg_subprogram_id = scope.dbg_subprogram_id;
     }
 
     /// Walk a function body, emitting each statement with the last in tail

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -315,6 +315,7 @@ pub fn compile_file_with_config(
     codegen.set_aux_slot_counts(aux_max_depths);
     codegen.set_quotation_aux_slot_counts(quotation_aux_depths);
     codegen.set_resolved_sugar(resolved_sugar);
+    codegen.set_source_file(source_path.to_path_buf());
     let ir = codegen
         .codegen_program_with_ffi(
             &program,
@@ -351,6 +352,10 @@ pub fn compile_file_with_config(
     let mut clang = Command::new("clang");
     clang
         .arg(opt_flag)
+        // Preserve DWARF emitted by codegen so runtime panics resolve
+        // back to .seq:line via the standard backtrace path. Pure metadata
+        // — no runtime cost; only increases binary size.
+        .arg("-g")
         .arg(&ir_path)
         .arg("-o")
         .arg(output_path)

--- a/crates/compiler/src/typechecker/freshen.rs
+++ b/crates/compiler/src/typechecker/freshen.rs
@@ -75,9 +75,13 @@ impl TypeChecker {
         row_map: &mut HashMap<String, String>,
     ) -> Type {
         match ty {
-            Type::Int | Type::Float | Type::Bool | Type::String | Type::Symbol | Type::Channel => {
-                ty.clone()
-            }
+            Type::Int
+            | Type::Float
+            | Type::Bool
+            | Type::String
+            | Type::Symbol
+            | Type::Channel
+            | Type::Variant => ty.clone(),
             Type::Var(name) => {
                 let fresh_name = type_map
                     .entry(name.clone())

--- a/crates/compiler/src/typechecker/tests.rs
+++ b/crates/compiler/src/typechecker/tests.rs
@@ -3722,7 +3722,11 @@ fn test_variant_field_count_rejects_string() {
             variant_call("variant.field-count"),
         ],
     );
-    assert!(result.is_err());
+    let err = result.expect_err("expected type error for String -> variant.field-count");
+    assert!(
+        err.contains("variant.field-count"),
+        "error should name variant.field-count, got: {err}"
+    );
 }
 
 #[test]
@@ -3736,7 +3740,11 @@ fn test_variant_init_rejects_string() {
             variant_call("variant.init"),
         ],
     );
-    assert!(result.is_err());
+    let err = result.expect_err("expected type error for String -> variant.init");
+    assert!(
+        err.contains("variant.init"),
+        "error should name variant.init, got: {err}"
+    );
 }
 
 #[test]
@@ -3751,7 +3759,66 @@ fn test_variant_append_rejects_string_base() {
             variant_call("variant.append"),
         ],
     );
-    assert!(result.is_err());
+    let err = result.expect_err("expected type error for String -> variant.append");
+    assert!(
+        err.contains("variant.append"),
+        "error should name variant.append, got: {err}"
+    );
+}
+
+#[test]
+fn test_variant_last_rejects_string() {
+    let result = check_word_with_body(
+        "bad",
+        StackType::Empty,
+        StackType::Empty.push(Type::Var("T".to_string())),
+        vec![
+            Statement::StringLiteral("x".to_string()),
+            variant_call("variant.last"),
+        ],
+    );
+    let err = result.expect_err("expected type error for String -> variant.last");
+    assert!(
+        err.contains("variant.last"),
+        "error should name variant.last, got: {err}"
+    );
+}
+
+#[test]
+fn test_union_value_accepted_by_variant_field_at() {
+    // Direct exercise of the Union(_) <: Variant relaxation rule:
+    // a value typed `Union("Box")` should be accepted by variant.field-at
+    // (which is signed against `Variant`).
+    let union_def = crate::ast::UnionDef {
+        name: "Box".to_string(),
+        variants: vec![crate::ast::UnionVariant {
+            name: "Cell".to_string(),
+            fields: vec![crate::ast::UnionField {
+                name: "x".to_string(),
+                type_name: "Int".to_string(),
+            }],
+            source: None,
+        }],
+        source: None,
+    };
+    let program = Program {
+        includes: vec![],
+        unions: vec![union_def],
+        words: vec![WordDef {
+            name: "first".to_string(),
+            effect: Some(Effect::new(
+                StackType::singleton(Type::Union("Box".to_string())),
+                StackType::singleton(Type::Int),
+            )),
+            body: vec![Statement::IntLiteral(0), variant_call("variant.field-at")],
+            source: None,
+            allowed_lints: vec![],
+        }],
+    };
+    let mut checker = TypeChecker::new();
+    checker
+        .check_program(&program)
+        .expect("Union(Box) should be accepted by variant.field-at");
 }
 
 #[test]

--- a/crates/compiler/src/typechecker/tests.rs
+++ b/crates/compiler/src/typechecker/tests.rs
@@ -3645,6 +3645,136 @@ fn test_bi_underflow() {
     );
 }
 
+// =========================================================================
+// variant.* type safety
+//
+// Regression coverage for the `variant.*` builtins requiring Type::Variant
+// (or a Union via the Union <: Variant relaxation) on the stack.
+// =========================================================================
+
+fn check_word_with_body(
+    name: &str,
+    inputs: StackType,
+    outputs: StackType,
+    body: Vec<Statement>,
+) -> Result<(), String> {
+    let program = Program {
+        includes: vec![],
+        unions: vec![],
+        words: vec![WordDef {
+            name: name.to_string(),
+            effect: Some(Effect::new(inputs, outputs)),
+            body,
+            source: None,
+            allowed_lints: vec![],
+        }],
+    };
+    let mut checker = TypeChecker::new();
+    checker.check_program(&program).map(|_| ())
+}
+
+fn variant_call(name: &str) -> Statement {
+    Statement::WordCall {
+        name: name.to_string(),
+        span: None,
+    }
+}
+
+#[test]
+fn test_variant_field_at_rejects_string() {
+    let result = check_word_with_body(
+        "bad",
+        StackType::Empty,
+        StackType::singleton(Type::Int),
+        vec![
+            Statement::StringLiteral("alpha beta".to_string()),
+            Statement::IntLiteral(0),
+            variant_call("variant.field-at"),
+        ],
+    );
+    let err = result.expect_err("expected type error for String -> variant.field-at");
+    assert!(
+        err.contains("variant.field-at") && err.contains("String"),
+        "error should name variant.field-at and String, got: {err}"
+    );
+}
+
+#[test]
+fn test_variant_tag_rejects_int() {
+    let result = check_word_with_body(
+        "bad",
+        StackType::Empty,
+        StackType::singleton(Type::Symbol),
+        vec![Statement::IntLiteral(7), variant_call("variant.tag")],
+    );
+    let err = result.expect_err("expected type error for Int -> variant.tag");
+    assert!(err.contains("variant.tag"));
+}
+
+#[test]
+fn test_variant_field_count_rejects_string() {
+    let result = check_word_with_body(
+        "bad",
+        StackType::Empty,
+        StackType::singleton(Type::Int),
+        vec![
+            Statement::StringLiteral("x".to_string()),
+            variant_call("variant.field-count"),
+        ],
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_variant_init_rejects_string() {
+    let result = check_word_with_body(
+        "bad",
+        StackType::Empty,
+        StackType::singleton(Type::Variant),
+        vec![
+            Statement::StringLiteral("x".to_string()),
+            variant_call("variant.init"),
+        ],
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_variant_append_rejects_string_base() {
+    let result = check_word_with_body(
+        "bad",
+        StackType::Empty,
+        StackType::singleton(Type::Variant),
+        vec![
+            Statement::StringLiteral("x".to_string()),
+            Statement::IntLiteral(1),
+            variant_call("variant.append"),
+        ],
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_variant_make_then_field_at_typechecks() {
+    let result = check_word_with_body(
+        "ok",
+        StackType::Empty,
+        StackType::singleton(Type::Int),
+        vec![
+            Statement::IntLiteral(42),
+            Statement::Symbol("Foo".to_string()),
+            variant_call("variant.make-1"),
+            Statement::IntLiteral(0),
+            variant_call("variant.field-at"),
+        ],
+    );
+    assert!(
+        result.is_ok(),
+        "variant.make-1 -> variant.field-at should typecheck, got: {:?}",
+        result
+    );
+}
+
 #[test]
 fn test_bi_polymorphic_quotations() {
     // : test ( Int -- Int String )  [ 2 i.* ] [ int->string ] bi ;

--- a/crates/compiler/src/typechecker/validation.rs
+++ b/crates/compiler/src/typechecker/validation.rs
@@ -99,9 +99,13 @@ impl TypeChecker {
                 Ok(())
             }
             // Concrete types are always valid
-            Type::Int | Type::Float | Type::Bool | Type::String | Type::Symbol | Type::Channel => {
-                Ok(())
-            }
+            Type::Int
+            | Type::Float
+            | Type::Bool
+            | Type::String
+            | Type::Symbol
+            | Type::Channel
+            | Type::Variant => Ok(()),
             // Union types are valid if they're registered
             Type::Union(name) => {
                 if !self.unions.contains_key(name) {

--- a/crates/compiler/src/types.rs
+++ b/crates/compiler/src/types.rs
@@ -65,6 +65,13 @@ pub enum Type {
     /// Example: Message in `union Message { Get { ... } Increment { ... } }`
     /// The full definition is looked up in the type environment
     Union(String),
+    /// Anonymous variant value — a tagged variant of unspecified union shape.
+    /// This is the compile-time mate of the runtime `Value::Variant` for cases
+    /// where we know the value is a variant but not which union it belongs to.
+    /// Used by the low-level `variant.*` builtins (variant.field-at, variant.tag,
+    /// variant.make-N, etc.). A `Type::Union(name)` is accepted where `Variant`
+    /// is expected (one-way relaxation, see unification).
+    Variant,
     /// Type variable (for polymorphism)
     /// Example: T in ( ..a T -- ..a T T )
     Var(String),
@@ -284,6 +291,7 @@ impl std::fmt::Display for Type {
                 write!(f, "Closure[{}, captures=({})]", effect, cap_str.join(", "))
             }
             Type::Union(name) => write!(f, "{}", name),
+            Type::Variant => write!(f, "Variant"),
             Type::Var(name) => write!(f, "{}", name),
         }
     }

--- a/crates/compiler/src/unification.rs
+++ b/crates/compiler/src/unification.rs
@@ -171,6 +171,12 @@ pub fn unify_types(t1: &Type, t2: &Type) -> Result<Subst, String> {
         // below; the symmetric form is a minor unsoundness in the reverse
         // direction (a `Variant` flowing back into a `Union(name)` slot)
         // that we accept for now.
+        //
+        // TODO: tighten to a directional rule once the typechecker tracks
+        // which side of a unification is "expected" vs "actual". Today a
+        // `Variant` (e.g. the result of `variant.append`) silently
+        // satisfies a `Union(name)` constraint without checking the tag —
+        // intended pragmatic loophole, not a permanent stance.
         (Type::Union(_), Type::Variant) | (Type::Variant, Type::Union(_)) => Ok(Subst::empty()),
 
         // Type variable unifies with anything (with occurs check)

--- a/crates/compiler/src/unification.rs
+++ b/crates/compiler/src/unification.rs
@@ -109,7 +109,8 @@ fn occurs_in_type(var: &str, ty: &Type) -> bool {
         | Type::String
         | Type::Symbol
         | Type::Channel
-        | Type::Union(_) => false,
+        | Type::Union(_)
+        | Type::Variant => false,
         Type::Quotation(effect) => {
             // Check if var occurs in quotation's input or output stack types
             occurs_in_stack(var, &effect.inputs) || occurs_in_stack(var, &effect.outputs)
@@ -158,6 +159,19 @@ pub fn unify_types(t1: &Type, t2: &Type) -> Result<Subst, String> {
                 ))
             }
         }
+
+        // Variant matches itself
+        (Type::Variant, Type::Variant) => Ok(Subst::empty()),
+
+        // Union <: Variant relaxation — a named union value is a variant.
+        // This lets `variant.*` builtins (typed against `Variant`) accept
+        // user values typed as `Union(name)` without losing union safety
+        // elsewhere: the rule applies only when one side is the bare
+        // `Variant` placeholder. Mirrors the Closure <: Quotation rule
+        // below; the symmetric form is a minor unsoundness in the reverse
+        // direction (a `Variant` flowing back into a `Union(name)` slot)
+        // that we accept for now.
+        (Type::Union(_), Type::Variant) | (Type::Variant, Type::Union(_)) => Ok(Subst::empty()),
 
         // Type variable unifies with anything (with occurs check)
         (Type::Var(name), ty) | (ty, Type::Var(name)) => {

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -396,6 +396,7 @@ pub(crate) fn format_type(ty: &seqc::Type) -> String {
         Type::Channel => "Channel".to_string(),
         Type::Var(name) => name.clone(),
         Type::Union(name) => name.clone(),
+        Type::Variant => "Variant".to_string(),
         Type::Quotation(effect) => format!("[ {} ]", format_effect(effect)),
         Type::Closure { effect, .. } => format!("{{ {} }}", format_effect(effect)),
     }

--- a/crates/repl/src/ir/stack_effects.rs
+++ b/crates/repl/src/ir/stack_effects.rs
@@ -58,6 +58,7 @@ fn type_to_value(ty: &Type) -> StackValue {
         Type::Symbol => StackValue::ty("Symbol"),
         Type::Channel => StackValue::ty("Channel"),
         Type::Union(name) => StackValue::ty(name.clone()),
+        Type::Variant => StackValue::ty("Variant"),
         Type::Quotation(_) => StackValue::ty("Quot"),
         Type::Closure { .. } => StackValue::ty("Closure"),
     }

--- a/docs/design/VARIANT_OP_TYPE_SAFETY.md
+++ b/docs/design/VARIANT_OP_TYPE_SAFETY.md
@@ -1,6 +1,6 @@
 # Variant-op Type Safety + Locatable Runtime Panics
 
-Status: design · 2026-04-25
+Status: implemented (Part A and Part B) · 2026-04-25
 
 ## Intent
 

--- a/docs/design/VARIANT_OP_TYPE_SAFETY.md
+++ b/docs/design/VARIANT_OP_TYPE_SAFETY.md
@@ -1,0 +1,127 @@
+# Variant-op Type Safety + Locatable Runtime Panics
+
+Status: design · 2026-04-25
+
+## Intent
+
+Today the compiler accepts `"alpha beta gamma" 0 variant.field-at` without
+complaint. The program builds, then panics in `runtime/src/variant_ops/access.rs`
+with no source location, leaving the user nothing to grep for. Two distinct
+holes:
+
+1. **Type checker can't distinguish "any value" from "a variant."** All
+   `variant.*` builtins are typed `(a V Int -- a T)` where `V` is a free
+   type variable, so `String` unifies with `V` happily.
+2. **Runtime panics carry no `.seq` source location.** Even when a panic
+   *is* the right answer (e.g. div-by-zero in older code paths, future
+   FFI failures), the user sees Rust file/line, not Seq file/line.
+
+Goal: catch shape-1 errors at compile time, and make any panic that
+*does* slip through self-locating in the source file. Both must respect
+"the fast path stays fast" (ROADMAP.md).
+
+## Constraints
+
+- **No measurable runtime overhead on the hot path.** This is
+  load-bearing. Any solution that adds a per-builtin-call cost must be
+  zero or near-zero (e.g. one `store i64` to a thread-local, only at
+  fallible builtins) — and only if no zero-cost path exists.
+- **No new user-visible syntax.** Users don't push spans onto the stack.
+- **Don't weaken the type system or break existing union/match flow.**
+  `Type::Union("Message")` keeps working; `match` exhaustiveness keeps
+  working; auto-generated `Make-X` constructors keep working.
+- **No generics.** (`feedback_no_generics.md` is firm: lint-based safety
+  preferred, but here a *kind* constraint on one type parameter is the
+  minimum that closes the hole — it isn't generics in the user-facing
+  sense.)
+- **Out of scope:** rejecting all runtime panics (some FFI calls and OOM
+  always can); coloured output; structured panic protocol.
+
+## Approach
+
+### Part A — compile-time check (primary fix)
+
+Two viable shapes; pick one:
+
+1. **Introduce `Type::Variant`** as an anonymous "this is a tagged
+   variant value" type. `variant.make-N` and `Make-X` constructors
+   return `Variant`. `Type::Union(name)` unifies with `Variant`
+   (Union-is-a-Variant, one direction). All `variant.*` ops change
+   their signature from `(a V Int -- a T)` to `(a Variant Int -- a T)`.
+   Cost: one new `Type` enum arm + one unification rule + signature
+   updates in `builtins/adt.rs`.
+2. **Kinded type variables.** `Type::Var("V")` gains an optional kind
+   tag; `variant.*` signatures use `Type::VarKinded("V", Kind::Variant)`.
+   Unification rejects `String` against a `Variant`-kinded var. More
+   general (could later constrain `Numeric`, `Hashable`, etc.) but more
+   surface area now.
+
+Recommend (1): smaller blast radius, matches how `Type::Union` already
+works, no new generics machinery. The codegen path doesn't change at
+all — `Variant`/`Union(_)` are already represented identically at
+runtime (`Value::Variant`).
+
+The `T` output (field type) stays a free type variable — that's
+correct, since fields are heterogeneous and only `match` can refine
+them safely. This intentionally leaves *that* dynamism in place;
+we're tightening only the input shape, not the output.
+
+### Part B — locatable panics (secondary, only if zero-cost)
+
+Three options, ranked by overhead:
+
+1. **LLVM `!dbg` metadata + DWARF.** Emit source locations on every
+   codegen instruction. When Rust runtime panics, its backtrace already
+   resolves return addresses; with debug info attached to Seq-generated
+   IR, the Seq-frame in the backtrace resolves to `.seq:line:col`.
+   **Zero runtime cost.** Cost is at panic time and at compile time
+   (slightly larger object files; gated behind a `--debug` flag if
+   needed). This is the right answer if it works — needs a spike to
+   confirm `addr2line` lights up Seq frames cleanly.
+2. **Thread-local current-span, set only at fallible-builtin calls.**
+   Reuse the pattern from `done/ASSERT_FAILURE_DETAILS.md` (Phase 2):
+   compiler emits `patch_seq_set_current_span(line)` immediately
+   before each call to a builtin in the existing fallible list (the
+   one already maintained for the error-flag lint). One `store i64`
+   per fallible call, zero overhead on infallible ops (arithmetic,
+   stack shuffling, etc.). Acceptable if option 1 doesn't pan out.
+3. **Unconditional span-threading through every call.** Rejected —
+   measurable overhead on the hot path.
+
+Part B is gated on Part A landing first. If Part A closes the
+`variant.field-at` class entirely, Part B's urgency drops — but it
+still pays off for legitimate runtime failures (FFI, OOM, future
+fallible ops).
+
+## Domain events
+
+- **User compiles a Seq program with a variant.* misuse** → typechecker
+  fails unification of input against `Type::Variant` → emits a
+  `WordCall`-located error pointing at `variant.field-at` with
+  expected/actual types → no executable produced → CI gates fire.
+- **User compiles a program that calls a fallible builtin** → codegen
+  emits a span-update or attaches `!dbg` metadata → no behavioural
+  change for the user.
+- **A runtime panic does fire** (FFI, OOM, etc.) → backtrace contains
+  `.seq:line` → user can locate the call site without binary-searching
+  the source.
+
+## Checkpoints
+
+1. The reproducing program (`"alpha beta gamma" 0 variant.field-at`)
+   fails to compile with a type error pointing at the
+   `variant.field-at` call's line and column. Existing `union`/`match`
+   programs still type-check.
+2. The full integration test suite passes (`just ci`). All `variant.*`
+   call sites in stdlib (`json.seq`, generated `Make-X` /
+   `X-fieldname` words, etc.) continue to type-check.
+3. New negative tests in `crates/compiler/src/typechecker/tests.rs`
+   covering: `String → variant.field-at`, `Int → variant.tag`, plus
+   one per remaining `variant.*` op.
+4. (Part B) Spike: a hand-crafted always-panicking `.seq` program
+   produces a backtrace whose top Seq frame resolves to the correct
+   `.seq` file and line under option 1 (DWARF) or option 2 (TLS span),
+   *without* a measurable regression in the existing benchmarks
+   (`just bench` if it exists, otherwise a quick wall-clock on
+   `examples/projects/sss.seq`).
+5. No new permanent unsafe code; no new `#[allow]` attributes.


### PR DESCRIPTION
  - Negative case: "alpha beta gamma" 0 variant.field-at now produces a clear, line-numbered compile error: at line 4: variant.field-at: stack type mismatch. Expected (..a$0 Variant Int), got (..rest String Int).
  - Positive case: a real union Message { ... } program with Make-Get, is-Get?, Get-chan still compiles and runs correctly (exit 42).

  Summary of changes:
  - crates/compiler/src/types.rs — added Type::Variant arm + Display
  - crates/compiler/src/unification.rs — Variant ~ Variant and the Union(_) <: Variant relaxation rule, mirroring the existing Closure/Quotation pattern
  - crates/compiler/src/typechecker/{freshen,validation}.rs — covered the new arm
  - crates/compiler/src/builtins/macros.rs — Variant in the ty! macro
  - crates/compiler/src/builtins/adt.rs — all variant.* and wrap-* signatures now use Variant instead of free V
  - crates/lsp/src/completion.rs, crates/repl/src/ir/stack_effects.rs — display the new arm
  - crates/compiler/src/typechecker/tests.rs — 6 regression tests (5 negative, 1 positive)