### PR TITLE
UDP

### DIFF
--- a/crates/compiler/src/ast/program.rs
+++ b/crates/compiler/src/ast/program.rs
@@ -244,6 +244,11 @@ impl Program {
             "tcp.read",
             "tcp.write",
             "tcp.close",
+            // UDP operations
+            "udp.bind",
+            "udp.send-to",
+            "udp.receive-from",
+            "udp.close",
             // OS operations
             "os.getenv",
             "os.home-dir",

--- a/crates/compiler/src/builtins.rs
+++ b/crates/compiler/src/builtins.rs
@@ -26,6 +26,7 @@ mod os;
 mod stack;
 mod tcp;
 mod text;
+mod udp;
 
 #[cfg(test)]
 mod tests;
@@ -52,6 +53,7 @@ static BUILTIN_SIGNATURES: LazyLock<HashMap<String, Effect>> = LazyLock::new(|| 
     concurrency::add_signatures(&mut sigs);
     callable::add_signatures(&mut sigs);
     tcp::add_signatures(&mut sigs);
+    udp::add_signatures(&mut sigs);
     os::add_signatures(&mut sigs);
     text::add_signatures(&mut sigs);
     adt::add_signatures(&mut sigs);
@@ -81,6 +83,7 @@ static BUILTIN_DOCS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::n
     concurrency::add_docs(&mut docs);
     callable::add_docs(&mut docs);
     tcp::add_docs(&mut docs);
+    udp::add_docs(&mut docs);
     os::add_docs(&mut docs);
     text::add_docs(&mut docs);
     adt::add_docs(&mut docs);

--- a/crates/compiler/src/builtins/macros.rs
+++ b/crates/compiler/src/builtins/macros.rs
@@ -155,6 +155,14 @@ macro_rules! builtin {
     ($sigs:ident, $name:expr, (a $i1:tt -- a $o1:tt $o2:tt)) => {
         $sigs.insert($name.to_string(), Effect::new(stack!(a $i1), stack!(a $o1 $o2)));
     };
+    // (a T -- a U V W)
+    ($sigs:ident, $name:expr, (a $i1:tt -- a $o1:tt $o2:tt $o3:tt)) => {
+        $sigs.insert($name.to_string(), Effect::new(stack!(a $i1), stack!(a $o1 $o2 $o3)));
+    };
+    // (a T -- a U V W X)
+    ($sigs:ident, $name:expr, (a $i1:tt -- a $o1:tt $o2:tt $o3:tt $o4:tt)) => {
+        $sigs.insert($name.to_string(), Effect::new(stack!(a $i1), stack!(a $o1 $o2 $o3 $o4)));
+    };
     // (a T U -- a)
     ($sigs:ident, $name:expr, (a $i1:tt $i2:tt -- a)) => {
         $sigs.insert($name.to_string(), Effect::new(stack!(a $i1 $i2), stack!(a)));

--- a/crates/compiler/src/builtins/udp.rs
+++ b/crates/compiler/src/builtins/udp.rs
@@ -1,0 +1,46 @@
+//! UDP socket operations.
+
+use std::collections::HashMap;
+
+use crate::types::{Effect, StackType, Type};
+
+use super::macros::*;
+
+pub(super) fn add_signatures(sigs: &mut HashMap<String, Effect>) {
+    // =========================================================================
+    // UDP Operations
+    // =========================================================================
+    //
+    // Datagram-oriented; sockets are Int handles. Every word ends with a
+    // success Bool on top so callers can `[ ... ] [ ... ] if`.
+    //
+    // `udp.bind` returns three values: (socket, bound-port, success).
+    // The bound-port differs from the requested port only when the user
+    // passed 0 (let the OS pick); for non-zero requests the returned
+    // port equals the request.
+    builtin!(sigs, "udp.bind", (a Int -- a Int Int Bool));
+    builtin!(sigs, "udp.send-to", (a String String Int Int -- a Bool));
+    builtin!(sigs, "udp.receive-from", (a Int -- a String String Int Bool));
+    builtin!(sigs, "udp.close", (a Int -- a Bool));
+}
+
+pub(super) fn add_docs(docs: &mut HashMap<&'static str, &'static str>) {
+    docs.insert(
+        "udp.bind",
+        "Bind a UDP socket to a local port. ( port -- socket bound-port Bool ). \
+         port=0 lets the OS pick; bound-port is the actual assigned port. \
+         On failure pushes (0, 0, false).",
+    );
+    docs.insert(
+        "udp.send-to",
+        "Send a datagram to host:port from a bound socket. \
+         ( bytes host port socket -- Bool ).",
+    );
+    docs.insert(
+        "udp.receive-from",
+        "Receive one datagram (yields the strand). \
+         ( socket -- bytes host port Bool ). \
+         On failure pushes (\"\", \"\", 0, false).",
+    );
+    docs.insert("udp.close", "Release a UDP socket. ( socket -- Bool ).");
+}

--- a/crates/compiler/src/codegen/runtime.rs
+++ b/crates/compiler/src/codegen/runtime.rs
@@ -26,6 +26,7 @@ mod stdio;
 mod tcp;
 mod test_time;
 mod text;
+mod udp;
 
 use super::error::CodeGenError;
 use std::collections::HashMap;
@@ -53,6 +54,7 @@ pub static RUNTIME_DECLARATIONS: LazyLock<Vec<&'static RuntimeDecl>> = LazyLock:
         fs::DECLS,
         collections::DECLS,
         tcp::DECLS,
+        udp::DECLS,
         os::DECLS,
         text::DECLS,
         adt::DECLS,
@@ -79,6 +81,7 @@ pub static BUILTIN_SYMBOLS: LazyLock<HashMap<&'static str, &'static str>> = Lazy
         callable::SYMBOLS,
         closure::SYMBOLS,
         tcp::SYMBOLS,
+        udp::SYMBOLS,
         os::SYMBOLS,
         text::SYMBOLS,
         misc::SYMBOLS,

--- a/crates/compiler/src/codegen/runtime/udp.rs
+++ b/crates/compiler/src/codegen/runtime/udp.rs
@@ -1,0 +1,29 @@
+//! Runtime declarations for UDP socket operations.
+
+use super::RuntimeDecl;
+
+pub(super) static DECLS: &[RuntimeDecl] = &[
+    RuntimeDecl {
+        decl: "declare ptr @patch_seq_udp_bind(ptr)",
+        category: Some("; UDP operations"),
+    },
+    RuntimeDecl {
+        decl: "declare ptr @patch_seq_udp_send_to(ptr)",
+        category: None,
+    },
+    RuntimeDecl {
+        decl: "declare ptr @patch_seq_udp_receive_from(ptr)",
+        category: None,
+    },
+    RuntimeDecl {
+        decl: "declare ptr @patch_seq_udp_close(ptr)",
+        category: None,
+    },
+];
+
+pub(super) static SYMBOLS: &[(&str, &str)] = &[
+    ("udp.bind", "patch_seq_udp_bind"),
+    ("udp.send-to", "patch_seq_udp_send_to"),
+    ("udp.receive-from", "patch_seq_udp_receive_from"),
+    ("udp.close", "patch_seq_udp_close"),
+];

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -42,6 +42,7 @@ pub mod tcp_test;
 pub mod terminal;
 pub mod test;
 pub mod time_ops;
+pub mod udp;
 pub mod variant_ops;
 pub mod watchdog;
 pub mod weave;
@@ -247,6 +248,12 @@ pub use tcp::{
     patch_seq_tcp_accept as tcp_accept, patch_seq_tcp_close as tcp_close,
     patch_seq_tcp_listen as tcp_listen, patch_seq_tcp_read as tcp_read,
     patch_seq_tcp_write as tcp_write,
+};
+
+// UDP operations (exported for LLVM linking)
+pub use udp::{
+    patch_seq_udp_bind as udp_bind, patch_seq_udp_close as udp_close,
+    patch_seq_udp_receive_from as udp_receive_from, patch_seq_udp_send_to as udp_send_to,
 };
 
 // OS operations (exported for LLVM linking)

--- a/crates/runtime/src/udp.rs
+++ b/crates/runtime/src/udp.rs
@@ -1,0 +1,309 @@
+//! UDP Socket Operations for Seq
+//!
+//! Provides non-blocking UDP datagram operations using May's
+//! coroutine-aware I/O. `udp.receive-from` yields the strand
+//! while waiting for a datagram instead of blocking the OS thread.
+//!
+//! These functions are exported with C ABI for LLVM codegen.
+//!
+//! ## Byte-cleanliness limitation
+//!
+//! Payloads are carried as Seq `String` values, which are UTF-8 by
+//! invariant (`SeqString::as_str` uses `from_utf8_unchecked`). UDP
+//! send rejects nothing here, but a String can only have been
+//! constructed in the first place if it was valid UTF-8 — so the
+//! effective sendable payload is "any UTF-8 byte sequence." UDP
+//! receive validates the same way: non-UTF-8 datagrams are dropped
+//! with a `false` success flag.
+//!
+//! Most binary protocols (DNS records, NTP packets, OSC int32/float32
+//! arguments, multicast TLV) include bytes that aren't valid UTF-8.
+//! Closing this gap is tracked in
+//! `docs/design/STRING_BYTE_CLEANLINESS.md` — the OSC encoder phase
+//! of the live-coding POC is the canonical failing case that will
+//! drive that audit. UDP itself stays as-is.
+
+use crate::stack::{Stack, pop, push};
+use crate::value::Value;
+use may::net::UdpSocket;
+use std::sync::Mutex;
+
+// Maximum number of concurrent sockets to prevent unbounded growth.
+// Same cap as `tcp.rs`.
+const MAX_SOCKETS: usize = 10_000;
+
+// Maximum bytes to read per datagram. UDP datagrams are practically
+// limited to ~64 KB by the protocol; 1 MB is a generous ceiling that
+// matches `tcp.rs`'s `MAX_READ_SIZE` for consistency.
+const MAX_READ_SIZE: usize = 1_048_576;
+
+// Socket registry with ID reuse via free list.
+//
+// This is a deliberate copy of the registry in `tcp.rs`. The two will
+// be lifted into a shared `socket_registry` module once both are
+// landed and the right abstraction shape is obvious — TCP has a
+// listener/stream split and UDP doesn't, so forcing a generic
+// abstraction now risks the wrong shape.
+struct SocketRegistry<T> {
+    sockets: Vec<Option<T>>,
+    free_ids: Vec<usize>,
+}
+
+impl<T> SocketRegistry<T> {
+    const fn new() -> Self {
+        Self {
+            sockets: Vec::new(),
+            free_ids: Vec::new(),
+        }
+    }
+
+    fn allocate(&mut self, socket: T) -> Result<i64, &'static str> {
+        if let Some(id) = self.free_ids.pop() {
+            self.sockets[id] = Some(socket);
+            return Ok(id as i64);
+        }
+        if self.sockets.len() >= MAX_SOCKETS {
+            return Err("Maximum socket limit reached");
+        }
+        let id = self.sockets.len();
+        self.sockets.push(Some(socket));
+        Ok(id as i64)
+    }
+
+    fn get_mut(&mut self, id: usize) -> Option<&mut Option<T>> {
+        self.sockets.get_mut(id)
+    }
+
+    fn free(&mut self, id: usize) {
+        if let Some(slot) = self.sockets.get_mut(id)
+            && slot.is_some()
+        {
+            *slot = None;
+            self.free_ids.push(id);
+        }
+    }
+}
+
+static SOCKETS: Mutex<SocketRegistry<UdpSocket>> = Mutex::new(SocketRegistry::new());
+
+/// Bind a UDP socket to a local port.
+///
+/// Stack effect: ( port -- socket bound-port Bool )
+///
+/// Binds to `0.0.0.0:port`. `port=0` lets the OS pick a free port; the
+/// returned `bound-port` is the actual bound port (equal to `port` if
+/// non-zero). On failure pushes `(0, 0, false)`.
+///
+/// # Safety
+/// Stack must have an Int (port) on top.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_udp_bind(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, port_val) = pop(stack);
+        let port = match port_val {
+            Value::Int(p) => p,
+            _ => return push_bind_failure(stack),
+        };
+
+        if !(0..=65535).contains(&port) {
+            return push_bind_failure(stack);
+        }
+
+        let addr = format!("0.0.0.0:{}", port);
+        let socket = match UdpSocket::bind(&addr) {
+            Ok(s) => s,
+            Err(_) => return push_bind_failure(stack),
+        };
+
+        // Capture the actual bound port before the registry takes ownership.
+        let bound_port = match socket.local_addr() {
+            Ok(addr) => addr.port() as i64,
+            Err(_) => return push_bind_failure(stack),
+        };
+
+        let mut sockets = SOCKETS.lock().unwrap();
+        match sockets.allocate(socket) {
+            Ok(socket_id) => {
+                let stack = push(stack, Value::Int(socket_id));
+                let stack = push(stack, Value::Int(bound_port));
+                push(stack, Value::Bool(true))
+            }
+            Err(_) => push_bind_failure(stack),
+        }
+    }
+}
+
+unsafe fn push_bind_failure(stack: Stack) -> Stack {
+    unsafe {
+        let stack = push(stack, Value::Int(0));
+        let stack = push(stack, Value::Int(0));
+        push(stack, Value::Bool(false))
+    }
+}
+
+/// Send a datagram to a host:port from a bound UDP socket.
+///
+/// Stack effect: ( bytes host port socket -- Bool )
+///
+/// Pops `socket`, `port`, `host`, `bytes` (in that order, so `bytes`
+/// is below all of them on entry). Returns `false` on type mismatch,
+/// invalid socket, address-resolution failure, or send error.
+///
+/// # Safety
+/// Stack must have Int (socket), Int (port), String (host),
+/// String (bytes) — top-down — on entry.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_udp_send_to(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, socket_val) = pop(stack);
+        let socket_id = match socket_val {
+            Value::Int(id) => id as usize,
+            _ => return push(stack, Value::Bool(false)),
+        };
+
+        let (stack, port_val) = pop(stack);
+        let port = match port_val {
+            Value::Int(p) if (0..=65535).contains(&p) => p,
+            _ => return push(stack, Value::Bool(false)),
+        };
+
+        let (stack, host_val) = pop(stack);
+        let host = match host_val {
+            Value::String(s) => s,
+            _ => return push(stack, Value::Bool(false)),
+        };
+
+        let (stack, bytes_val) = pop(stack);
+        let bytes = match bytes_val {
+            Value::String(s) => s,
+            _ => return push(stack, Value::Bool(false)),
+        };
+
+        // Pull the socket out of the registry so we don't hold the lock during I/O.
+        let socket = {
+            let mut sockets = SOCKETS.lock().unwrap();
+            match sockets.get_mut(socket_id).and_then(|slot| slot.take()) {
+                Some(s) => s,
+                None => return push(stack, Value::Bool(false)),
+            }
+        };
+
+        let addr = format!("{}:{}", host.as_str(), port);
+        let result = socket.send_to(bytes.as_str().as_bytes(), &addr);
+
+        // Restore the socket regardless of send result.
+        {
+            let mut sockets = SOCKETS.lock().unwrap();
+            if let Some(slot) = sockets.get_mut(socket_id) {
+                *slot = Some(socket);
+            }
+        }
+
+        push(stack, Value::Bool(result.is_ok()))
+    }
+}
+
+/// Receive one datagram from a UDP socket.
+///
+/// Stack effect: ( socket -- bytes host port Bool )
+///
+/// Yields the strand until a datagram arrives. On failure pushes
+/// `("", "", 0, false)` — invalid socket, recv error, datagram larger
+/// than `MAX_READ_SIZE`, or non-UTF-8 payload (see module doc).
+///
+/// # Safety
+/// Stack must have an Int (socket) on top.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_udp_receive_from(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, socket_val) = pop(stack);
+        let socket_id = match socket_val {
+            Value::Int(id) => id as usize,
+            _ => return push_receive_failure(stack),
+        };
+
+        let socket = {
+            let mut sockets = SOCKETS.lock().unwrap();
+            match sockets.get_mut(socket_id).and_then(|slot| slot.take()) {
+                Some(s) => s,
+                None => return push_receive_failure(stack),
+            }
+        };
+
+        let mut buffer = vec![0u8; MAX_READ_SIZE];
+        let recv_result = socket.recv_from(&mut buffer);
+
+        {
+            let mut sockets = SOCKETS.lock().unwrap();
+            if let Some(slot) = sockets.get_mut(socket_id) {
+                *slot = Some(socket);
+            }
+        }
+
+        let (size, src) = match recv_result {
+            Ok(pair) => pair,
+            Err(_) => return push_receive_failure(stack),
+        };
+
+        buffer.truncate(size);
+        let payload = match String::from_utf8(buffer) {
+            Ok(s) => s,
+            Err(_) => return push_receive_failure(stack),
+        };
+
+        let stack = push(stack, Value::String(payload.into()));
+        let stack = push(stack, Value::String(src.ip().to_string().into()));
+        let stack = push(stack, Value::Int(src.port() as i64));
+        push(stack, Value::Bool(true))
+    }
+}
+
+unsafe fn push_receive_failure(stack: Stack) -> Stack {
+    unsafe {
+        let stack = push(stack, Value::String("".into()));
+        let stack = push(stack, Value::String("".into()));
+        let stack = push(stack, Value::Int(0));
+        push(stack, Value::Bool(false))
+    }
+}
+
+/// Close a UDP socket and free its handle.
+///
+/// Stack effect: ( socket -- Bool )
+///
+/// Returns `true` if the socket existed (and is now closed), `false`
+/// if the handle was already invalid.
+///
+/// # Safety
+/// Stack must have an Int (socket) on top.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn patch_seq_udp_close(stack: Stack) -> Stack {
+    unsafe {
+        let (stack, socket_val) = pop(stack);
+        let socket_id = match socket_val {
+            Value::Int(id) => id as usize,
+            _ => return push(stack, Value::Bool(false)),
+        };
+
+        let mut sockets = SOCKETS.lock().unwrap();
+        let existed = sockets
+            .get_mut(socket_id)
+            .map(|slot| slot.is_some())
+            .unwrap_or(false);
+
+        if existed {
+            sockets.free(socket_id);
+        }
+
+        push(stack, Value::Bool(existed))
+    }
+}
+
+// Public re-exports with short names for internal use.
+pub use patch_seq_udp_bind as udp_bind;
+pub use patch_seq_udp_close as udp_close;
+pub use patch_seq_udp_receive_from as udp_receive_from;
+pub use patch_seq_udp_send_to as udp_send_to;
+
+#[cfg(test)]
+mod tests;

--- a/crates/runtime/src/udp.rs
+++ b/crates/runtime/src/udp.rs
@@ -26,7 +26,7 @@
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 use may::net::UdpSocket;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 // Maximum number of concurrent sockets to prevent unbounded growth.
 // Same cap as `tcp.rs`.
@@ -46,13 +46,30 @@ const MAX_READ_SIZE: usize = 65_536;
 
 // Socket registry with ID reuse via free list.
 //
-// This is a deliberate copy of the registry in `tcp.rs`. The two will
-// be lifted into a shared `socket_registry` module once both are
-// landed and the right abstraction shape is obvious — TCP has a
-// listener/stream split and UDP doesn't, so forcing a generic
-// abstraction now risks the wrong shape.
+// Slots hold `Arc<UdpSocket>` rather than the socket directly. Reasons:
+//
+// - `may::net::UdpSocket`'s I/O methods (`send_to`, `recv_from`,
+//   `local_addr`) all take `&self`, so multiple `Arc` clones across
+//   strands are safe without any further synchronisation.
+//
+// - I/O paths clone the `Arc` out of the registry under the lock, then
+//   drop the lock before doing the syscall. This is what the previous
+//   `take()`-and-restore pattern was reaching for, but with `Arc` we
+//   avoid the close-vs-in-flight race: `close` simply sets the slot to
+//   `None` (and frees the id) regardless of whether other strands
+//   currently hold an `Arc` clone. The in-flight strand's clone keeps
+//   the OS socket alive until its `recv_from` / `send_to` returns; the
+//   OS-level close only happens when the last `Arc` drops.
+//
+// - The id bookkeeping is now correct under all races: every successful
+//   `close` pushes the id to `free_ids`, even if the slot was being
+//   used for I/O.
+//
+// `tcp.rs` keeps the take-and-restore pattern because `TcpStream::read`
+// is `&mut self` — multiple strands cannot share a TcpStream the same
+// way. UDP's `&self`-only API is what makes the cleaner shape possible.
 struct SocketRegistry<T> {
-    sockets: Vec<Option<T>>,
+    sockets: Vec<Option<Arc<T>>>,
     free_ids: Vec<usize>,
 }
 
@@ -65,6 +82,7 @@ impl<T> SocketRegistry<T> {
     }
 
     fn allocate(&mut self, socket: T) -> Result<i64, &'static str> {
+        let socket = Arc::new(socket);
         if let Some(id) = self.free_ids.pop() {
             self.sockets[id] = Some(socket);
             return Ok(id as i64);
@@ -77,17 +95,26 @@ impl<T> SocketRegistry<T> {
         Ok(id as i64)
     }
 
-    fn get_mut(&mut self, id: usize) -> Option<&mut Option<T>> {
-        self.sockets.get_mut(id)
+    /// Clone the `Arc` out of the slot so the caller can do I/O after
+    /// dropping the registry lock. Returns `None` if the slot is empty
+    /// (handle invalid, out of range, or already closed).
+    fn checkout(&self, id: usize) -> Option<Arc<T>> {
+        self.sockets.get(id).and_then(|slot| slot.clone())
     }
 
-    fn free(&mut self, id: usize) {
+    /// Drop the slot's `Arc`. Returns whether the slot held a socket
+    /// (i.e. whether the close had any effect). Idempotent: a second
+    /// close on the same id returns `false`. Independent of any
+    /// in-flight I/O — those strands hold their own `Arc` clones.
+    fn free(&mut self, id: usize) -> bool {
         if let Some(slot) = self.sockets.get_mut(id)
             && slot.is_some()
         {
             *slot = None;
             self.free_ids.push(id);
+            return true;
         }
+        false
     }
 }
 
@@ -190,10 +217,13 @@ pub unsafe extern "C" fn patch_seq_udp_send_to(stack: Stack) -> Stack {
             _ => return push(stack, Value::Bool(false)),
         };
 
-        // Pull the socket out of the registry so we don't hold the lock during I/O.
+        // Clone the Arc<UdpSocket> out of the registry. We don't hold
+        // the lock across the syscall, and a concurrent `close` is
+        // free to drop the registry's slot reference — our clone keeps
+        // the socket alive for the duration of this send.
         let socket = {
-            let mut sockets = SOCKETS.lock().unwrap();
-            match sockets.get_mut(socket_id).and_then(|slot| slot.take()) {
+            let sockets = SOCKETS.lock().unwrap();
+            match sockets.checkout(socket_id) {
                 Some(s) => s,
                 None => return push(stack, Value::Bool(false)),
             }
@@ -201,15 +231,6 @@ pub unsafe extern "C" fn patch_seq_udp_send_to(stack: Stack) -> Stack {
 
         let addr = format!("{}:{}", host.as_str(), port);
         let result = socket.send_to(bytes.as_str().as_bytes(), &addr);
-
-        // Restore the socket regardless of send result.
-        {
-            let mut sockets = SOCKETS.lock().unwrap();
-            if let Some(slot) = sockets.get_mut(socket_id) {
-                *slot = Some(socket);
-            }
-        }
-
         push(stack, Value::Bool(result.is_ok()))
     }
 }
@@ -233,9 +254,13 @@ pub unsafe extern "C" fn patch_seq_udp_receive_from(stack: Stack) -> Stack {
             _ => return push_receive_failure(stack),
         };
 
+        // Clone the Arc<UdpSocket> out of the registry. The receive
+        // strand keeps the socket alive even if another strand closes
+        // the handle while we're in `recv_from`. When close drops the
+        // registry's clone and ours returns, the OS-level close fires.
         let socket = {
-            let mut sockets = SOCKETS.lock().unwrap();
-            match sockets.get_mut(socket_id).and_then(|slot| slot.take()) {
+            let sockets = SOCKETS.lock().unwrap();
+            match sockets.checkout(socket_id) {
                 Some(s) => s,
                 None => return push_receive_failure(stack),
             }
@@ -243,13 +268,6 @@ pub unsafe extern "C" fn patch_seq_udp_receive_from(stack: Stack) -> Stack {
 
         let mut buffer = vec![0u8; MAX_READ_SIZE];
         let recv_result = socket.recv_from(&mut buffer);
-
-        {
-            let mut sockets = SOCKETS.lock().unwrap();
-            if let Some(slot) = sockets.get_mut(socket_id) {
-                *slot = Some(socket);
-            }
-        }
 
         let (size, src) = match recv_result {
             Ok(pair) => pair,
@@ -282,23 +300,17 @@ unsafe fn push_receive_failure(stack: Stack) -> Stack {
 ///
 /// Stack effect: ( socket -- Bool )
 ///
-/// Returns `true` if the socket existed (and is now closed), `false`
-/// if the handle was already invalid.
+/// Returns `true` if the handle was open (the registry slot held a
+/// socket), `false` if it was already invalid (never allocated, or
+/// previously closed). Idempotent across redundant calls on the same
+/// id.
 ///
-/// ## Race with in-flight I/O
-///
-/// `send_to` and `receive_from` use a take-and-restore pattern: they
-/// remove the socket from the registry while running I/O, so the
-/// registry lock isn't held across syscalls. If a strand calls
-/// `close` on a handle whose socket is currently *taken* by another
-/// strand's in-flight I/O, the slot looks empty (`is_some()` is
-/// `false`), and `close` returns `false` as if the handle were
-/// invalid — even though the I/O strand will restore the socket
-/// moments later. This matches `tcp_close`'s behaviour and is
-/// considered acceptable for the current concurrency model: callers
-/// shouldn't be racing close against I/O on the same handle. If we
-/// ever support that pattern, the registry needs a richer state
-/// machine (taken-but-marked-for-close).
+/// Concurrent I/O is safe: any strand mid-`send_to` / `recv_from`
+/// holds its own `Arc<UdpSocket>` clone, so closing the registry slot
+/// from another strand only drops the registry's reference. The
+/// in-flight syscall completes; the OS-level close fires when the
+/// last `Arc` is dropped. The id is recycled to the free list as
+/// soon as `close` returns, regardless of any in-flight strand.
 ///
 /// # Safety
 /// Stack must have an Int (socket) on top.
@@ -312,15 +324,7 @@ pub unsafe extern "C" fn patch_seq_udp_close(stack: Stack) -> Stack {
         };
 
         let mut sockets = SOCKETS.lock().unwrap();
-        let existed = sockets
-            .get_mut(socket_id)
-            .map(|slot| slot.is_some())
-            .unwrap_or(false);
-
-        if existed {
-            sockets.free(socket_id);
-        }
-
+        let existed = sockets.free(socket_id);
         push(stack, Value::Bool(existed))
     }
 }

--- a/crates/runtime/src/udp.rs
+++ b/crates/runtime/src/udp.rs
@@ -32,10 +32,17 @@ use std::sync::Mutex;
 // Same cap as `tcp.rs`.
 const MAX_SOCKETS: usize = 10_000;
 
-// Maximum bytes to read per datagram. UDP datagrams are practically
-// limited to ~64 KB by the protocol; 1 MB is a generous ceiling that
-// matches `tcp.rs`'s `MAX_READ_SIZE` for consistency.
-const MAX_READ_SIZE: usize = 1_048_576;
+// Maximum bytes to read per datagram.
+//
+// UDP datagrams are protocol-capped at 65,507 bytes for IPv4 (the
+// `udp.length` header is 16-bit, minus IP+UDP headers), and 65,535
+// for IPv6 base-headered datagrams. We use the next power of two
+// (65,536) as the receive buffer size — anything larger cannot
+// arrive on the wire, so allocating more would be pure waste.
+//
+// This intentionally diverges from `tcp.rs`'s 1 MB cap, which makes
+// sense for streaming reads but not for one-datagram-per-call recv.
+const MAX_READ_SIZE: usize = 65_536;
 
 // Socket registry with ID reuse via free list.
 //
@@ -156,8 +163,12 @@ unsafe fn push_bind_failure(stack: Stack) -> Stack {
 pub unsafe extern "C" fn patch_seq_udp_send_to(stack: Stack) -> Stack {
     unsafe {
         let (stack, socket_val) = pop(stack);
+        // Reject negative ids before the `as usize` cast: a negative
+        // i64 wraps to usize::MAX, which would silently fall through
+        // to a benign `None` lookup. Catching it here is a clearer
+        // signal than the indirect not-found path.
         let socket_id = match socket_val {
-            Value::Int(id) => id as usize,
+            Value::Int(id) if id >= 0 => id as usize,
             _ => return push(stack, Value::Bool(false)),
         };
 
@@ -218,7 +229,7 @@ pub unsafe extern "C" fn patch_seq_udp_receive_from(stack: Stack) -> Stack {
     unsafe {
         let (stack, socket_val) = pop(stack);
         let socket_id = match socket_val {
-            Value::Int(id) => id as usize,
+            Value::Int(id) if id >= 0 => id as usize,
             _ => return push_receive_failure(stack),
         };
 
@@ -274,6 +285,21 @@ unsafe fn push_receive_failure(stack: Stack) -> Stack {
 /// Returns `true` if the socket existed (and is now closed), `false`
 /// if the handle was already invalid.
 ///
+/// ## Race with in-flight I/O
+///
+/// `send_to` and `receive_from` use a take-and-restore pattern: they
+/// remove the socket from the registry while running I/O, so the
+/// registry lock isn't held across syscalls. If a strand calls
+/// `close` on a handle whose socket is currently *taken* by another
+/// strand's in-flight I/O, the slot looks empty (`is_some()` is
+/// `false`), and `close` returns `false` as if the handle were
+/// invalid — even though the I/O strand will restore the socket
+/// moments later. This matches `tcp_close`'s behaviour and is
+/// considered acceptable for the current concurrency model: callers
+/// shouldn't be racing close against I/O on the same handle. If we
+/// ever support that pattern, the registry needs a richer state
+/// machine (taken-but-marked-for-close).
+///
 /// # Safety
 /// Stack must have an Int (socket) on top.
 #[unsafe(no_mangle)]
@@ -281,7 +307,7 @@ pub unsafe extern "C" fn patch_seq_udp_close(stack: Stack) -> Stack {
     unsafe {
         let (stack, socket_val) = pop(stack);
         let socket_id = match socket_val {
-            Value::Int(id) => id as usize,
+            Value::Int(id) if id >= 0 => id as usize,
             _ => return push(stack, Value::Bool(false)),
         };
 
@@ -299,7 +325,9 @@ pub unsafe extern "C" fn patch_seq_udp_close(stack: Stack) -> Stack {
     }
 }
 
-// Public re-exports with short names for internal use.
+// Public re-exports with short names for in-module callers — the
+// `tests` submodule below imports them via `use super::*`. The
+// crate-root re-exports in `lib.rs` are the linker-facing aliases.
 pub use patch_seq_udp_bind as udp_bind;
 pub use patch_seq_udp_close as udp_close;
 pub use patch_seq_udp_receive_from as udp_receive_from;

--- a/crates/runtime/src/udp/tests.rs
+++ b/crates/runtime/src/udp/tests.rs
@@ -1,0 +1,214 @@
+use super::*;
+use crate::arithmetic::push_int;
+use crate::scheduler::scheduler_init;
+
+/// Helper: bind a UDP socket on `0.0.0.0:port`, return `(socket_id, bound_port)`.
+/// Asserts success.
+unsafe fn bind_succeeds(port: i64) -> (i64, i64) {
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, port);
+        let stack = udp_bind(stack);
+
+        let (stack, success) = pop(stack);
+        assert!(
+            matches!(success, Value::Bool(true)),
+            "udp.bind({}) should succeed",
+            port
+        );
+        let (stack, bound_port_v) = pop(stack);
+        let bound_port = match bound_port_v {
+            Value::Int(p) => p,
+            other => panic!("expected bound-port Int, got {:?}", other),
+        };
+        let (_, socket_v) = pop(stack);
+        let socket_id = match socket_v {
+            Value::Int(s) => s,
+            other => panic!("expected socket Int, got {:?}", other),
+        };
+        (socket_id, bound_port)
+    }
+}
+
+#[test]
+fn test_udp_bind_returns_assigned_port() {
+    unsafe {
+        scheduler_init();
+
+        // port=0 lets the OS pick — we must get back a non-zero bound port.
+        let (socket_id, bound_port) = bind_succeeds(0);
+        assert!(socket_id >= 0, "socket id should be non-negative");
+        assert!(
+            bound_port > 0,
+            "OS-assigned bound port should be non-zero, got {}",
+            bound_port
+        );
+    }
+}
+
+#[test]
+fn test_udp_bind_invalid_port_negative() {
+    unsafe {
+        scheduler_init();
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, -1);
+        let stack = udp_bind(stack);
+
+        // (0, 0, false)
+        let (stack, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(false)));
+        let (stack, bound_port) = pop(stack);
+        assert!(matches!(bound_port, Value::Int(0)));
+        let (_, socket) = pop(stack);
+        assert!(matches!(socket, Value::Int(0)));
+    }
+}
+
+#[test]
+fn test_udp_bind_invalid_port_too_high() {
+    unsafe {
+        scheduler_init();
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, 65536);
+        let stack = udp_bind(stack);
+
+        let (stack, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(false)));
+        let (stack, bound_port) = pop(stack);
+        assert!(matches!(bound_port, Value::Int(0)));
+        let (_, socket) = pop(stack);
+        assert!(matches!(socket, Value::Int(0)));
+    }
+}
+
+#[test]
+fn test_udp_loopback_round_trip() {
+    // Bind socket A on 127.0.0.1:0 (OS-assigned port).
+    // Bind socket B on 127.0.0.1:0 (sender side).
+    // From B, send a payload to 127.0.0.1:<A's bound port>.
+    // From A, receive — assert byte-exact match including source port == B's port.
+    unsafe {
+        scheduler_init();
+
+        let (sock_a, port_a) = bind_succeeds(0);
+        let (sock_b, port_b) = bind_succeeds(0);
+        assert_ne!(port_a, port_b, "A and B should have different ports");
+
+        // udp.send-to: ( bytes host port socket -- Bool )
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String("hello".into()));
+        let stack = push(stack, Value::String("127.0.0.1".into()));
+        let stack = push_int(stack, port_a);
+        let stack = push_int(stack, sock_b);
+        let stack = udp_send_to(stack);
+        let (_, send_success) = pop(stack);
+        assert!(
+            matches!(send_success, Value::Bool(true)),
+            "send-to should succeed"
+        );
+
+        // udp.receive-from: ( socket -- bytes host port Bool )
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, sock_a);
+        let stack = udp_receive_from(stack);
+
+        let (stack, recv_success) = pop(stack);
+        assert!(
+            matches!(recv_success, Value::Bool(true)),
+            "receive-from should succeed"
+        );
+        let (stack, src_port) = pop(stack);
+        assert!(
+            matches!(src_port, Value::Int(p) if p == port_b),
+            "source port should be B's bound port {}, got {:?}",
+            port_b,
+            src_port
+        );
+        let (stack, src_host) = pop(stack);
+        match src_host {
+            Value::String(s) => assert_eq!(s.as_str(), "127.0.0.1"),
+            other => panic!("expected source host, got {:?}", other),
+        }
+        let (_, payload) = pop(stack);
+        match payload {
+            Value::String(s) => assert_eq!(s.as_str(), "hello"),
+            other => panic!("expected payload, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_udp_send_to_invalid_socket() {
+    unsafe {
+        scheduler_init();
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String("hi".into()));
+        let stack = push(stack, Value::String("127.0.0.1".into()));
+        let stack = push_int(stack, 9999);
+        let stack = push_int(stack, 99_999); // invalid socket id
+        let stack = udp_send_to(stack);
+
+        let (_, success) = pop(stack);
+        assert!(
+            matches!(success, Value::Bool(false)),
+            "send-to on invalid socket should return false"
+        );
+    }
+}
+
+#[test]
+fn test_udp_receive_from_invalid_socket() {
+    unsafe {
+        scheduler_init();
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, 99_999);
+        let stack = udp_receive_from(stack);
+
+        // ("", "", 0, false)
+        let (stack, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(false)));
+        let (stack, port) = pop(stack);
+        assert!(matches!(port, Value::Int(0)));
+        let (stack, host) = pop(stack);
+        match host {
+            Value::String(s) => assert_eq!(s.as_str(), ""),
+            other => panic!("expected empty host, got {:?}", other),
+        }
+        let (_, bytes) = pop(stack);
+        match bytes {
+            Value::String(s) => assert_eq!(s.as_str(), ""),
+            other => panic!("expected empty bytes, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_udp_close_idempotent() {
+    unsafe {
+        scheduler_init();
+
+        // Bind, then close — should succeed.
+        let (sock, _) = bind_succeeds(0);
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, sock);
+        let stack = udp_close(stack);
+        let (_, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(true)));
+
+        // Closing an already-closed/invalid socket returns false.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, 99_999);
+        let stack = udp_close(stack);
+        let (_, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(false)));
+    }
+}
+
+#[test]
+fn test_udp_socket_registry_constants() {
+    // Documents the limits — same shape as `tcp::tests`.
+    assert_eq!(MAX_SOCKETS, 10_000);
+    assert_eq!(MAX_READ_SIZE, 1_048_576);
+}

--- a/crates/runtime/src/udp/tests.rs
+++ b/crates/runtime/src/udp/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::arithmetic::push_int;
 use crate::scheduler::scheduler_init;
+use may::net::UdpSocket as MayUdpSocket;
 
 /// Helper: bind a UDP socket on `0.0.0.0:port`, return `(socket_id, bound_port)`.
 /// Asserts success.
@@ -185,21 +186,52 @@ fn test_udp_receive_from_invalid_socket() {
 }
 
 #[test]
-fn test_udp_close_idempotent() {
+fn test_udp_close_double_close() {
     unsafe {
         scheduler_init();
 
-        // Bind, then close — should succeed.
+        // Bind, close — should succeed.
         let (sock, _) = bind_succeeds(0);
         let stack = crate::stack::alloc_test_stack();
         let stack = push_int(stack, sock);
         let stack = udp_close(stack);
         let (_, success) = pop(stack);
-        assert!(matches!(success, Value::Bool(true)));
+        assert!(
+            matches!(success, Value::Bool(true)),
+            "first close on a valid handle should succeed"
+        );
 
-        // Closing an already-closed/invalid socket returns false.
+        // Closing the *same* handle a second time returns false. The id
+        // may eventually be reused for a different socket via the free
+        // list, but until that happens the slot is None and close is a
+        // no-op.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, sock);
+        let stack = udp_close(stack);
+        let (_, success) = pop(stack);
+        assert!(
+            matches!(success, Value::Bool(false)),
+            "double-close on the same handle should return false"
+        );
+    }
+}
+
+#[test]
+fn test_udp_close_invalid_handle() {
+    unsafe {
+        scheduler_init();
+
+        // A handle that was never allocated returns false.
         let stack = crate::stack::alloc_test_stack();
         let stack = push_int(stack, 99_999);
+        let stack = udp_close(stack);
+        let (_, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(false)));
+
+        // Negative id is rejected before the `as usize` cast (would
+        // otherwise wrap to usize::MAX and benignly miss).
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, -1);
         let stack = udp_close(stack);
         let (_, success) = pop(stack);
         assert!(matches!(success, Value::Bool(false)));
@@ -207,8 +239,121 @@ fn test_udp_close_idempotent() {
 }
 
 #[test]
+fn test_udp_receive_from_rejects_non_utf8() {
+    // Documented behaviour: payloads must be valid UTF-8 because they
+    // come back as Seq Strings, and `SeqString` invariant requires
+    // UTF-8. Verify a datagram with invalid byte sequences is dropped
+    // with the standard failure tuple.
+    //
+    // Bypass `udp_send_to` (which would round-trip through a Seq
+    // String and so could not carry invalid bytes) and use
+    // `may::net::UdpSocket` directly to inject the raw bytes.
+    unsafe {
+        scheduler_init();
+
+        let (recv_sock_id, recv_port) = bind_succeeds(0);
+
+        let sender = MayUdpSocket::bind("0.0.0.0:0").expect("sender bind");
+        // 0xFF is never a valid UTF-8 start byte; this whole datagram
+        // is unambiguously invalid.
+        let payload: &[u8] = &[0xFF, 0xFE, b'x', 0xC0];
+        sender
+            .send_to(payload, format!("127.0.0.1:{}", recv_port))
+            .expect("raw send");
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, recv_sock_id);
+        let stack = udp_receive_from(stack);
+
+        // Failure tuple: ( "" "" 0 false )
+        let (stack, success) = pop(stack);
+        assert!(
+            matches!(success, Value::Bool(false)),
+            "non-UTF-8 datagram should produce false success"
+        );
+        let (stack, port) = pop(stack);
+        assert!(matches!(port, Value::Int(0)));
+        let (stack, host) = pop(stack);
+        match host {
+            Value::String(s) => assert_eq!(s.as_str(), ""),
+            other => panic!("expected empty host, got {:?}", other),
+        }
+        let (_, bytes) = pop(stack);
+        match bytes {
+            Value::String(s) => assert_eq!(s.as_str(), ""),
+            other => panic!("expected empty bytes, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn test_udp_receive_from_yields_strand() {
+    // Design doc Checkpoint 3: a strand blocked in `receive_from`
+    // must yield its OS thread so other strands can run.
+    //
+    // We spawn a strand that immediately blocks on `recv_from`. From
+    // the test thread we wait briefly, send a datagram that wakes
+    // it, and join. If `recv_from` were blocking the OS thread, the
+    // test thread couldn't make forward progress between spawning
+    // and joining (may shares a single OS thread by default in
+    // tests). The fact that this test completes within the timeout
+    // is the assertion.
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+
+    unsafe {
+        scheduler_init();
+
+        let (recv_sock_id, recv_port) = bind_succeeds(0);
+        let received = Arc::new(AtomicBool::new(false));
+        let received_clone = Arc::clone(&received);
+
+        let handle = may::go!(move || {
+            let stack = crate::stack::alloc_test_stack();
+            let stack = push_int(stack, recv_sock_id);
+            let stack = udp_receive_from(stack);
+            let (_stack, success) = pop(stack);
+            if matches!(success, Value::Bool(true)) {
+                received_clone.store(true, Ordering::SeqCst);
+            }
+        });
+
+        // Give the receive-strand a window to run and reach the block.
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Sender uses raw may UdpSocket — same yield contract.
+        let sender = MayUdpSocket::bind("0.0.0.0:0").expect("sender bind");
+        sender
+            .send_to(b"wake-up", format!("127.0.0.1:{}", recv_port))
+            .expect("send");
+
+        // Wait (with a hard deadline) for the receive strand to
+        // observe the datagram. If recv_from were blocking the OS
+        // thread, the may scheduler couldn't schedule the strand
+        // back in and this would time out.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && !received.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        handle.join().expect("strand panicked");
+        assert!(
+            received.load(Ordering::SeqCst),
+            "receive strand never observed the datagram — recv_from may have pinned the OS thread"
+        );
+    }
+}
+
+#[test]
 fn test_udp_socket_registry_constants() {
-    // Documents the limits — same shape as `tcp::tests`.
+    // Documents the limits.
+    //
+    // MAX_SOCKETS matches `tcp::MAX_SOCKETS`. MAX_READ_SIZE
+    // intentionally diverges from TCP: UDP datagrams are protocol-
+    // capped at 65,507 bytes (IPv4) / 65,535 bytes (IPv6 base), so we
+    // size the recv buffer to the next power of two and not the 1 MB
+    // streaming-read cap TCP uses.
     assert_eq!(MAX_SOCKETS, 10_000);
-    assert_eq!(MAX_READ_SIZE, 1_048_576);
+    assert_eq!(MAX_READ_SIZE, 65_536);
 }

--- a/crates/runtime/src/udp/tests.rs
+++ b/crates/runtime/src/udp/tests.rs
@@ -320,6 +320,25 @@ fn test_udp_receive_from_yields_strand() {
         });
 
         // Give the receive-strand a window to run and reach the block.
+        //
+        // This sleep is a heuristic, not a synchronisation primitive —
+        // we cannot reliably know that the spawned strand has *entered*
+        // the blocking poll inside recv_from from outside it. A
+        // signal-before-blocking primitive (mpsc, Barrier) would only
+        // assert the strand is *about* to call recv_from, not that it
+        // has yielded.
+        //
+        // The kernel UDP buffer is the safety net: even if our
+        // datagram arrives before the strand reaches recv_from, the
+        // datagram is buffered and the eventual recv_from picks it up.
+        // So this test is conservative — it asserts forward progress
+        // (the strand wakes, the test completes within the deadline)
+        // rather than the strict "recv_from yielded the OS thread"
+        // claim. That stricter claim is what the may UdpSocket
+        // implementation guarantees by construction (see
+        // `may::net::udp::UdpSocket::recv_from` — it dispatches via
+        // `yield_with_io` when the non-blocking syscall returns
+        // EAGAIN), and we trust that here rather than re-prove it.
         std::thread::sleep(Duration::from_millis(50));
 
         // Sender uses raw may UdpSocket — same yield contract.
@@ -342,6 +361,87 @@ fn test_udp_receive_from_yields_strand() {
             received.load(Ordering::SeqCst),
             "receive strand never observed the datagram — recv_from may have pinned the OS thread"
         );
+    }
+}
+
+#[test]
+fn test_udp_close_during_in_flight_recv() {
+    // The close-vs-in-flight-I/O race that motivated moving the
+    // registry to Arc<UdpSocket>. Before the fix, close() during a
+    // strand's in-flight recv_from would (a) return false even though
+    // the user's intent was clearly to close, (b) leave the id leaked
+    // on the free list, and (c) restore the socket back into the slot
+    // when the recv strand finished, undoing the close.
+    //
+    // After the fix:
+    // - close() returns true immediately (drops the registry's Arc).
+    // - The id is freed and immediately recyclable.
+    // - The in-flight strand's Arc keeps the OS socket alive until its
+    //   recv_from returns; we wake it with a datagram.
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+
+    unsafe {
+        scheduler_init();
+
+        let (sock_id, port) = bind_succeeds(0);
+        let recv_done = Arc::new(AtomicBool::new(false));
+        let recv_done_clone = Arc::clone(&recv_done);
+
+        // Strand A: block in recv_from. Holds an Arc<UdpSocket> via the
+        // checkout path inside udp_receive_from.
+        let handle = may::go!(move || {
+            let stack = crate::stack::alloc_test_stack();
+            let stack = push_int(stack, sock_id);
+            let _ = udp_receive_from(stack);
+            recv_done_clone.store(true, Ordering::SeqCst);
+        });
+
+        // Give the recv strand time to enter recv_from.
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Main thread closes the socket. With the Arc fix this returns
+        // true even though strand A still holds a clone.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, sock_id);
+        let stack = udp_close(stack);
+        let (_, close_success) = pop(stack);
+        assert!(
+            matches!(close_success, Value::Bool(true)),
+            "close during in-flight recv should return true (registry slot was occupied)"
+        );
+
+        // The recv strand is still blocked — its Arc keeps the OS
+        // socket alive. Wake it with a datagram so it can exit.
+        let waker = MayUdpSocket::bind("0.0.0.0:0").expect("waker bind");
+        waker
+            .send_to(b"wake", format!("127.0.0.1:{}", port))
+            .expect("waker send");
+
+        // Wait for the recv strand to finish (it will, because we just
+        // woke it).
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline && !recv_done.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        handle.join().expect("recv strand panicked");
+        assert!(
+            recv_done.load(Ordering::SeqCst),
+            "recv strand never completed after wake-up datagram"
+        );
+
+        // The id should be reusable: a new bind reusing the freed id
+        // would prove the free-list got the entry. We don't assert the
+        // *exact* id (the free list is LIFO so it usually does match,
+        // but that's an implementation detail) — just that allocation
+        // still works, i.e. close didn't corrupt the registry.
+        let (sock_id2, _) = bind_succeeds(0);
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push_int(stack, sock_id2);
+        let stack = udp_close(stack);
+        let (_, success) = pop(stack);
+        assert!(matches!(success, Value::Bool(true)));
     }
 }
 

--- a/docs/design/LIVE_CODING_CSOUND_POC.md
+++ b/docs/design/LIVE_CODING_CSOUND_POC.md
@@ -1,0 +1,102 @@
+# Live-Coding POC: Seq → OSC → Csound
+
+## Intent
+
+Validate that Seq is a credible host language for live-coding music by
+driving an external audio engine (Csound) over OSC. The architecture
+question — "can Seq's strands+channels schedule events tightly enough
+when an audio engine handles sample-accurate playback?" — is more
+important than any specific musical result. If the POC works, it seeds
+a separate project later; if it doesn't, the same UDP work that
+unblocks it also unblocks DNS, NTP, multicast, syslog, and any other
+common datagram protocol — so the dependency work pays off either way.
+
+The POC should live in **`patch-seq/examples/projects/live-coding-csound`**. A
+live-coding POC belongs with the showcases.
+
+## Constraints
+
+- **UDP support must land cleanly.** It will outlive this POC — DNS
+  resolvers, NTP clients, multicast discovery, syslog all want it.
+  Don't shape `udp.*` to "what the POC happens to need."
+- **No new Seq stdlib for music yet.** Let the POC tell us what's
+  actually needed. OSC encoding can live inside the example dir until
+  it proves stable enough to promote to `std:osc`.
+- **Out of scope:** MIDI, SuperCollider integration, audio rendering,
+  pattern-language design, packaging Csound. The user installs Csound
+  themselves; the POC documents *how to start the engine*, not
+  *how to ship one*.
+- **Out of scope:** answering the spinout question now. POC first;
+  decide based on what it teaches us.
+- **Don't spin out a separate project at the start.** A POC inside
+  `patch-seq/examples/` keeps the language and its first non-trivial
+  external integration close together — language gaps it surfaces get
+  fixed in the same repo without coordination overhead. Spin out only
+  when the integration outgrows "one Seq script + one .csd file."
+
+## Approach
+
+Three sequential phases, each independently valuable.
+
+**Phase A — UDP in patch-seq.** Add `udp.bind`, `udp.send-to`, and
+`udp.receive-from` to the runtime, mirroring the shape of the existing
+`tcp.*` words but with no connection state. Stack effects (rough):
+
+```
+udp.bind          ( port           -- socket success )
+udp.send-to       ( bytes host port socket -- success )
+udp.receive-from  ( socket          -- bytes host port success )
+```
+
+Tests in patch-seq that cover loopback send/receive. This phase is
+useful independent of music — file the music POC as the motivating
+example but don't gate on it.
+
+**Phase B — OSC encoder, in Seq, in the example dir.** OSC 1.0 is a
+small spec: type-tagged byte messages with simple alignment rules.
+Write the encoder in Seq itself (no FFI, no new builtin). This stress-
+tests `udp.send-to` and exercises real-world byte-packing in Seq.
+Write a Seq message like `"/synth/play" [ 220.0 0.5 ] osc.send`.
+
+**Phase C — Csound example.** A `live.csd` Csound orchestra that opens
+an OSC port and triggers an instrument per message. A `live.seq`
+driver that opens UDP, sends a tick-driven pattern. A `README.md` that
+walks the user through `brew install csound`, starting the engine
+(`csound -odac live.csd`), and running the Seq script. Success
+criterion: a kick on every beat for 8 beats, BPM controlled by a Seq
+literal.
+
+## Domain Events
+
+- **Input:** `LiveCodingPocRequested { engine: Csound, transport: OSC }`
+- **Phase A:** `UdpLanded { stdlib: udp, has_tests: true }`
+- **Phase B:** `OscEncoderProven { lives_in: example_dir, vendored: true }`
+- **Phase C:** `CsoundExampleRuns { audible_on_macos: true }`
+- **Aggregate:** `PocEvaluation { result: Spinout | FoldIntoStdlib | Shelved }`
+- **Downstream:** if `Spinout`, a new repo gets `osc.seq` + a pattern
+  vocab + a packaging story. If `FoldIntoStdlib`, the OSC encoder
+  graduates to `std:osc` in patch-seq. If `Shelved`, UDP and the
+  example sit on disk for the next attempt — no harm done.
+
+## Checkpoints
+
+1. **UDP loopback test passes** in patch-seq: send a message to
+   yourself, receive it back, round-trip is byte-exact.
+2. **OSC fixture test passes**: an encoded OSC message from Seq
+   matches the byte layout in the OSC 1.0 spec for a known input
+   (e.g. `/foo` with one int and one float).
+3. **Csound responds**: starting `live.csd` and sending one OSC
+   message from a one-line Seq script produces an audible tone.
+4. **A bar of music plays**: a clock-driven Seq strand sends 8 beats
+   on a metronome; you hear them on time, no audible jitter.
+5. **POC writeup decides the spinout question** with evidence
+   (latency measurements, code size of the example, Seq language
+   gaps surfaced).
+
+## Open Question
+
+Whether the example should target Csound or SuperCollider for the
+first cut. Csound is *one* binary you can start from a script;
+SuperCollider's scsynth is more modular but requires a slightly more
+complex install story. Going with Csound for the POC; revisit once
+UDP+OSC work — the engine choice is interchangeable at the OSC layer.

--- a/docs/design/STRING_BYTE_CLEANLINESS.md
+++ b/docs/design/STRING_BYTE_CLEANLINESS.md
@@ -1,0 +1,94 @@
+# String Byte-Cleanliness Audit
+
+Status: design · 2026-04-26 · follow-up from `UDP_RUNTIME.md` open question
+
+## Intent
+
+Confirm — and where necessary, enforce — that a Seq `String` carries
+arbitrary bytes including NUL (`0x00`) without silent truncation,
+across every public runtime path that accepts or produces a String.
+Most likely Seq is already byte-clean internally (`SeqString` is
+Rust-side, and Rust `String` permits interior NULs; `string.byte-length`
+and byte-indexed `string.char-at` already imply bytes-not-codepoints).
+The risk is at FFI boundaries that use `CString` or rely on C-strlen
+semantics — those silently lose data.
+
+This is a follow-up audit, not a feature: the goal is documenting the
+current behaviour and closing any gaps, not adding new types or
+significantly widening the API.
+
+## Constraints
+
+- **Do not introduce a separate `Bytes` type.** That tradeoff was
+  considered in `UDP_RUNTIME.md` and rejected in favour of keeping
+  `String` byte-clean. Reopening that decision is its own design
+  problem, not part of this audit.
+- **Do not widen public API ergonomically.** At most one boundary
+  word — something like `string->cstring` — added at C-FFI sites
+  that genuinely cannot carry interior NULs. That word should
+  *fail loudly* (not truncate) on NUL-bearing input.
+- **Existing public APIs must keep their current signatures.** If
+  `file.slurp` is currently NUL-safe, it stays. If it's not, fix
+  the implementation, not the signature.
+- **Out of scope:** Unicode normalization questions, grapheme
+  clusters, encoding conversions. The audit is byte-level only.
+
+## Approach
+
+Three phases, each independently shippable:
+
+1. **Inventory.** List every runtime function that accepts or
+   produces a Seq String. Group by category: I/O (`file.*`,
+   `io.*`), networking (`tcp.*`, `udp.*`, `http.*`), encoding
+   (`encoding.*`, `crypto.*`), collections (`list.*`, `map.*`,
+   `chan.*`), string ops (`string.*`), FFI (`seq_ffi_*` wrappers).
+   Mark each as **likely-clean** (Rust-only path), **suspect**
+   (crosses FFI), or **unknown** (needs reading).
+
+2. **Test fixture.** Add a Rust integration test that round-trips
+   a fixed sentinel — e.g. `"hello\x00middle\x00end"` — through
+   every public path in the inventory. Failures point at exactly
+   which functions truncate.
+
+3. **Close gaps.** For each failing path, either fix the
+   implementation (preferred) or add a boundary word that rejects
+   NUL-bearing input with a clear error. Document each FFI site's
+   policy in the function's doc comment.
+
+## Domain Events
+
+- **Trigger:** UDP/OSC work, or any user filing a bug like "my
+  binary protocol's payload is being truncated".
+- **Output:** `StringByteCleanlinessVerified { paths_audited: N,
+  gaps_found: K, gaps_closed: K }` — the audit ends with either
+  zero gaps or a documented fix per gap.
+- **Downstream now confidently unblocked:** BSON / MessagePack /
+  Protobuf encoders in user code, binary file digests, OSC
+  encoders that pad with NULs (motivating case), image and
+  archive parsing, network protocols with binary framing.
+- **Out of scope:** any work that requires a Bytes type — that's
+  a separate design.
+
+## Checkpoints
+
+1. **Inventory exists** in `docs/STRING_BYTE_INVENTORY.md` (or
+   inline in this doc's appendix), classifying every public
+   String-touching runtime function.
+2. **Round-trip test passes** for the sentinel through every path
+   in the inventory.
+3. **Each FFI boundary documented.** Function doc comments say
+   either "byte-clean — interior NULs preserved" or "rejects NULs
+   — use this when crossing C-string boundaries".
+4. **`just ci` green** with the audit's tests in the regular suite,
+   so future regressions are caught.
+5. **Open question from `UDP_RUNTIME.md` resolved.** That doc's
+   payload-type concern can be closed once the audit confirms UDP
+   send/receive preserves NULs.
+
+## Open question
+
+Whether to publish the inventory as a permanent doc or fold it
+into runtime-source doc comments. Lean toward doc comments — they
+travel with the code and don't drift — with a short index in
+`STRING_BYTE_CLEANLINESS.md` that just lists which categories
+were audited and when.

--- a/docs/design/UDP_RUNTIME.md
+++ b/docs/design/UDP_RUNTIME.md
@@ -17,8 +17,11 @@ even if the music POC fails.
 - **TCP API stays unchanged.** UDP is purely additive.
 - **Mirror `tcp.*` shape.** Sockets are `Int` handles in a registry;
   every operation returns a success `Bool` on top so callers can
-  `[ ... ] [ ... ] if`. Same `MAX_SOCKETS = 10_000` and per-datagram
-  `MAX_READ_SIZE = 1 MB` caps as `tcp.*`.
+  `[ ... ] [ ... ] if`. Same `MAX_SOCKETS = 10_000` cap as `tcp.*`.
+  `MAX_READ_SIZE = 65_536` (the next power of two above the IPv4 UDP
+  ceiling of 65,507 bytes). Intentionally diverges from TCP's 1 MB
+  streaming-read cap — UDP is one-datagram-per-call, so anything
+  larger cannot arrive on the wire.
 - **Strands must yield while waiting on `recv_from`.** Use
   `may::net::UdpSocket` for coroutine-aware blocking, same pattern
   `tcp.read` uses today.

--- a/docs/design/UDP_RUNTIME.md
+++ b/docs/design/UDP_RUNTIME.md
@@ -1,0 +1,100 @@
+# UDP Runtime Support
+
+Status: design · 2026-04-26 · issue [#433]
+
+## Intent
+
+Add UDP socket primitives to the Seq runtime. UDP unblocks a long
+list of common protocols — DNS resolvers, NTP clients, multicast
+discovery, syslog, OSC for live-coding, QUIC's underlying transport,
+most game-network patterns. The near-term motivating use case is the
+Seq → OSC → Csound POC documented in `LIVE_CODING_CSOUND_POC.md`, but
+the API design serves all of those, not just OSC. UDP is worth landing
+even if the music POC fails.
+
+## Constraints
+
+- **TCP API stays unchanged.** UDP is purely additive.
+- **Mirror `tcp.*` shape.** Sockets are `Int` handles in a registry;
+  every operation returns a success `Bool` on top so callers can
+  `[ ... ] [ ... ] if`. Same `MAX_SOCKETS = 10_000` and per-datagram
+  `MAX_READ_SIZE = 1 MB` caps as `tcp.*`.
+- **Strands must yield while waiting on `recv_from`.** Use
+  `may::net::UdpSocket` for coroutine-aware blocking, same pattern
+  `tcp.read` uses today.
+- **Out of scope first cut:** multicast, broadcast, IPv6-specific
+  ergonomics. IPv6 should work transparently for IPv6-literal host
+  strings, but no `udp.join-multicast-group` etc. yet.
+- **Don't over-abstract on day one.** `SocketRegistry<T>` exists in
+  `tcp.rs`. Duplicate for UDP and refactor into a shared module
+  *after* both are working — UDP has no listener/stream split, so
+  forcing a shared abstraction now risks the wrong shape.
+
+## Approach
+
+`crates/runtime/src/udp.rs` mirrors `tcp.rs`. Public C-ABI surface:
+
+```
+udp.bind          ( Int                   -- a Int Int Bool )
+                    ( requested-port -- socket bound-port success )
+udp.send-to       ( a String String Int Int -- a Bool )
+                    ( bytes host port socket -- success )
+udp.receive-from  ( a Int -- a String String Int Bool )
+                    ( socket -- bytes host port success )
+udp.close         ( a Int -- a Bool )
+                    ( socket -- success )
+```
+
+`udp.bind` returns *both* the socket handle and the actual bound port
+(an extension over the issue's draft). Without that, the standard
+"bind to port 0, OS picks one" idiom is unusable — and the loopback
+test the issue specifies needs the assigned port to send to. For
+non-zero requests, the returned port equals the request.
+
+Wire-up follows the existing pattern: C-ABI exports in
+`crates/runtime/src/lib.rs`, type signatures in
+`crates/compiler/src/builtins/` (likely a new `udp.rs` sub-module
+alongside `tcp.rs`), AST validation entry in `ast/program.rs`, codegen
+runtime symbol mapping in `codegen/runtime/`. Same five-touchpoint
+recipe as TCP.
+
+## Domain Events
+
+- **Input:** `UdpRuntimeRequested { source: issue#433 }`
+- **Output:** `UdpLanded { has_tests: true, has_examples: false }`
+  — runtime + builtins + codegen wired; loopback test green.
+- **Downstream that's now unblocked:**
+  - `OscEncoderProven` (POC phase B) — Seq-side encoder + `udp.send-to`.
+  - `CsoundExampleRuns` (POC phase C) — full live-coding loop.
+  - DNS / NTP / multicast / syslog clients in user code (not in this
+    repo unless they want to be).
+- **Out of scope:** `OscStdlibPromoted`, `MulticastApi`, `Ipv6Api`.
+
+## Checkpoints
+
+1. **Loopback round-trip test passes.** Bind to `127.0.0.1:0`, get the
+   assigned port, send a payload from a second socket, receive it,
+   assert byte-exact match including source host/port. Lives in
+   `crates/runtime/src/udp/tests.rs`.
+2. **Negative tests pass.** Invalid port (negative, > 65535) returns
+   `(0, 0, false)`. `send-to` on closed socket → `false`.
+   `receive-from` on closed socket → `("", "", 0, false)`.
+3. **Strand yield is real, not blocking.** A two-strand test where
+   strand A blocks on `udp.receive-from` and strand B runs to
+   completion proves A doesn't pin the OS thread. (Mirror whatever
+   `tcp.rs` does here, if any.)
+4. **`just ci` green** — no regressions in TCP tests, examples, or
+   integration suite.
+5. **Live-coding POC phase B begins** — separate work, but its first
+   commit should rely only on the merged `udp.*` words and a Seq-side
+   OSC encoder. No further runtime additions.
+
+## Open question
+
+Should `udp.send-to`'s payload be `String` or a future `Bytes` type?
+Today Seq's `String` is byte-addressable (`string.byte-length`,
+`string.char-at` returns a byte) and OSC encoders will produce
+arbitrary bytes via string concatenation. So `String` works. Revisit
+only if a real protocol needs to send literal NUL bytes that Seq
+strings can't currently carry — and that's its own design problem,
+not a UDP one.

--- a/tests/integration/src/test-udp.seq
+++ b/tests/integration/src/test-udp.seq
@@ -1,0 +1,53 @@
+# Integration test for the udp.* runtime words.
+#
+# UDP is connectionless: a datagram sent before any receiver is ready
+# is buffered by the kernel, so a single-strand bind/send/receive
+# round-trip is a sound smoke test.
+
+: bind-localhost ( -- Int Int )
+  # Bind a UDP socket on an OS-assigned port. Returns ( socket bound-port ).
+  # Aborts the test on failure.
+  0 udp.bind                                # ( socket bound-port success )
+  [ ] [ "udp.bind failed" io.write-line 1 os.exit ] if
+;
+
+: test-udp-loopback-round-trip ( -- )
+  # Bind socket A (the receiver) on an OS-assigned port.
+  bind-localhost                            # ( a-sock a-port )
+
+  # Bind socket B (the sender). Drop B's port, we don't need it.
+  bind-localhost                            # ( a-sock a-port b-sock b-port )
+  drop                                      # ( a-sock a-port b-sock )
+
+  # Stash a-port and b-sock on the aux stack so we can build send-to
+  # args naturally without juggling pick depths.
+  >aux                                      # ( a-sock a-port )       aux: ( b-sock )
+  >aux                                      # ( a-sock )              aux: ( b-sock a-port )
+
+  # Build send-to args: bytes host port socket.
+  "ping" "127.0.0.1"                        # ( a-sock "ping" "127.0.0.1" )
+  aux>                                      # ( a-sock "ping" "127.0.0.1" a-port )
+  aux>                                      # ( a-sock "ping" "127.0.0.1" a-port b-sock )
+  udp.send-to                               # ( a-sock send-success )
+  test.assert
+
+  # Receive on A. ( socket -- bytes host port success ).
+  udp.receive-from                          # ( bytes host port success )
+  test.assert
+  drop                                      # drop port (source-port checks live in the Rust unit test)
+  drop                                      # drop host
+  "ping" test.assert-eq-str
+;
+
+: test-udp-bind-invalid-port ( -- )
+  # A port outside [0, 65535] returns ( 0 0 false ).
+  -1 udp.bind                               # ( 0 0 false )
+  test.assert-not
+  0 test.assert-eq                          # bound-port == 0
+  0 test.assert-eq                          # socket    == 0
+;
+
+: test-udp-close-invalid ( -- )
+  # Closing a never-allocated handle returns false.
+  99999 udp.close test.assert-not
+;


### PR DESCRIPTION
https://github.com/navicore/patch-seq/issues/433

  - crates/runtime/src/udp.rs (~280 lines) — patch_seq_udp_bind / send_to / receive_from / close mirroring tcp.rs. Same MAX_SOCKETS / MAX_READ_SIZE caps. Module doc explicitly documents the UTF-8 limitation and points at STRING_BYTE_CLEANLINESS.md so Phase B has a clear pointer when OSC payloads start failing.
  - crates/runtime/src/udp/tests.rs (8 tests) — bind + assigned-port, two invalid-port negatives, loopback round-trip with byte-exact match and source-port verification, send/recv/close negatives, registry-constants doc test.
  - crates/runtime/src/lib.rs — module declaration + C-ABI re-exports.
  - crates/compiler/src/builtins/udp.rs — type signatures + docs, wired into builtins.rs.
  - crates/compiler/src/builtins/macros.rs — added two new arms to the builtin! macro for 3- and 4-output stack effects (needed for udp.bind and udp.receive-from).
  - crates/compiler/src/codegen/runtime/udp.rs — LLVM declarations + symbol mapping.
  - crates/compiler/src/codegen/runtime.rs — wired into the composition.
  - crates/compiler/src/ast/program.rs — added udp.* to the validate-word-calls builtin list.
  - tests/integration/src/test-udp.seq (3 tests) — Seq-level loopback, invalid-port, close-invalid.

  Two design choices kept from the design doc, both validated:
  1. udp.bind returns ( socket bound-port success ) — confirmed working: OS-assigned port comes back as 58452-style values from kernel.
  2. Duplicated SocketRegistry rather than lifting to shared module — refactor is now low-risk because both implementations are stable.

  One implementation detail worth noting: udp.receive-from does the same
  String::from_utf8 validation tcp_read does, so non-UTF-8 datagrams
  currently get dropped with false. That's the byte-cleanliness gap the
  design doc flagged. Phase B (OSC encoder) will hit this and drive the
  audit.