### PR TITLE
binary in string

### DIFF
--- a/crates/core/src/seqstring.rs
+++ b/crates/core/src/seqstring.rs
@@ -1,22 +1,35 @@
-//! SeqString - Arena or Globally Allocated String
+//! SeqString - Arena or Globally Allocated Byte String
 //!
-//! Strings in Seq can be allocated from two sources:
+//! Strings in Seq are sequences of arbitrary bytes — there is **no
+//! UTF-8 invariant** on this type. Byte-clean operations (concat,
+//! length-in-bytes, channel send, network I/O, file I/O of binary
+//! content, crypto inputs) work on any input. Text-level operations
+//! (codepoint length, case folding, regex Unicode classes, JSON
+//! escaping) call [`SeqString::as_str`] which validates UTF-8 at the
+//! boundary and returns `Option<&str>`; on invalid bytes those ops
+//! fail loudly with the standard `(value Bool)` failure tuple.
+//!
+//! The two allocation sources stay:
 //! 1. Thread-local arena (fast, bulk-freed on strand exit)
-//! 2. Global allocator (persists across arena resets)
+//! 2. Global allocator (persists across arena resets, used for
+//!    cross-strand transfer)
 //!
-//! This allows fast temporary string creation during strand execution
-//! while maintaining safety for channel communication (clone to global).
+//! See `docs/design/STRING_BYTE_CLEANLINESS.md` for the full design.
 
 use crate::arena;
 use std::fmt;
 
-/// String that tracks its allocation source
+/// Byte string that tracks its allocation source.
 ///
 /// # Safety Invariants
-/// - If global=true: ptr points to global-allocated String, must be dropped
-/// - If global=false: ptr points to thread-local arena, no drop needed
-/// - ptr + len must form a valid UTF-8 string
-/// - For global strings: capacity must match the original String's capacity
+/// - If `global=true`: `ptr` points to a global-allocated byte buffer
+///   whose memory matches `len`/`capacity`; the buffer is freed on
+///   `Drop`.
+/// - If `global=false`: `ptr` points into the thread-local arena; the
+///   arena owns the memory and frees it in bulk on strand exit.
+/// - The byte content is *not* required to be valid UTF-8.
+/// - For global strings: `capacity` must match the original `Vec<u8>`'s
+///   capacity so deallocation is correctly sized.
 pub struct SeqString {
     ptr: *const u8,
     len: usize,
@@ -24,10 +37,10 @@ pub struct SeqString {
     global: bool,
 }
 
-// Implement PartialEq manually to compare string content, not pointers
+// Implement PartialEq manually to compare content (bytes), not pointers.
 impl PartialEq for SeqString {
     fn eq(&self, other: &Self) -> bool {
-        self.as_str() == other.as_str()
+        self.as_bytes() == other.as_bytes()
     }
 }
 
@@ -47,12 +60,47 @@ unsafe impl Send for SeqString {}
 unsafe impl Sync for SeqString {}
 
 impl SeqString {
-    /// Get string slice
+    /// Borrow the underlying bytes. Always succeeds; the type carries
+    /// no UTF-8 invariant. Byte-clean operations (concat, byte
+    /// length, equality, search, network I/O, crypto, etc.) should
+    /// use this.
+    pub fn as_bytes(&self) -> &[u8] {
+        // Safety: `ptr` and `len` describe a valid byte buffer per the
+        // `SeqString` invariants; the lifetime of the returned slice is
+        // tied to `&self` so the buffer cannot be freed while the
+        // slice is live.
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+
+    /// View as `&str` if the bytes happen to be valid UTF-8.
     ///
-    /// # Safety
-    /// ptr + len must point to valid UTF-8. This is guaranteed by constructors.
-    pub fn as_str(&self) -> &str {
-        unsafe { std::str::from_utf8_unchecked(std::slice::from_raw_parts(self.ptr, self.len)) }
+    /// Text-level operations (codepoint counting, case folding,
+    /// `string.json-escape`, `regex.*` with Unicode classes,
+    /// formatting for display) call this and treat `None` as a
+    /// fallible-text failure — the conventional `(value Bool)`
+    /// failure tuple, returning -1 / empty string / `false` per the
+    /// surrounding op's contract.
+    pub fn as_str(&self) -> Option<&str> {
+        std::str::from_utf8(self.as_bytes()).ok()
+    }
+
+    /// View as `&str`, replacing any invalid UTF-8 with U+FFFD. Use
+    /// only for human-facing display where lossiness is acceptable
+    /// (Debug, panic messages, REPL output). Operations that round-
+    /// trip user data must use [`as_bytes`] or [`as_str`] instead.
+    pub fn as_str_lossy(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(self.as_bytes())
+    }
+
+    /// View as `&str`, returning `""` if the bytes aren't valid UTF-8.
+    ///
+    /// The convenience for text-required ops (`string.length`,
+    /// `string.find`, file paths, integer parsing, …) that expect a
+    /// `&str` and have an existing degenerate-result-or-failure-tuple
+    /// path for empty input. A non-UTF-8 input lands in that same
+    /// failure path, with no extra branching at every call site.
+    pub fn as_str_or_empty(&self) -> &str {
+        self.as_str().unwrap_or("")
     }
 
     /// Check if this string is globally allocated
@@ -106,91 +154,115 @@ impl SeqString {
 }
 
 impl Clone for SeqString {
-    /// Clone always allocates from global allocator for Send safety
+    /// Clone always allocates from the global allocator for Send safety.
     ///
-    /// This ensures that when a String is sent through a channel,
-    /// the receiving strand gets an independent copy that doesn't
-    /// depend on the sender's arena.
+    /// When a `SeqString` is sent through a channel, the receiving
+    /// strand gets an independent global-allocated copy that doesn't
+    /// depend on the sender's arena. Byte-clean: copies the underlying
+    /// `&[u8]`, no UTF-8 validation.
     fn clone(&self) -> Self {
-        let s = self.as_str().to_string();
-        global_string(s)
+        global_bytes(self.as_bytes().to_vec())
     }
 }
 
 impl Drop for SeqString {
     fn drop(&mut self) {
         // Drop only if BOTH conditions are true:
-        // - global=true: Arena strings have global=false and are bulk-freed on strand exit
+        // - global=true: Arena strings have global=false and are bulk-freed on strand exit.
         // - capacity > 0: Interned symbols (Issue #166) have capacity=0 and point to
-        //   static data that must NOT be deallocated
+        //   static data that must NOT be deallocated.
         if self.global && self.capacity > 0 {
-            // Reconstruct String and drop it
-            // Safety: We created this from String in global_string() and stored
-            // the original ptr, len, and capacity. This ensures correct deallocation.
+            // Reconstruct the owning `Vec<u8>` and drop it. Using
+            // `Vec<u8>::from_raw_parts` (rather than `String::from_raw_parts`)
+            // imposes no UTF-8 requirement on the buffer contents; deallocation
+            // size is identical because `String` is just `Vec<u8>` plus a
+            // UTF-8 invariant.
+            //
+            // Safety: We created this buffer in `global_bytes()` (via
+            // `Vec::into_raw_parts`-equivalent) and stored the original
+            // `ptr`, `len`, and `capacity`, so reconstruction is exact.
             unsafe {
-                let _s = String::from_raw_parts(
-                    self.ptr as *mut u8,
-                    self.len,
-                    self.capacity, // Use original capacity for correct deallocation
-                );
-                // _s is dropped here, freeing the memory with correct size
+                let _v = Vec::<u8>::from_raw_parts(self.ptr as *mut u8, self.len, self.capacity);
+                // _v is dropped here, freeing the memory with correct size.
             }
         }
-        // Arena strings don't need explicit drop - arena reset frees them
-        // Static/interned strings (capacity=0) point to static data - no drop needed
+        // Arena strings don't need explicit drop — the arena's reset frees them.
+        // Static/interned strings (capacity=0) point to static data — no drop needed.
     }
 }
 
 impl fmt::Debug for SeqString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SeqString({:?}, global={})", self.as_str(), self.global)
+        // Lossy display is fine here — Debug is for human consumption.
+        write!(
+            f,
+            "SeqString({:?}, global={})",
+            self.as_str_lossy(),
+            self.global
+        )
     }
 }
 
 impl fmt::Display for SeqString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        // Display is human-facing; lossy-replace invalid UTF-8 with U+FFFD.
+        // Round-trip data should use `as_bytes()` directly.
+        write!(f, "{}", self.as_str_lossy())
     }
 }
 
-/// Create arena-allocated string (fast path for temporaries)
+/// Create arena-allocated bytes (fast path for temporaries).
+///
+/// Accepts arbitrary bytes; no UTF-8 validation.
 ///
 /// # Performance
-/// ~5ns vs ~100ns for global allocator (20x faster)
+/// ~5ns vs ~100ns for global allocator (20× faster).
 ///
 /// # Lifetime
-/// Valid until arena_reset() is called (typically when strand exits)
-pub fn arena_string(s: &str) -> SeqString {
+/// Valid until `arena_reset()` is called (typically when the strand exits).
+pub fn arena_bytes(bytes: &[u8]) -> SeqString {
     arena::with_arena(|arena| {
-        let arena_str = arena.alloc_str(s);
+        let arena_buf = arena.alloc_slice_copy(bytes);
         SeqString {
-            ptr: arena_str.as_ptr(),
-            len: arena_str.len(),
+            ptr: arena_buf.as_ptr(),
+            len: arena_buf.len(),
             capacity: 0, // Not used for arena strings
             global: false,
         }
     })
 }
 
-/// Create globally-allocated string (persists across arena resets)
+/// Create arena-allocated string from a UTF-8 `&str`. Convenience
+/// wrapper over [`arena_bytes`] for callers that already have a Rust
+/// `&str` in hand.
+pub fn arena_string(s: &str) -> SeqString {
+    arena_bytes(s.as_bytes())
+}
+
+/// Create globally-allocated bytes (persists across arena resets).
 ///
-/// # Usage
-/// For strings that need to outlive the current strand, or be sent through channels.
-///
-/// # Performance
-/// Same as regular String allocation
-pub fn global_string(s: String) -> SeqString {
-    let len = s.len();
-    let capacity = s.capacity();
-    let ptr = s.as_ptr();
-    std::mem::forget(s); // Transfer ownership, don't drop
+/// Accepts arbitrary bytes; no UTF-8 validation. Used when a
+/// `SeqString` needs to outlive the current strand or cross a channel
+/// boundary.
+pub fn global_bytes(bytes: Vec<u8>) -> SeqString {
+    let len = bytes.len();
+    let capacity = bytes.capacity();
+    let ptr = bytes.as_ptr();
+    std::mem::forget(bytes); // Transfer ownership; Drop reconstructs and frees.
 
     SeqString {
         ptr,
         len,
-        capacity, // Store original capacity for correct deallocation
+        capacity,
         global: true,
     }
+}
+
+/// Create globally-allocated string from a UTF-8 `String`. Convenience
+/// wrapper over [`global_bytes`] for callers that already have a Rust
+/// `String` in hand.
+pub fn global_string(s: String) -> SeqString {
+    global_bytes(s.into_bytes())
 }
 
 /// Convert &str to SeqString using arena allocation
@@ -214,7 +286,7 @@ mod tests {
     #[test]
     fn test_arena_string() {
         let s = arena_string("Hello, arena!");
-        assert_eq!(s.as_str(), "Hello, arena!");
+        assert_eq!(s.as_str(), Some("Hello, arena!"));
         assert_eq!(s.len(), 13);
         assert!(!s.is_global());
     }
@@ -222,7 +294,7 @@ mod tests {
     #[test]
     fn test_global_string() {
         let s = global_string("Hello, global!".to_string());
-        assert_eq!(s.as_str(), "Hello, global!");
+        assert_eq!(s.as_str(), Some("Hello, global!"));
         assert_eq!(s.len(), 14);
         assert!(s.is_global());
     }
@@ -233,7 +305,7 @@ mod tests {
         let s1 = arena_string("test");
         let s2 = s1.clone();
 
-        assert_eq!(s1.as_str(), s2.as_str());
+        assert_eq!(s1.as_bytes(), s2.as_bytes());
         assert!(!s1.is_global());
         assert!(s2.is_global()); // Clone is always global!
     }
@@ -243,7 +315,7 @@ mod tests {
         let s1 = global_string("test".to_string());
         let s2 = s1.clone();
 
-        assert_eq!(s1.as_str(), s2.as_str());
+        assert_eq!(s1.as_bytes(), s2.as_bytes());
         assert!(s1.is_global());
         assert!(s2.is_global());
     }
@@ -253,7 +325,7 @@ mod tests {
         // Create and drop a global string
         {
             let s = global_string("Will be dropped".to_string());
-            assert_eq!(s.as_str(), "Will be dropped");
+            assert_eq!(s.as_str(), Some("Will be dropped"));
         }
         // If we get here without crashing, drop worked
     }
@@ -263,7 +335,7 @@ mod tests {
         // Create and drop an arena string
         {
             let s = arena_string("Will be dropped (no-op)");
-            assert_eq!(s.as_str(), "Will be dropped (no-op)");
+            assert_eq!(s.as_str(), Some("Will be dropped (no-op)"));
         }
         // Arena strings don't need explicit drop
     }
@@ -283,14 +355,14 @@ mod tests {
     #[test]
     fn test_from_str() {
         let s: SeqString = "test".into();
-        assert_eq!(s.as_str(), "test");
+        assert_eq!(s.as_str(), Some("test"));
         assert!(!s.is_global()); // from &str uses arena
     }
 
     #[test]
     fn test_from_string() {
         let s: SeqString = "test".to_string().into();
-        assert_eq!(s.as_str(), "test");
+        assert_eq!(s.as_str(), Some("test"));
         assert!(s.is_global()); // from String uses global
     }
 
@@ -314,13 +386,13 @@ mod tests {
         let s = arena_string("");
         assert_eq!(s.len(), 0);
         assert!(s.is_empty());
-        assert_eq!(s.as_str(), "");
+        assert_eq!(s.as_str(), Some(""));
     }
 
     #[test]
     fn test_unicode() {
         let s = arena_string("Hello, 世界! 🦀");
-        assert_eq!(s.as_str(), "Hello, 世界! 🦀");
+        assert_eq!(s.as_str(), Some("Hello, 世界! 🦀"));
         assert!(s.len() > 10); // UTF-8 bytes, not chars
     }
 
@@ -338,7 +410,7 @@ mod tests {
         // Verify the SeqString captured the original capacity
         assert_eq!(cem.len(), 2);
         assert_eq!(cem.capacity, 100); // Critical: Must be 100, not 2!
-        assert_eq!(cem.as_str(), "hi");
+        assert_eq!(cem.as_str(), Some("hi"));
         assert!(cem.is_global());
 
         // Drop cem - if capacity was wrong, this would cause heap corruption
@@ -353,5 +425,87 @@ mod tests {
         let s = arena_string("test");
         assert_eq!(s.capacity, 0); // Arena strings have capacity=0
         assert!(!s.is_global());
+    }
+
+    // ------------------------------------------------------------------
+    // Byte-cleanliness sentinel tests.
+    //
+    // The type carries arbitrary bytes — no UTF-8 invariant. The
+    // sentinel covers: a NUL byte, a non-UTF-8 lead byte (0xDC alone is
+    // a UTF-8 continuation byte; standalone it's invalid), a high byte
+    // (0xFF, never valid in any UTF-8 position), and a partial
+    // multi-byte UTF-8 prefix (0xC3 without continuation). If any path
+    // through the runtime mangles or rejects these, the bug shows up
+    // here first.
+    // ------------------------------------------------------------------
+
+    const SENTINEL: &[u8] = &[0x00, 0xDC, b'x', 0xFF, 0xC3, b'!'];
+
+    #[test]
+    fn global_bytes_carries_arbitrary_bytes() {
+        let s = global_bytes(SENTINEL.to_vec());
+        assert_eq!(s.as_bytes(), SENTINEL);
+        assert_eq!(s.len(), SENTINEL.len());
+        assert!(s.is_global());
+        // The sentinel isn't valid UTF-8, so as_str is None.
+        assert_eq!(s.as_str(), None);
+    }
+
+    #[test]
+    fn arena_bytes_carries_arbitrary_bytes() {
+        let s = arena_bytes(SENTINEL);
+        assert_eq!(s.as_bytes(), SENTINEL);
+        assert_eq!(s.len(), SENTINEL.len());
+        assert!(!s.is_global());
+        assert_eq!(s.as_str(), None);
+    }
+
+    #[test]
+    fn equality_uses_bytes_not_utf8() {
+        // Two SeqStrings with identical non-UTF-8 bytes are equal.
+        let s1 = arena_bytes(SENTINEL);
+        let s2 = global_bytes(SENTINEL.to_vec());
+        assert_eq!(s1, s2);
+
+        // Differ in one byte.
+        let mut alt = SENTINEL.to_vec();
+        alt[0] = 0x01;
+        let s3 = global_bytes(alt);
+        assert_ne!(s1, s3);
+    }
+
+    #[test]
+    fn clone_round_trips_arbitrary_bytes() {
+        // Clone must preserve invalid UTF-8 byte-for-byte; it goes
+        // through the global allocator (cross-strand transfer path).
+        let s = arena_bytes(SENTINEL);
+        let cloned = s.clone();
+        assert_eq!(s.as_bytes(), cloned.as_bytes());
+        assert!(cloned.is_global());
+    }
+
+    #[test]
+    fn drop_does_not_require_utf8() {
+        // Allocate-and-drop a global non-UTF-8 buffer. Pre-fix this
+        // would be UB inside the Drop impl (String::from_raw_parts on
+        // invalid UTF-8). The fixed Drop reconstructs a Vec<u8>
+        // instead, which has no UTF-8 requirement.
+        for _ in 0..16 {
+            let _ = global_bytes(SENTINEL.to_vec());
+        }
+        // If we reach here without the allocator complaining, the
+        // capacity bookkeeping is also intact for byte buffers.
+    }
+
+    #[test]
+    fn as_str_lossy_replaces_invalid() {
+        // Display path: invalid UTF-8 becomes U+FFFD, but the call
+        // doesn't fail or panic.
+        let s = global_bytes(SENTINEL.to_vec());
+        let lossy = s.as_str_lossy();
+        assert!(lossy.contains('\u{FFFD}'));
+        // The valid 'x' and '!' bytes are still there.
+        assert!(lossy.contains('x'));
+        assert!(lossy.contains('!'));
     }
 }

--- a/crates/core/src/son.rs
+++ b/crates/core/src/son.rs
@@ -77,11 +77,16 @@ fn format_value(value: &Value, config: &SonConfig, depth: usize, buf: &mut Strin
             buf.push_str(if *b { "true" } else { "false" });
         }
         Value::String(s) => {
-            format_string(s.as_str(), buf);
+            // SON is text serialization (Seq-source-syntax compatible).
+            // Non-UTF-8 bytes have no clean Seq-syntax representation,
+            // so we display lossily — round-trip of arbitrary bytes
+            // through SON is *not* supported. Callers needing to
+            // round-trip binary data should base64/hex-encode first.
+            format_string(&s.as_str_lossy(), buf);
         }
         Value::Symbol(s) => {
             buf.push(':');
-            buf.push_str(s.as_str());
+            buf.push_str(&s.as_str_lossy());
         }
         Value::Variant(v) => {
             format_variant(v, config, depth, buf);
@@ -127,15 +132,17 @@ fn format_string(s: &str, buf: &mut String) {
 
 /// Format a variant (includes List as special case)
 fn format_variant(v: &VariantData, config: &SonConfig, depth: usize, buf: &mut String) {
-    let tag = v.tag.as_str();
+    // Variant tags are constructor names — text by design. We compare
+    // bytes for the List discriminator (no UTF-8 dependence) and use
+    // the lossy-display form for the printed tag in non-List cases.
+    let is_list = v.tag.as_bytes() == b"List";
 
-    // Special case: List variant uses list-of/lv syntax
-    if tag == "List" {
+    if is_list {
         format_list(&v.fields, config, depth, buf);
     } else {
         // General variant: :Tag field1 field2 wrap-N
         buf.push(':');
-        buf.push_str(tag);
+        buf.push_str(&v.tag.as_str_lossy());
 
         let field_count = v.fields.len();
 
@@ -219,7 +226,7 @@ fn map_key_sort_string(key: &MapKey) -> String {
     match key {
         MapKey::Int(n) => format!("0_{:020}", n), // Prefix with 0 for ints
         MapKey::Bool(b) => format!("1_{}", b),    // Prefix with 1 for bools
-        MapKey::String(s) => format!("2_{}", s.as_str()), // Prefix with 2 for strings
+        MapKey::String(s) => format!("2_{}", s.as_str_lossy()), // Prefix with 2 for strings
     }
 }
 
@@ -228,7 +235,7 @@ fn format_map_key(key: &MapKey, buf: &mut String) {
     match key {
         MapKey::Int(n) => buf.push_str(&n.to_string()),
         MapKey::Bool(b) => buf.push_str(if *b { "true" } else { "false" }),
-        MapKey::String(s) => format_string(s.as_str(), buf),
+        MapKey::String(s) => format_string(&s.as_str_lossy(), buf),
     }
 }
 

--- a/crates/core/src/stack.rs
+++ b/crates/core/src/stack.rs
@@ -814,7 +814,7 @@ mod tests {
             let stack = push(stack, Value::String(s));
             let (_, val) = pop(stack);
             match val {
-                Value::String(s) => assert_eq!(s.as_str(), "hello"),
+                Value::String(s) => assert_eq!(s.as_bytes(), b"hello"),
                 other => panic!("Expected String, got {:?}", other),
             }
         }
@@ -828,7 +828,7 @@ mod tests {
             let stack = push(stack, Value::Symbol(s));
             let (_, val) = pop(stack);
             match val {
-                Value::Symbol(s) => assert_eq!(s.as_str(), "my-sym"),
+                Value::Symbol(s) => assert_eq!(s.as_bytes(), b"my-sym"),
                 other => panic!("Expected Symbol, got {:?}", other),
             }
         }
@@ -844,7 +844,7 @@ mod tests {
             let (_, val) = pop(stack);
             match val {
                 Value::Variant(v) => {
-                    assert_eq!(v.tag.as_str(), "Foo");
+                    assert_eq!(v.tag.as_bytes(), b"Foo");
                     assert_eq!(v.fields.len(), 2);
                 }
                 other => panic!("Expected Variant, got {:?}", other),

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -254,10 +254,13 @@ impl std::fmt::Display for Value {
             Value::Int(n) => write!(f, "{}", n),
             Value::Float(n) => write!(f, "{}", n),
             Value::Bool(b) => write!(f, "{}", b),
-            Value::String(s) => write!(f, "{:?}", s.as_str()),
-            Value::Symbol(s) => write!(f, ":{}", s.as_str()),
+            // Display is human-facing; lossy-display non-UTF-8 strings.
+            // Round-trip data uses `as_bytes()` directly via the
+            // appropriate runtime op, not Display.
+            Value::String(s) => write!(f, "{:?}", s.as_str_lossy()),
+            Value::Symbol(s) => write!(f, ":{}", s.as_str_lossy()),
             Value::Variant(v) => {
-                write!(f, ":{}", v.tag.as_str())?;
+                write!(f, ":{}", v.tag.as_str_lossy())?;
                 if !v.fields.is_empty() {
                     write!(f, "(")?;
                 }

--- a/crates/runtime/src/channel/tests.rs
+++ b/crates/runtime/src/channel/tests.rs
@@ -182,7 +182,7 @@ fn test_arena_string_send_between_strands() {
 
                 match msg_val {
                     Value::String(s) => {
-                        assert_eq!(s.as_str(), "Arena message!");
+                        assert_eq!(s.as_str_or_empty(), "Arena message!");
                         assert!(s.is_global(), "Received string should be global");
                         VERIFIED.store(true, Ordering::Release);
                     }

--- a/crates/runtime/src/compress.rs
+++ b/crates/runtime/src/compress.rs
@@ -47,19 +47,17 @@ pub unsafe extern "C" fn patch_seq_compress_gzip(stack: Stack) -> Stack {
     let (stack, data_val) = unsafe { pop(stack) };
 
     match data_val {
-        Value::String(data) => {
-            match gzip_compress(data.as_str().as_bytes(), Compression::default()) {
-                Some(compressed) => {
-                    let encoded = STANDARD.encode(&compressed);
-                    let stack = unsafe { push(stack, Value::String(global_string(encoded))) };
-                    unsafe { push(stack, Value::Bool(true)) }
-                }
-                None => {
-                    let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
-                    unsafe { push(stack, Value::Bool(false)) }
-                }
+        Value::String(data) => match gzip_compress(data.as_bytes(), Compression::default()) {
+            Some(compressed) => {
+                let encoded = STANDARD.encode(&compressed);
+                let stack = unsafe { push(stack, Value::String(global_string(encoded))) };
+                unsafe { push(stack, Value::Bool(true)) }
             }
-        }
+            None => {
+                let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
+                unsafe { push(stack, Value::Bool(false)) }
+            }
+        },
         _ => panic!("compress.gzip: expected String on stack"),
     }
 }
@@ -83,7 +81,7 @@ pub unsafe extern "C" fn patch_seq_compress_gzip_level(stack: Stack) -> Stack {
     match (data_val, level_val) {
         (Value::String(data), Value::Int(level)) => {
             let level = level.clamp(1, 9) as u32;
-            match gzip_compress(data.as_str().as_bytes(), Compression::new(level)) {
+            match gzip_compress(data.as_bytes(), Compression::new(level)) {
                 Some(compressed) => {
                     let encoded = STANDARD.encode(&compressed);
                     let stack = unsafe { push(stack, Value::String(global_string(encoded))) };
@@ -117,7 +115,7 @@ pub unsafe extern "C" fn patch_seq_compress_gunzip(stack: Stack) -> Stack {
     match data_val {
         Value::String(data) => {
             // Decode base64
-            let decoded = match STANDARD.decode(data.as_str()) {
+            let decoded = match STANDARD.decode(data.as_str_or_empty()) {
                 Ok(d) => d,
                 Err(_) => {
                     let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
@@ -156,7 +154,7 @@ pub unsafe extern "C" fn patch_seq_compress_zstd(stack: Stack) -> Stack {
     let (stack, data_val) = unsafe { pop(stack) };
 
     match data_val {
-        Value::String(data) => match zstd::encode_all(data.as_str().as_bytes(), 3) {
+        Value::String(data) => match zstd::encode_all(data.as_bytes(), 3) {
             Ok(compressed) => {
                 let encoded = STANDARD.encode(&compressed);
                 let stack = unsafe { push(stack, Value::String(global_string(encoded))) };
@@ -190,7 +188,7 @@ pub unsafe extern "C" fn patch_seq_compress_zstd_level(stack: Stack) -> Stack {
     match (data_val, level_val) {
         (Value::String(data), Value::Int(level)) => {
             let level = level.clamp(1, 22) as i32;
-            match zstd::encode_all(data.as_str().as_bytes(), level) {
+            match zstd::encode_all(data.as_bytes(), level) {
                 Ok(compressed) => {
                     let encoded = STANDARD.encode(&compressed);
                     let stack = unsafe { push(stack, Value::String(global_string(encoded))) };
@@ -224,7 +222,7 @@ pub unsafe extern "C" fn patch_seq_compress_unzstd(stack: Stack) -> Stack {
     match data_val {
         Value::String(data) => {
             // Decode base64
-            let decoded = match STANDARD.decode(data.as_str()) {
+            let decoded = match STANDARD.decode(data.as_str_or_empty()) {
                 Ok(d) => d,
                 Err(_) => {
                     let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };

--- a/crates/runtime/src/compress/tests.rs
+++ b/crates/runtime/src/compress/tests.rs
@@ -27,7 +27,7 @@ fn test_gzip_roundtrip() {
 
     let (_, result) = unsafe { pop(stack) };
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "hello world");
+        assert_eq!(s.as_str_or_empty(), "hello world");
     } else {
         panic!("expected string");
     }
@@ -58,7 +58,7 @@ fn test_gzip_level() {
 
     let (_, result) = unsafe { pop(stack) };
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "hello world");
+        assert_eq!(s.as_str_or_empty(), "hello world");
     } else {
         panic!("expected string");
     }
@@ -90,7 +90,7 @@ fn test_zstd_roundtrip() {
 
     let (_, result) = unsafe { pop(stack) };
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "hello world");
+        assert_eq!(s.as_str_or_empty(), "hello world");
     } else {
         panic!("expected string");
     }
@@ -121,7 +121,7 @@ fn test_zstd_level() {
 
     let (_, result) = unsafe { pop(stack) };
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "hello world");
+        assert_eq!(s.as_str_or_empty(), "hello world");
     } else {
         panic!("expected string");
     }
@@ -193,7 +193,7 @@ fn test_empty_string() {
 
     let (_, result) = unsafe { pop(stack) };
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "");
+        assert_eq!(s.as_str_or_empty(), "");
     } else {
         panic!("expected string");
     }
@@ -219,7 +219,7 @@ fn test_large_data() {
 
     let (_, result) = unsafe { pop(stack) };
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), large_data);
+        assert_eq!(s.as_str_or_empty(), large_data);
     } else {
         panic!("expected string");
     }

--- a/crates/runtime/src/cond/tests.rs
+++ b/crates/runtime/src/cond/tests.rs
@@ -121,7 +121,7 @@ fn test_cond_single_match() {
 
         let (_, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "matched"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "matched"),
             _ => panic!("Expected String, got {:?}", result),
         }
     }
@@ -145,7 +145,7 @@ fn test_cond_first_match_wins() {
 
         let (_, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "matched"), // first body wins
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "matched"), // first body wins
             _ => panic!("Expected String, got {:?}", result),
         }
     }
@@ -168,7 +168,7 @@ fn test_cond_second_match() {
 
         let (_, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "default"), // second body wins
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "default"), // second body wins
             _ => panic!("Expected String, got {:?}", result),
         }
     }
@@ -193,7 +193,7 @@ fn test_cond_classify_number() {
         let stack = cond(stack);
         let (_, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "negative"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "negative"),
             _ => panic!("Expected String"),
         }
 
@@ -211,7 +211,7 @@ fn test_cond_classify_number() {
         let stack = cond(stack);
         let (_, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "zero"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "zero"),
             _ => panic!("Expected String"),
         }
 
@@ -229,7 +229,7 @@ fn test_cond_classify_number() {
         let stack = cond(stack);
         let (_, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "positive"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "positive"),
             _ => panic!("Expected String"),
         }
     }

--- a/crates/runtime/src/crypto/aes.rs
+++ b/crates/runtime/src/crypto/aes.rs
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn patch_seq_crypto_aes_gcm_encrypt(stack: Stack) -> Stack
 
     match (plaintext_val, key_val) {
         (Value::String(plaintext), Value::String(key_hex)) => {
-            match aes_gcm_encrypt(plaintext.as_str(), key_hex.as_str()) {
+            match aes_gcm_encrypt(plaintext.as_str_or_empty(), key_hex.as_str_or_empty()) {
                 Some(ciphertext) => {
                     let stack = unsafe { push(stack, Value::String(global_string(ciphertext))) };
                     unsafe { push(stack, Value::Bool(true)) }
@@ -73,7 +73,7 @@ pub unsafe extern "C" fn patch_seq_crypto_aes_gcm_decrypt(stack: Stack) -> Stack
 
     match (ciphertext_val, key_val) {
         (Value::String(ciphertext), Value::String(key_hex)) => {
-            match aes_gcm_decrypt(ciphertext.as_str(), key_hex.as_str()) {
+            match aes_gcm_decrypt(ciphertext.as_str_or_empty(), key_hex.as_str_or_empty()) {
                 Some(plaintext) => {
                     let stack = unsafe { push(stack, Value::String(global_string(plaintext))) };
                     unsafe { push(stack, Value::Bool(true)) }

--- a/crates/runtime/src/crypto/aes.rs
+++ b/crates/runtime/src/crypto/aes.rs
@@ -1,6 +1,6 @@
 //! AES-256-GCM authenticated encryption.
 
-use crate::seqstring::global_string;
+use crate::seqstring::{global_bytes, global_string};
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 
@@ -35,7 +35,10 @@ pub unsafe extern "C" fn patch_seq_crypto_aes_gcm_encrypt(stack: Stack) -> Stack
 
     match (plaintext_val, key_val) {
         (Value::String(plaintext), Value::String(key_hex)) => {
-            match aes_gcm_encrypt(plaintext.as_str_or_empty(), key_hex.as_str_or_empty()) {
+            // Plaintext is byte-clean — random bytes, file content,
+            // pre-encoded structured data all encrypt correctly.
+            // Key is text (hex) so we still go through `as_str_or_empty`.
+            match aes_gcm_encrypt(plaintext.as_bytes(), key_hex.as_str_or_empty()) {
                 Some(ciphertext) => {
                     let stack = unsafe { push(stack, Value::String(global_string(ciphertext))) };
                     unsafe { push(stack, Value::Bool(true)) }
@@ -73,9 +76,13 @@ pub unsafe extern "C" fn patch_seq_crypto_aes_gcm_decrypt(stack: Stack) -> Stack
 
     match (ciphertext_val, key_val) {
         (Value::String(ciphertext), Value::String(key_hex)) => {
+            // Ciphertext is base64 (text). Plaintext bytes come back
+            // raw — wrap them in a byte-clean SeqString so binary
+            // payloads survive the round-trip.
             match aes_gcm_decrypt(ciphertext.as_str_or_empty(), key_hex.as_str_or_empty()) {
-                Some(plaintext) => {
-                    let stack = unsafe { push(stack, Value::String(global_string(plaintext))) };
+                Some(plaintext_bytes) => {
+                    let stack =
+                        unsafe { push(stack, Value::String(global_bytes(plaintext_bytes))) };
                     unsafe { push(stack, Value::Bool(true)) }
                 }
                 None => {
@@ -88,7 +95,11 @@ pub unsafe extern "C" fn patch_seq_crypto_aes_gcm_decrypt(stack: Stack) -> Stack
     }
 }
 
-pub(super) fn aes_gcm_encrypt(plaintext: &str, key_hex: &str) -> Option<String> {
+/// Encrypt arbitrary bytes with AES-256-GCM. The plaintext is treated
+/// as bytes (binary or text), the key is hex-encoded, and the
+/// returned ciphertext is base64-encoded (so always valid UTF-8 and
+/// safe to store in any string-typed field).
+pub(super) fn aes_gcm_encrypt(plaintext: &[u8], key_hex: &str) -> Option<String> {
     // Decode hex key
     let key_bytes = hex::decode(key_hex).ok()?;
     if key_bytes.len() != AES_KEY_SIZE {
@@ -104,7 +115,7 @@ pub(super) fn aes_gcm_encrypt(plaintext: &str, key_hex: &str) -> Option<String> 
     let nonce = Nonce::from_slice(&nonce_bytes);
 
     // Encrypt
-    let ciphertext = cipher.encrypt(nonce, plaintext.as_bytes()).ok()?;
+    let ciphertext = cipher.encrypt(nonce, plaintext).ok()?;
 
     // Combine: nonce || ciphertext (tag is appended by aes-gcm)
     let mut combined = Vec::with_capacity(AES_NONCE_SIZE + ciphertext.len());
@@ -114,7 +125,11 @@ pub(super) fn aes_gcm_encrypt(plaintext: &str, key_hex: &str) -> Option<String> 
     Some(STANDARD.encode(&combined))
 }
 
-pub(super) fn aes_gcm_decrypt(ciphertext_b64: &str, key_hex: &str) -> Option<String> {
+/// Decrypt an AES-256-GCM ciphertext (base64-encoded) with the given
+/// hex-encoded key. Returns the recovered plaintext as raw bytes —
+/// callers can wrap them in a byte-clean SeqString (binary plaintext
+/// preserved) or validate as UTF-8 if they expect text.
+pub(super) fn aes_gcm_decrypt(ciphertext_b64: &str, key_hex: &str) -> Option<Vec<u8>> {
     // Decode base64
     let combined = STANDARD.decode(ciphertext_b64).ok()?;
     if combined.len() < AES_NONCE_SIZE + AES_GCM_TAG_SIZE {
@@ -134,7 +149,5 @@ pub(super) fn aes_gcm_decrypt(ciphertext_b64: &str, key_hex: &str) -> Option<Str
 
     // Create cipher and decrypt
     let cipher = Aes256Gcm::new_from_slice(&key_bytes).ok()?;
-    let plaintext_bytes = cipher.decrypt(nonce, ciphertext).ok()?;
-
-    String::from_utf8(plaintext_bytes).ok()
+    cipher.decrypt(nonce, ciphertext).ok()
 }

--- a/crates/runtime/src/crypto/ed25519.rs
+++ b/crates/runtime/src/crypto/ed25519.rs
@@ -62,7 +62,8 @@ pub unsafe extern "C" fn patch_seq_crypto_ed25519_sign(stack: Stack) -> Stack {
 
     match (msg_val, key_val) {
         (Value::String(message), Value::String(private_key_hex)) => {
-            match ed25519_sign(message.as_str_or_empty(), private_key_hex.as_str_or_empty()) {
+            // Message is byte-clean; the key is hex (text).
+            match ed25519_sign(message.as_bytes(), private_key_hex.as_str_or_empty()) {
                 Some(signature) => {
                     let stack = unsafe { push(stack, Value::String(global_string(signature))) };
                     unsafe { push(stack, Value::Bool(true)) }
@@ -101,8 +102,9 @@ pub unsafe extern "C" fn patch_seq_crypto_ed25519_verify(stack: Stack) -> Stack 
 
     match (msg_val, sig_val, pubkey_val) {
         (Value::String(message), Value::String(signature_hex), Value::String(public_key_hex)) => {
+            // Message is byte-clean; signature and key are hex (text).
             let valid = ed25519_verify(
-                message.as_str_or_empty(),
+                message.as_bytes(),
                 signature_hex.as_str_or_empty(),
                 public_key_hex.as_str_or_empty(),
             );
@@ -114,7 +116,9 @@ pub unsafe extern "C" fn patch_seq_crypto_ed25519_verify(stack: Stack) -> Stack 
 
 // Helper functions for Ed25519
 
-pub(super) fn ed25519_sign(message: &str, private_key_hex: &str) -> Option<String> {
+/// Sign arbitrary bytes (binary or text). The key is hex-encoded; the
+/// returned signature is hex-encoded (always valid UTF-8).
+pub(super) fn ed25519_sign(message: &[u8], private_key_hex: &str) -> Option<String> {
     let key_bytes = hex::decode(private_key_hex).ok()?;
     if key_bytes.len() != 32 {
         return None;
@@ -122,12 +126,13 @@ pub(super) fn ed25519_sign(message: &str, private_key_hex: &str) -> Option<Strin
 
     let key_array: [u8; 32] = key_bytes.try_into().ok()?;
     let signing_key = SigningKey::from_bytes(&key_array);
-    let signature = signing_key.sign(message.as_bytes());
+    let signature = signing_key.sign(message);
 
     Some(hex::encode(signature.to_bytes()))
 }
 
-pub(super) fn ed25519_verify(message: &str, signature_hex: &str, public_key_hex: &str) -> bool {
+/// Verify a signature against arbitrary bytes (binary or text).
+pub(super) fn ed25519_verify(message: &[u8], signature_hex: &str, public_key_hex: &str) -> bool {
     let verify_inner = || -> Option<bool> {
         let sig_bytes = hex::decode(signature_hex).ok()?;
         if sig_bytes.len() != 64 {
@@ -145,7 +150,7 @@ pub(super) fn ed25519_verify(message: &str, signature_hex: &str, public_key_hex:
         let signature = Signature::from_bytes(&sig_array);
         let verifying_key = VerifyingKey::from_bytes(&pubkey_array).ok()?;
 
-        Some(verifying_key.verify(message.as_bytes(), &signature).is_ok())
+        Some(verifying_key.verify(message, &signature).is_ok())
     };
 
     verify_inner().unwrap_or(false)

--- a/crates/runtime/src/crypto/ed25519.rs
+++ b/crates/runtime/src/crypto/ed25519.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn patch_seq_crypto_ed25519_sign(stack: Stack) -> Stack {
 
     match (msg_val, key_val) {
         (Value::String(message), Value::String(private_key_hex)) => {
-            match ed25519_sign(message.as_str(), private_key_hex.as_str()) {
+            match ed25519_sign(message.as_str_or_empty(), private_key_hex.as_str_or_empty()) {
                 Some(signature) => {
                     let stack = unsafe { push(stack, Value::String(global_string(signature))) };
                     unsafe { push(stack, Value::Bool(true)) }
@@ -102,9 +102,9 @@ pub unsafe extern "C" fn patch_seq_crypto_ed25519_verify(stack: Stack) -> Stack 
     match (msg_val, sig_val, pubkey_val) {
         (Value::String(message), Value::String(signature_hex), Value::String(public_key_hex)) => {
             let valid = ed25519_verify(
-                message.as_str(),
-                signature_hex.as_str(),
-                public_key_hex.as_str(),
+                message.as_str_or_empty(),
+                signature_hex.as_str_or_empty(),
+                public_key_hex.as_str_or_empty(),
             );
             unsafe { push(stack, Value::Bool(valid)) }
         }

--- a/crates/runtime/src/crypto/hash.rs
+++ b/crates/runtime/src/crypto/hash.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn patch_seq_sha256(stack: Stack) -> Stack {
     match value {
         Value::String(s) => {
             let mut hasher = Sha256::new();
-            hasher.update(s.as_str().as_bytes());
+            hasher.update(s.as_bytes());
             let result = hasher.finalize();
             let hex_digest = hex::encode(result);
             unsafe { push(stack, Value::String(global_string(hex_digest))) }
@@ -54,9 +54,9 @@ pub unsafe extern "C" fn patch_seq_hmac_sha256(stack: Stack) -> Stack {
 
     match (msg_value, key_value) {
         (Value::String(msg), Value::String(key)) => {
-            let mut mac = <HmacSha256 as Mac>::new_from_slice(key.as_str().as_bytes())
-                .expect("HMAC can take any key");
-            mac.update(msg.as_str().as_bytes());
+            let mut mac =
+                <HmacSha256 as Mac>::new_from_slice(key.as_bytes()).expect("HMAC can take any key");
+            mac.update(msg.as_bytes());
             let result = mac.finalize();
             let hex_sig = hex::encode(result.into_bytes());
             unsafe { push(stack, Value::String(global_string(hex_sig))) }
@@ -90,8 +90,8 @@ pub unsafe extern "C" fn patch_seq_constant_time_eq(stack: Stack) -> Stack {
 
     match (a_value, b_value) {
         (Value::String(a), Value::String(b)) => {
-            let a_bytes = a.as_str().as_bytes();
-            let b_bytes = b.as_str().as_bytes();
+            let a_bytes = a.as_bytes();
+            let b_bytes = b.as_bytes();
 
             // Use subtle crate for truly constant-time comparison
             // This handles different-length strings correctly without timing leaks

--- a/crates/runtime/src/crypto/pbkdf.rs
+++ b/crates/runtime/src/crypto/pbkdf.rs
@@ -39,7 +39,11 @@ pub unsafe extern "C" fn patch_seq_crypto_pbkdf2_sha256(stack: Stack) -> Stack {
                 return unsafe { push(stack, Value::Bool(false)) };
             }
 
-            let key = derive_key_pbkdf2(password.as_str(), salt.as_str(), iterations as u32);
+            let key = derive_key_pbkdf2(
+                password.as_str_or_empty(),
+                salt.as_str_or_empty(),
+                iterations as u32,
+            );
             let key_hex = hex::encode(key);
             let stack = unsafe { push(stack, Value::String(global_string(key_hex))) };
             unsafe { push(stack, Value::Bool(true)) }

--- a/crates/runtime/src/crypto/pbkdf.rs
+++ b/crates/runtime/src/crypto/pbkdf.rs
@@ -39,11 +39,10 @@ pub unsafe extern "C" fn patch_seq_crypto_pbkdf2_sha256(stack: Stack) -> Stack {
                 return unsafe { push(stack, Value::Bool(false)) };
             }
 
-            let key = derive_key_pbkdf2(
-                password.as_str_or_empty(),
-                salt.as_str_or_empty(),
-                iterations as u32,
-            );
+            // Password and salt are byte-clean — random bytes for
+            // salts are common, and binary password material (e.g.,
+            // pre-hashed input) survives unchanged.
+            let key = derive_key_pbkdf2(password.as_bytes(), salt.as_bytes(), iterations as u32);
             let key_hex = hex::encode(key);
             let stack = unsafe { push(stack, Value::String(global_string(key_hex))) };
             unsafe { push(stack, Value::Bool(true)) }
@@ -52,8 +51,12 @@ pub unsafe extern "C" fn patch_seq_crypto_pbkdf2_sha256(stack: Stack) -> Stack {
     }
 }
 
-pub(super) fn derive_key_pbkdf2(password: &str, salt: &str, iterations: u32) -> [u8; AES_KEY_SIZE] {
+pub(super) fn derive_key_pbkdf2(
+    password: &[u8],
+    salt: &[u8],
+    iterations: u32,
+) -> [u8; AES_KEY_SIZE] {
     let mut key = [0u8; AES_KEY_SIZE];
-    pbkdf2::pbkdf2_hmac::<Sha256>(password.as_bytes(), salt.as_bytes(), iterations, &mut key);
+    pbkdf2::pbkdf2_hmac::<Sha256>(password, salt, iterations, &mut key);
     key
 }

--- a/crates/runtime/src/crypto/tests.rs
+++ b/crates/runtime/src/crypto/tests.rs
@@ -20,7 +20,7 @@ fn test_sha256() {
             Value::String(s) => {
                 // SHA-256 of "hello"
                 assert_eq!(
-                    s.as_str(),
+                    s.as_str_or_empty(),
                     "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
                 );
             }
@@ -41,7 +41,7 @@ fn test_sha256_empty() {
             Value::String(s) => {
                 // SHA-256 of empty string
                 assert_eq!(
-                    s.as_str(),
+                    s.as_str_or_empty(),
                     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 );
             }
@@ -63,7 +63,7 @@ fn test_hmac_sha256() {
             Value::String(s) => {
                 // HMAC-SHA256("message", "secret")
                 assert_eq!(
-                    s.as_str(),
+                    s.as_str_or_empty(),
                     "8b5f48702995c1598c573db1e21866a9b825d4a794d169d7060a03605796360b"
                 );
             }
@@ -131,9 +131,9 @@ fn test_random_bytes() {
         match value {
             Value::String(s) => {
                 // 16 bytes = 32 hex chars
-                assert_eq!(s.as_str().len(), 32);
+                assert_eq!(s.as_str_or_empty().len(), 32);
                 // Should be valid hex
-                assert!(hex::decode(s.as_str()).is_ok());
+                assert!(hex::decode(s.as_str_or_empty()).is_ok());
             }
             _ => panic!("Expected String"),
         }
@@ -150,7 +150,7 @@ fn test_random_bytes_zero() {
 
         match value {
             Value::String(s) => {
-                assert_eq!(s.as_str(), "");
+                assert_eq!(s.as_str_or_empty(), "");
             }
             _ => panic!("Expected String"),
         }
@@ -167,10 +167,10 @@ fn test_uuid4() {
         match value {
             Value::String(s) => {
                 // UUID format: 8-4-4-4-12
-                assert_eq!(s.as_str().len(), 36);
-                assert_eq!(s.as_str().chars().filter(|c| *c == '-').count(), 4);
+                assert_eq!(s.as_str_or_empty().len(), 36);
+                assert_eq!(s.as_str_or_empty().chars().filter(|c| *c == '-').count(), 4);
                 // Version 4 indicator at position 14
-                assert_eq!(s.as_str().chars().nth(14), Some('4'));
+                assert_eq!(s.as_str_or_empty().chars().nth(14), Some('4'));
             }
             _ => panic!("Expected String"),
         }
@@ -188,7 +188,7 @@ fn test_uuid4_unique() {
 
         match (value1, value2) {
             (Value::String(s1), Value::String(s2)) => {
-                assert_ne!(s1.as_str(), s2.as_str());
+                assert_ne!(s1.as_str_or_empty(), s2.as_str_or_empty());
             }
             _ => panic!("Expected Strings"),
         }
@@ -206,7 +206,7 @@ fn test_random_bytes_max_limit() {
         match value {
             Value::String(s) => {
                 // 1024 bytes = 2048 hex chars
-                assert_eq!(s.as_str().len(), 2048);
+                assert_eq!(s.as_str_or_empty().len(), 2048);
             }
             _ => panic!("Expected String"),
         }
@@ -251,7 +251,7 @@ fn test_aes_gcm_roundtrip() {
         // Check plaintext
         let (_, result) = pop(stack);
         if let Value::String(s) = result {
-            assert_eq!(s.as_str(), "hello world");
+            assert_eq!(s.as_str_or_empty(), "hello world");
         } else {
             panic!("expected string");
         }
@@ -369,9 +369,9 @@ fn test_pbkdf2_sha256() {
         // Check key is 64 hex chars (32 bytes)
         let (_, result) = pop(stack);
         if let Value::String(s) = result {
-            assert_eq!(s.as_str().len(), 64);
+            assert_eq!(s.as_str_or_empty().len(), 64);
             // Verify it's valid hex
-            assert!(hex::decode(s.as_str()).is_ok());
+            assert!(hex::decode(s.as_str_or_empty()).is_ok());
         } else {
             panic!("expected string");
         }
@@ -531,13 +531,13 @@ fn test_ed25519_keypair_ffi() {
 
         // Both should be 64-char hex strings (32 bytes)
         if let Value::String(pk) = public_key {
-            assert_eq!(pk.as_str().len(), 64);
+            assert_eq!(pk.as_str_or_empty().len(), 64);
         } else {
             panic!("Expected String for public key");
         }
 
         if let Value::String(sk) = private_key {
-            assert_eq!(sk.as_str().len(), 64);
+            assert_eq!(sk.as_str_or_empty().len(), 64);
         } else {
             panic!("Expected String for private key");
         }
@@ -566,7 +566,7 @@ fn test_ed25519_sign_ffi() {
 
         assert_eq!(success, Value::Bool(true));
         if let Value::String(sig) = signature {
-            assert_eq!(sig.as_str().len(), 128); // 64 bytes = 128 hex chars
+            assert_eq!(sig.as_str_or_empty().len(), 128); // 64 bytes = 128 hex chars
         } else {
             panic!("Expected String for signature");
         }

--- a/crates/runtime/src/crypto/tests.rs
+++ b/crates/runtime/src/crypto/tests.rs
@@ -328,9 +328,9 @@ fn test_aes_gcm_invalid_ciphertext() {
 fn test_aes_gcm_empty_plaintext() {
     let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-    let ciphertext = aes_gcm_encrypt("", key).unwrap();
+    let ciphertext = aes_gcm_encrypt(b"", key).unwrap();
     let decrypted = aes_gcm_decrypt(&ciphertext, key).unwrap();
-    assert_eq!(decrypted, "");
+    assert_eq!(decrypted, b"");
 }
 
 #[test]
@@ -338,9 +338,9 @@ fn test_aes_gcm_special_characters() {
     let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     let plaintext = "Hello\nWorld\tTab\"Quote\\Backslash";
 
-    let ciphertext = aes_gcm_encrypt(plaintext, key).unwrap();
+    let ciphertext = aes_gcm_encrypt(plaintext.as_bytes(), key).unwrap();
     let decrypted = aes_gcm_decrypt(&ciphertext, key).unwrap();
-    assert_eq!(decrypted, plaintext);
+    assert_eq!(decrypted, plaintext.as_bytes());
 }
 
 // PBKDF2 Tests
@@ -381,12 +381,12 @@ fn test_pbkdf2_sha256() {
 #[test]
 fn test_pbkdf2_deterministic() {
     // Same inputs should produce same key
-    let key1 = derive_key_pbkdf2("password", "salt", 10000);
-    let key2 = derive_key_pbkdf2("password", "salt", 10000);
+    let key1 = derive_key_pbkdf2(b"password", b"salt", 10000);
+    let key2 = derive_key_pbkdf2(b"password", b"salt", 10000);
     assert_eq!(key1, key2);
 
     // Different inputs should produce different keys
-    let key3 = derive_key_pbkdf2("password", "different-salt", 10000);
+    let key3 = derive_key_pbkdf2(b"password", b"different-salt", 10000);
     assert_ne!(key1, key3);
 }
 
@@ -414,16 +414,16 @@ fn test_encrypt_decrypt_with_derived_key() {
     let iterations = 10000u32;
 
     // Derive key
-    let key = derive_key_pbkdf2(password, salt, iterations);
+    let key = derive_key_pbkdf2(password.as_bytes(), salt.as_bytes(), iterations);
     let key_hex = hex::encode(key);
 
     // Encrypt
     let plaintext = "sensitive data to protect";
-    let ciphertext = aes_gcm_encrypt(plaintext, &key_hex).unwrap();
+    let ciphertext = aes_gcm_encrypt(plaintext.as_bytes(), &key_hex).unwrap();
 
     // Decrypt
     let decrypted = aes_gcm_decrypt(&ciphertext, &key_hex).unwrap();
-    assert_eq!(decrypted, plaintext);
+    assert_eq!(decrypted, plaintext.as_bytes());
 }
 
 // Ed25519 tests
@@ -440,11 +440,11 @@ fn test_ed25519_sign_verify() {
     let public_hex = hex::encode(verifying_key.to_bytes());
 
     // Sign
-    let signature = ed25519_sign(message, &private_hex).unwrap();
+    let signature = ed25519_sign(message.as_bytes(), &private_hex).unwrap();
     assert_eq!(signature.len(), 128); // 64 bytes = 128 hex chars
 
     // Verify
-    assert!(ed25519_verify(message, &signature, &public_hex));
+    assert!(ed25519_verify(message.as_bytes(), &signature, &public_hex));
 }
 
 #[test]
@@ -458,10 +458,14 @@ fn test_ed25519_wrong_message() {
     let private_hex = hex::encode(signing_key.to_bytes());
     let public_hex = hex::encode(verifying_key.to_bytes());
 
-    let signature = ed25519_sign(message, &private_hex).unwrap();
+    let signature = ed25519_sign(message.as_bytes(), &private_hex).unwrap();
 
     // Verify with wrong message should fail
-    assert!(!ed25519_verify(wrong_message, &signature, &public_hex));
+    assert!(!ed25519_verify(
+        wrong_message.as_bytes(),
+        &signature,
+        &public_hex
+    ));
 }
 
 #[test]
@@ -474,10 +478,14 @@ fn test_ed25519_wrong_key() {
     let private_hex = hex::encode(signing_key1.to_bytes());
     let wrong_public_hex = hex::encode(signing_key2.verifying_key().to_bytes());
 
-    let signature = ed25519_sign(message, &private_hex).unwrap();
+    let signature = ed25519_sign(message.as_bytes(), &private_hex).unwrap();
 
     // Verify with wrong public key should fail
-    assert!(!ed25519_verify(message, &signature, &wrong_public_hex));
+    assert!(!ed25519_verify(
+        message.as_bytes(),
+        &signature,
+        &wrong_public_hex
+    ));
 }
 
 #[test]
@@ -486,7 +494,7 @@ fn test_ed25519_invalid_key_length() {
     let invalid_key = "tooshort";
 
     // Sign with invalid key should fail
-    assert!(ed25519_sign(message, invalid_key).is_none());
+    assert!(ed25519_sign(message.as_bytes(), invalid_key).is_none());
 }
 
 #[test]
@@ -499,7 +507,11 @@ fn test_ed25519_invalid_signature() {
     let invalid_signature = "0".repeat(128); // Valid length but wrong signature
 
     // Verify with invalid signature should fail
-    assert!(!ed25519_verify(message, &invalid_signature, &public_hex));
+    assert!(!ed25519_verify(
+        message.as_bytes(),
+        &invalid_signature,
+        &public_hex
+    ));
 }
 
 #[test]
@@ -513,10 +525,10 @@ fn test_ed25519_empty_message() {
     let public_hex = hex::encode(verifying_key.to_bytes());
 
     // Sign empty message
-    let signature = ed25519_sign(message, &private_hex).unwrap();
+    let signature = ed25519_sign(message.as_bytes(), &private_hex).unwrap();
 
     // Verify should succeed
-    assert!(ed25519_verify(message, &signature, &public_hex));
+    assert!(ed25519_verify(message.as_bytes(), &signature, &public_hex));
 }
 
 #[test]
@@ -586,7 +598,7 @@ fn test_ed25519_verify_ffi() {
         let public_hex = hex::encode(verifying_key.to_bytes());
 
         let message = "Verify this message";
-        let signature = ed25519_sign(message, &private_hex).unwrap();
+        let signature = ed25519_sign(message.as_bytes(), &private_hex).unwrap();
 
         let stack = push(stack, Value::String(global_string(message.to_string())));
         let stack = push(stack, Value::String(global_string(signature)));
@@ -750,4 +762,61 @@ fn test_random_int_uniformity() {
             tolerance
         );
     }
+}
+
+// ----------------------------------------------------------------------------
+// Byte-cleanliness regression tests.
+//
+// Crypto plaintext, message, password, and salt arguments are all arbitrary
+// bytes — they must round-trip without UTF-8 validation eating high-byte
+// content. Bug class: pre-fix, the FFI wrappers passed `as_str_or_empty()`
+// to the inner functions, silently encrypting / signing / hashing the empty
+// string for any non-UTF-8 input.
+// ----------------------------------------------------------------------------
+
+const CRYPTO_BIN: &[u8] = &[0x00, 0xDC, b'x', 0xFF, 0xC3, b'!', 0x80];
+
+#[test]
+fn aes_gcm_round_trips_binary_plaintext() {
+    let key_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let ciphertext = aes_gcm_encrypt(CRYPTO_BIN, key_hex).unwrap();
+    let decrypted = aes_gcm_decrypt(&ciphertext, key_hex).unwrap();
+    assert_eq!(
+        decrypted, CRYPTO_BIN,
+        "binary plaintext must survive AES-GCM round trip byte-for-byte"
+    );
+}
+
+#[test]
+fn ed25519_signs_and_verifies_binary_message() {
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let private_hex = hex::encode(signing_key.to_bytes());
+    let public_hex = hex::encode(signing_key.verifying_key().to_bytes());
+
+    let signature =
+        ed25519_sign(CRYPTO_BIN, &private_hex).expect("signing arbitrary bytes must succeed");
+    assert!(
+        ed25519_verify(CRYPTO_BIN, &signature, &public_hex),
+        "verification of a binary message must succeed"
+    );
+
+    // A different message — same key — must not verify.
+    let other = &[0x01, 0x02, 0x03];
+    assert!(
+        !ed25519_verify(other, &signature, &public_hex),
+        "signature must not verify against a different message"
+    );
+}
+
+#[test]
+fn pbkdf2_derives_from_binary_password_and_salt() {
+    let key1 = derive_key_pbkdf2(CRYPTO_BIN, &[0x00, 0xFF, 0x42], 1000);
+    let key2 = derive_key_pbkdf2(CRYPTO_BIN, &[0x00, 0xFF, 0x42], 1000);
+    assert_eq!(key1, key2, "deterministic for same binary inputs");
+
+    // Differ only in one byte of the password — must produce a different key.
+    let mut alt = CRYPTO_BIN.to_vec();
+    alt[0] = 0x01;
+    let key3 = derive_key_pbkdf2(&alt, &[0x00, 0xFF, 0x42], 1000);
+    assert_ne!(key1, key3, "byte-level sensitivity in password");
 }

--- a/crates/runtime/src/encoding.rs
+++ b/crates/runtime/src/encoding.rs
@@ -2,6 +2,11 @@
 //!
 //! These functions are exported with C ABI for LLVM codegen to call.
 //!
+//! All encode/decode pairs are byte-clean: encode accepts arbitrary
+//! input bytes; decode produces arbitrary output bytes wrapped in a
+//! byte-clean SeqString. This is the canonical use case for these
+//! encodings — round-tripping binary content as text.
+//!
 //! # API
 //!
 //! ```seq
@@ -18,7 +23,7 @@
 //! "68656c6c6f" encoding.hex-decode   # ( String -- String Bool )
 //! ```
 
-use crate::seqstring::global_string;
+use crate::seqstring::{global_bytes, global_string};
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 
@@ -60,18 +65,14 @@ pub unsafe extern "C" fn patch_seq_base64_decode(stack: Stack) -> Stack {
     let (stack, value) = unsafe { pop(stack) };
 
     match value {
+        // Decoded bytes go straight into a byte-clean SeqString —
+        // base64 is the canonical "encode arbitrary bytes as text",
+        // so the decode side must round-trip whatever was encoded.
         Value::String(s) => match BASE64_STANDARD.decode(s.as_bytes()) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(decoded) => {
-                    let stack = unsafe { push(stack, Value::String(global_string(decoded))) };
-                    unsafe { push(stack, Value::Bool(true)) }
-                }
-                Err(_) => {
-                    // Decoded bytes are not valid UTF-8
-                    let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
-                    unsafe { push(stack, Value::Bool(false)) }
-                }
-            },
+            Ok(bytes) => {
+                let stack = unsafe { push(stack, Value::String(global_bytes(bytes))) };
+                unsafe { push(stack, Value::Bool(true)) }
+            }
             Err(_) => {
                 // Invalid Base64 input
                 let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
@@ -125,16 +126,10 @@ pub unsafe extern "C" fn patch_seq_base64url_decode(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => match BASE64_URL_SAFE_NO_PAD.decode(s.as_bytes()) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(decoded) => {
-                    let stack = unsafe { push(stack, Value::String(global_string(decoded))) };
-                    unsafe { push(stack, Value::Bool(true)) }
-                }
-                Err(_) => {
-                    let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
-                    unsafe { push(stack, Value::Bool(false)) }
-                }
-            },
+            Ok(bytes) => {
+                let stack = unsafe { push(stack, Value::String(global_bytes(bytes))) };
+                unsafe { push(stack, Value::Bool(true)) }
+            }
             Err(_) => {
                 let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
                 unsafe { push(stack, Value::Bool(false)) }
@@ -186,18 +181,13 @@ pub unsafe extern "C" fn patch_seq_hex_decode(stack: Stack) -> Stack {
     let (stack, value) = unsafe { pop(stack) };
 
     match value {
-        Value::String(s) => match hex::decode(s.as_str_or_empty()) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(decoded) => {
-                    let stack = unsafe { push(stack, Value::String(global_string(decoded))) };
-                    unsafe { push(stack, Value::Bool(true)) }
-                }
-                Err(_) => {
-                    // Decoded bytes are not valid UTF-8
-                    let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };
-                    unsafe { push(stack, Value::Bool(false)) }
-                }
-            },
+        // Hex is the same story as base64: an encoding *for* arbitrary
+        // bytes, so the decode result is byte-clean.
+        Value::String(s) => match hex::decode(s.as_bytes()) {
+            Ok(bytes) => {
+                let stack = unsafe { push(stack, Value::String(global_bytes(bytes))) };
+                unsafe { push(stack, Value::Bool(true)) }
+            }
             Err(_) => {
                 // Invalid hex input
                 let stack = unsafe { push(stack, Value::String(global_string(String::new()))) };

--- a/crates/runtime/src/encoding.rs
+++ b/crates/runtime/src/encoding.rs
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn patch_seq_base64_encode(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => {
-            let encoded = BASE64_STANDARD.encode(s.as_str().as_bytes());
+            let encoded = BASE64_STANDARD.encode(s.as_bytes());
             unsafe { push(stack, Value::String(global_string(encoded))) }
         }
         _ => panic!("base64-encode: expected String on stack, got {:?}", value),
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn patch_seq_base64_decode(stack: Stack) -> Stack {
     let (stack, value) = unsafe { pop(stack) };
 
     match value {
-        Value::String(s) => match BASE64_STANDARD.decode(s.as_str().as_bytes()) {
+        Value::String(s) => match BASE64_STANDARD.decode(s.as_bytes()) {
             Ok(bytes) => match String::from_utf8(bytes) {
                 Ok(decoded) => {
                     let stack = unsafe { push(stack, Value::String(global_string(decoded))) };
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn patch_seq_base64url_encode(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => {
-            let encoded = BASE64_URL_SAFE_NO_PAD.encode(s.as_str().as_bytes());
+            let encoded = BASE64_URL_SAFE_NO_PAD.encode(s.as_bytes());
             unsafe { push(stack, Value::String(global_string(encoded))) }
         }
         _ => panic!(
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn patch_seq_base64url_decode(stack: Stack) -> Stack {
     let (stack, value) = unsafe { pop(stack) };
 
     match value {
-        Value::String(s) => match BASE64_URL_SAFE_NO_PAD.decode(s.as_str().as_bytes()) {
+        Value::String(s) => match BASE64_URL_SAFE_NO_PAD.decode(s.as_bytes()) {
             Ok(bytes) => match String::from_utf8(bytes) {
                 Ok(decoded) => {
                     let stack = unsafe { push(stack, Value::String(global_string(decoded))) };
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn patch_seq_hex_encode(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => {
-            let encoded = hex::encode(s.as_str().as_bytes());
+            let encoded = hex::encode(s.as_bytes());
             unsafe { push(stack, Value::String(global_string(encoded))) }
         }
         _ => panic!("hex-encode: expected String on stack, got {:?}", value),
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn patch_seq_hex_decode(stack: Stack) -> Stack {
     let (stack, value) = unsafe { pop(stack) };
 
     match value {
-        Value::String(s) => match hex::decode(s.as_str()) {
+        Value::String(s) => match hex::decode(s.as_str_or_empty()) {
             Ok(bytes) => match String::from_utf8(bytes) {
                 Ok(decoded) => {
                     let stack = unsafe { push(stack, Value::String(global_string(decoded))) };

--- a/crates/runtime/src/encoding/tests.rs
+++ b/crates/runtime/src/encoding/tests.rs
@@ -10,7 +10,7 @@ fn test_base64_encode() {
         let (_, value) = pop(stack);
 
         match value {
-            Value::String(s) => assert_eq!(s.as_str(), "aGVsbG8="),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "aGVsbG8="),
             _ => panic!("Expected String"),
         }
     }
@@ -27,7 +27,7 @@ fn test_base64_decode_success() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str(), "hello"),
+            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str_or_empty(), "hello"),
             _ => panic!("Expected (String, true)"),
         }
     }
@@ -47,7 +47,7 @@ fn test_base64_decode_failure() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(false)) => assert_eq!(s.as_str(), ""),
+            (Value::String(s), Value::Bool(false)) => assert_eq!(s.as_str_or_empty(), ""),
             _ => panic!("Expected (empty String, false)"),
         }
     }
@@ -65,9 +65,9 @@ fn test_base64url_encode() {
         match value {
             Value::String(s) => {
                 // Should not contain + or / or =
-                assert!(!s.as_str().contains('+'));
-                assert!(!s.as_str().contains('/'));
-                assert!(!s.as_str().contains('='));
+                assert!(!s.as_str_or_empty().contains('+'));
+                assert!(!s.as_str_or_empty().contains('/'));
+                assert!(!s.as_str_or_empty().contains('='));
             }
             _ => panic!("Expected String"),
         }
@@ -87,7 +87,7 @@ fn test_base64url_roundtrip() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str(), original),
+            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str_or_empty(), original),
             _ => panic!("Expected (String, true)"),
         }
     }
@@ -102,7 +102,7 @@ fn test_hex_encode() {
         let (_, value) = pop(stack);
 
         match value {
-            Value::String(s) => assert_eq!(s.as_str(), "68656c6c6f"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "68656c6c6f"),
             _ => panic!("Expected String"),
         }
     }
@@ -122,7 +122,7 @@ fn test_hex_decode_success() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str(), "hello"),
+            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str_or_empty(), "hello"),
             _ => panic!("Expected (String, true)"),
         }
     }
@@ -142,7 +142,7 @@ fn test_hex_decode_uppercase() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str(), "hello"),
+            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str_or_empty(), "hello"),
             _ => panic!("Expected (String, true)"),
         }
     }
@@ -159,7 +159,7 @@ fn test_hex_decode_failure() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(false)) => assert_eq!(s.as_str(), ""),
+            (Value::String(s), Value::Bool(false)) => assert_eq!(s.as_str_or_empty(), ""),
             _ => panic!("Expected (empty String, false)"),
         }
     }
@@ -178,7 +178,7 @@ fn test_hex_roundtrip() {
         let (_, decoded) = pop(stack);
 
         match (decoded, success) {
-            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str(), original),
+            (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str_or_empty(), original),
             _ => panic!("Expected (String, true)"),
         }
     }

--- a/crates/runtime/src/encoding/tests.rs
+++ b/crates/runtime/src/encoding/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::seqstring::global_bytes;
 use crate::stack::pop;
 
 #[test]
@@ -180,6 +181,66 @@ fn test_hex_roundtrip() {
         match (decoded, success) {
             (Value::String(s), Value::Bool(true)) => assert_eq!(s.as_str_or_empty(), original),
             _ => panic!("Expected (String, true)"),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Byte-cleanliness regression tests for encoding round-trips.
+//
+// base64 and hex are encodings *for* arbitrary bytes — the canonical use
+// case is binary-as-text. Round-tripping non-UTF-8 bytes through encode →
+// decode must produce byte-identical output.
+// ----------------------------------------------------------------------------
+
+const ENC_BIN: &[u8] = &[0x00, 0xDC, b'x', 0xFF, 0xC3, b'!', 0x80];
+
+#[test]
+fn byte_clean_base64_round_trips_binary() {
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(ENC_BIN.to_vec())));
+        let stack = patch_seq_base64_encode(stack);
+        let (stack, encoded) = pop(stack);
+        let encoded = match encoded {
+            Value::String(s) => s,
+            _ => panic!("expected encoded String"),
+        };
+        // base64 output is always ASCII text.
+        let _ = encoded.as_str().expect("base64 output must be valid UTF-8");
+
+        let stack = push(stack, Value::String(encoded));
+        let stack = patch_seq_base64_decode(stack);
+        let (stack, success) = pop(stack);
+        assert_eq!(success, Value::Bool(true));
+        let (_, decoded) = pop(stack);
+        match decoded {
+            Value::String(s) => assert_eq!(s.as_bytes(), ENC_BIN),
+            _ => panic!("expected decoded String"),
+        }
+    }
+}
+
+#[test]
+fn byte_clean_hex_round_trips_binary() {
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(ENC_BIN.to_vec())));
+        let stack = patch_seq_hex_encode(stack);
+        let (stack, encoded) = pop(stack);
+        let encoded = match encoded {
+            Value::String(s) => s,
+            _ => panic!("expected encoded String"),
+        };
+
+        let stack = push(stack, Value::String(encoded));
+        let stack = patch_seq_hex_decode(stack);
+        let (stack, success) = pop(stack);
+        assert_eq!(success, Value::Bool(true));
+        let (_, decoded) = pop(stack);
+        match decoded {
+            Value::String(s) => assert_eq!(s.as_bytes(), ENC_BIN),
+            _ => panic!("expected decoded String"),
         }
     }
 }

--- a/crates/runtime/src/file.rs
+++ b/crates/runtime/src/file.rs
@@ -23,12 +23,24 @@
 //! ;
 //! ```
 
+use crate::seqstring::global_bytes;
 use crate::stack::{Stack, pop, push};
 use crate::value::{Value, VariantData};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::sync::Arc;
+
+/// Path conversion idiom: paths are inherently text on the OS APIs we
+/// target (Linux/macOS POSIX, which expose `&str` via Rust's `Path`),
+/// so non-UTF-8 path bytes can't be handed to the OS as-is.
+/// `SeqString::as_str_or_empty()` returns `""` for non-UTF-8 input,
+/// which routes the call through the OS error path and produces the
+/// standard `(empty, false)` failure tuple — same observable result
+/// as if we'd validated upfront. Helper kept for readability.
+fn path_str(s: &crate::seqstring::SeqString) -> &str {
+    s.as_str_or_empty()
+}
 
 /// Read entire file contents as a string
 ///
@@ -49,9 +61,12 @@ pub unsafe extern "C" fn patch_seq_file_slurp(stack: Stack) -> Stack {
     let (rest, value) = unsafe { pop(stack) };
 
     match value {
-        Value::String(path) => match fs::read_to_string(path.as_str()) {
+        // Read the file as raw bytes — `fs::read` returns `Vec<u8>` and
+        // imposes no UTF-8 requirement, so binary file slurp now works.
+        // Wrap the bytes directly into a byte-clean SeqString.
+        Value::String(path) => match fs::read(path_str(&path)) {
             Ok(contents) => {
-                let stack = unsafe { push(rest, Value::String(contents.into())) };
+                let stack = unsafe { push(rest, Value::String(global_bytes(contents))) };
                 unsafe { push(stack, Value::Bool(true)) }
             }
             Err(_) => {
@@ -80,7 +95,7 @@ pub unsafe extern "C" fn patch_seq_file_exists(stack: Stack) -> Stack {
 
     match value {
         Value::String(path) => {
-            let exists = Path::new(path.as_str()).exists();
+            let exists = Path::new(path_str(&path)).exists();
             unsafe { push(rest, Value::Bool(exists)) }
         }
         _ => panic!(
@@ -143,7 +158,7 @@ pub unsafe extern "C" fn patch_seq_file_for_each_line_plus(stack: Stack) -> Stac
     };
 
     // Open file
-    let file = match File::open(path.as_str()) {
+    let file = match File::open(path_str(&path)) {
         Ok(f) => f,
         Err(e) => {
             // Return error: ( "error message" 0 )
@@ -247,7 +262,9 @@ pub unsafe extern "C" fn patch_seq_file_spit(stack: Stack) -> Stack {
         ),
     };
 
-    match fs::write(path.as_str(), content.as_str()) {
+    // Content is byte-clean — `fs::write` accepts any `AsRef<[u8]>`
+    // so we don't need UTF-8 validation here. Binary file write works.
+    match fs::write(path_str(&path), content.as_bytes()) {
         Ok(()) => unsafe { push(stack, Value::Bool(true)) },
         Err(_) => unsafe { push(stack, Value::Bool(false)) },
     }
@@ -288,8 +305,8 @@ pub unsafe extern "C" fn patch_seq_file_append(stack: Stack) -> Stack {
     let result = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(path.as_str())
-        .and_then(|mut file| file.write_all(content.as_str().as_bytes()));
+        .open(path_str(&path))
+        .and_then(|mut file| file.write_all(content.as_bytes()));
 
     match result {
         Ok(()) => unsafe { push(stack, Value::Bool(true)) },
@@ -317,7 +334,7 @@ pub unsafe extern "C" fn patch_seq_file_delete(stack: Stack) -> Stack {
         _ => panic!("file.delete: expected String path, got {:?}", path_value),
     };
 
-    match fs::remove_file(path.as_str()) {
+    match fs::remove_file(path_str(&path)) {
         Ok(()) => unsafe { push(stack, Value::Bool(true)) },
         Err(_) => unsafe { push(stack, Value::Bool(false)) },
     }
@@ -343,7 +360,7 @@ pub unsafe extern "C" fn patch_seq_file_size(stack: Stack) -> Stack {
         _ => panic!("file.size: expected String path, got {:?}", path_value),
     };
 
-    match fs::metadata(path.as_str()) {
+    match fs::metadata(path_str(&path)) {
         Ok(metadata) => {
             let size = metadata.len() as i64;
             let stack = unsafe { push(stack, Value::Int(size)) };
@@ -379,7 +396,7 @@ pub unsafe extern "C" fn patch_seq_dir_exists(stack: Stack) -> Stack {
         _ => panic!("dir.exists?: expected String path, got {:?}", path_value),
     };
 
-    let exists = Path::new(path.as_str()).is_dir();
+    let exists = Path::new(path_str(&path)).is_dir();
     unsafe { push(stack, Value::Bool(exists)) }
 }
 
@@ -403,7 +420,7 @@ pub unsafe extern "C" fn patch_seq_dir_make(stack: Stack) -> Stack {
         _ => panic!("dir.make: expected String path, got {:?}", path_value),
     };
 
-    match fs::create_dir_all(path.as_str()) {
+    match fs::create_dir_all(path_str(&path)) {
         Ok(()) => unsafe { push(stack, Value::Bool(true)) },
         Err(_) => unsafe { push(stack, Value::Bool(false)) },
     }
@@ -429,7 +446,7 @@ pub unsafe extern "C" fn patch_seq_dir_delete(stack: Stack) -> Stack {
         _ => panic!("dir.delete: expected String path, got {:?}", path_value),
     };
 
-    match fs::remove_dir(path.as_str()) {
+    match fs::remove_dir(path_str(&path)) {
         Ok(()) => unsafe { push(stack, Value::Bool(true)) },
         Err(_) => unsafe { push(stack, Value::Bool(false)) },
     }
@@ -455,7 +472,7 @@ pub unsafe extern "C" fn patch_seq_dir_list(stack: Stack) -> Stack {
         _ => panic!("dir.list: expected String path, got {:?}", path_value),
     };
 
-    match fs::read_dir(path.as_str()) {
+    match fs::read_dir(path_str(&path)) {
         Ok(entries) => {
             let mut names: Vec<Value> = Vec::new();
             for entry in entries.flatten() {

--- a/crates/runtime/src/file/tests.rs
+++ b/crates/runtime/src/file/tests.rs
@@ -19,7 +19,7 @@ fn test_file_slurp() {
         assert_eq!(success, Value::Bool(true));
         let (_stack, value) = pop(stack);
         match value {
-            Value::String(s) => assert_eq!(s.as_str().trim(), "Hello, file!"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty().trim(), "Hello, file!"),
             _ => panic!("Expected String"),
         }
     }
@@ -68,7 +68,7 @@ fn test_file_slurp_utf8() {
         assert_eq!(success, Value::Bool(true));
         let (_stack, value) = pop(stack);
         match value {
-            Value::String(s) => assert_eq!(s.as_str(), "Hello, 世界! 🌍"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "Hello, 世界! 🌍"),
             _ => panic!("Expected String"),
         }
     }
@@ -89,7 +89,7 @@ fn test_file_slurp_empty() {
         assert_eq!(success, Value::Bool(true)); // Empty file is still success
         let (_stack, value) = pop(stack);
         match value {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), ""),
             _ => panic!("Expected String"),
         }
     }
@@ -106,7 +106,7 @@ fn test_file_slurp_not_found() {
         let (_stack, contents) = pop(stack);
         assert_eq!(success, Value::Bool(false));
         match contents {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), ""),
             _ => panic!("Expected String"),
         }
     }
@@ -450,7 +450,7 @@ fn test_dir_list_success() {
         let (_stack, list) = pop(stack);
         match list {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
                 assert_eq!(v.fields.len(), 2);
             }
             _ => panic!("Expected Variant(List)"),
@@ -474,7 +474,7 @@ fn test_dir_list_empty() {
         let (_stack, list) = pop(stack);
         match list {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
                 assert_eq!(v.fields.len(), 0);
             }
             _ => panic!("Expected Variant(List)"),
@@ -495,7 +495,7 @@ fn test_dir_list_nonexistent() {
         let (_stack, list) = pop(stack);
         match list {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
                 assert_eq!(v.fields.len(), 0); // empty list on failure
             }
             _ => panic!("Expected Variant(List)"),

--- a/crates/runtime/src/float_ops.rs
+++ b/crates/runtime/src/float_ops.rs
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn patch_seq_string_to_float(stack: Stack) -> Stack {
     let (stack, val) = unsafe { pop(stack) };
 
     match val {
-        Value::String(s) => match s.as_str().parse::<f64>() {
+        Value::String(s) => match s.as_str_or_empty().parse::<f64>() {
             Ok(f) => {
                 let stack = unsafe { push(stack, Value::Float(f)) };
                 unsafe { push(stack, Value::Bool(true)) }

--- a/crates/runtime/src/float_ops/tests.rs
+++ b/crates/runtime/src/float_ops/tests.rs
@@ -286,7 +286,7 @@ fn test_float_to_string() {
 
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "3.5"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "3.5"),
             _ => panic!("Expected String"),
         }
     }
@@ -302,7 +302,7 @@ fn test_float_to_string_whole_number() {
 
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "42"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "42"),
             _ => panic!("Expected String"),
         }
     }

--- a/crates/runtime/src/http_client.rs
+++ b/crates/runtime/src/http_client.rs
@@ -53,7 +53,7 @@
 //! - **TLS**: Enabled by default via rustls (no OpenSSL dependency)
 //! - **Connection pooling**: Enabled via shared agent instance
 
-use crate::seqstring::global_string;
+use crate::seqstring::{global_bytes, global_string};
 use crate::stack::{Stack, pop, push};
 use crate::value::{MapKey, Value};
 
@@ -198,8 +198,14 @@ fn validate_url_for_ssrf(url: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Build a response map from status, body, ok flag, and optional error
-fn build_response_map(status: i64, body: String, ok: bool, error: Option<String>) -> Value {
+/// Build a response map from status, body, ok flag, and optional error.
+///
+/// `body` is the raw response payload — HTTP bodies are arbitrary
+/// octets per RFC 7230, so we store them in a byte-clean SeqString
+/// without UTF-8 validation. Seq programs that need text decode
+/// the bytes themselves; programs handling binary downloads keep
+/// the original bytes intact.
+fn build_response_map(status: i64, body: Vec<u8>, ok: bool, error: Option<String>) -> Value {
     let mut map: HashMap<MapKey, Value> = HashMap::new();
 
     map.insert(
@@ -208,7 +214,7 @@ fn build_response_map(status: i64, body: String, ok: bool, error: Option<String>
     );
     map.insert(
         MapKey::String(global_string("body".to_string())),
-        Value::String(global_string(body)),
+        Value::String(global_bytes(body)),
     );
     map.insert(
         MapKey::String(global_string("ok".to_string())),
@@ -227,7 +233,7 @@ fn build_response_map(status: i64, body: String, ok: bool, error: Option<String>
 
 /// Build an error response map
 fn error_response(error: String) -> Value {
-    build_response_map(0, String::new(), false, Some(error))
+    build_response_map(0, Vec::new(), false, Some(error))
 }
 
 /// Perform HTTP GET request
@@ -274,9 +280,10 @@ pub unsafe extern "C" fn patch_seq_http_post(stack: Stack) -> Stack {
 
     match (url_value, body_value, content_type_value) {
         (Value::String(url), Value::String(body), Value::String(content_type)) => {
+            // Body is byte-clean; URL and Content-Type stay text.
             let response = perform_post(
                 url.as_str_or_empty(),
-                body.as_str_or_empty(),
+                body.as_bytes(),
                 content_type.as_str_or_empty(),
             );
             unsafe { push(stack, response) }
@@ -306,9 +313,10 @@ pub unsafe extern "C" fn patch_seq_http_put(stack: Stack) -> Stack {
 
     match (url_value, body_value, content_type_value) {
         (Value::String(url), Value::String(body), Value::String(content_type)) => {
+            // Body is byte-clean (see http.post); URL and Content-Type stay text.
             let response = perform_put(
                 url.as_str_or_empty(),
-                body.as_str_or_empty(),
+                body.as_bytes(),
                 content_type.as_str_or_empty(),
             );
             unsafe { push(stack, response) }
@@ -346,6 +354,18 @@ pub unsafe extern "C" fn patch_seq_http_delete(stack: Stack) -> Stack {
     }
 }
 
+/// Read up to `MAX_BODY_SIZE` bytes from a ureq response. Returns the
+/// raw byte buffer on success — callers wrap it in a byte-clean
+/// SeqString so binary response bodies (image downloads, Protobuf,
+/// MessagePack, etc.) round-trip intact.
+fn read_response_bytes(response: ureq::Response) -> Result<Vec<u8>, std::io::Error> {
+    use std::io::Read;
+    let mut reader = response.into_reader().take((MAX_BODY_SIZE as u64) + 1);
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
 /// Handle HTTP response result and convert to Value
 fn handle_response(result: Result<ureq::Response, ureq::Error>) -> Value {
     match result {
@@ -353,7 +373,7 @@ fn handle_response(result: Result<ureq::Response, ureq::Error>) -> Value {
             let status = response.status() as i64;
             let ok = (200..300).contains(&response.status());
 
-            match response.into_string() {
+            match read_response_bytes(response) {
                 Ok(body) => {
                     if body.len() > MAX_BODY_SIZE {
                         error_response(format!(
@@ -369,8 +389,8 @@ fn handle_response(result: Result<ureq::Response, ureq::Error>) -> Value {
             }
         }
         Err(ureq::Error::Status(code, response)) => {
-            // HTTP error status (4xx, 5xx)
-            let body = response.into_string().unwrap_or_default();
+            // HTTP error status (4xx, 5xx) — body might still be useful.
+            let body = read_response_bytes(response).unwrap_or_default();
             build_response_map(
                 code as i64,
                 body,
@@ -394,8 +414,10 @@ fn perform_get(url: &str) -> Value {
     handle_response(HTTP_AGENT.get(url).call())
 }
 
-/// Internal: Perform POST request
-fn perform_post(url: &str, body: &str, content_type: &str) -> Value {
+/// Internal: Perform POST request. Body is byte-clean — HTTP request
+/// bodies are arbitrary octets per RFC 7230, so binary content
+/// (Protobuf, MessagePack, image uploads) flows through unchanged.
+fn perform_post(url: &str, body: &[u8], content_type: &str) -> Value {
     // SSRF protection: validate URL before making request
     if let Err(msg) = validate_url_for_ssrf(url) {
         return error_response(msg);
@@ -404,12 +426,12 @@ fn perform_post(url: &str, body: &str, content_type: &str) -> Value {
         HTTP_AGENT
             .post(url)
             .set("Content-Type", content_type)
-            .send_string(body),
+            .send_bytes(body),
     )
 }
 
-/// Internal: Perform PUT request
-fn perform_put(url: &str, body: &str, content_type: &str) -> Value {
+/// Internal: Perform PUT request. Body is byte-clean (see `perform_post`).
+fn perform_put(url: &str, body: &[u8], content_type: &str) -> Value {
     // SSRF protection: validate URL before making request
     if let Err(msg) = validate_url_for_ssrf(url) {
         return error_response(msg);
@@ -418,7 +440,7 @@ fn perform_put(url: &str, body: &str, content_type: &str) -> Value {
         HTTP_AGENT
             .put(url)
             .set("Content-Type", content_type)
-            .send_string(body),
+            .send_bytes(body),
     )
 }
 

--- a/crates/runtime/src/http_client.rs
+++ b/crates/runtime/src/http_client.rs
@@ -246,7 +246,7 @@ pub unsafe extern "C" fn patch_seq_http_get(stack: Stack) -> Stack {
 
     match url_value {
         Value::String(url) => {
-            let response = perform_get(url.as_str());
+            let response = perform_get(url.as_str_or_empty());
             unsafe { push(stack, response) }
         }
         _ => panic!(
@@ -274,7 +274,11 @@ pub unsafe extern "C" fn patch_seq_http_post(stack: Stack) -> Stack {
 
     match (url_value, body_value, content_type_value) {
         (Value::String(url), Value::String(body), Value::String(content_type)) => {
-            let response = perform_post(url.as_str(), body.as_str(), content_type.as_str());
+            let response = perform_post(
+                url.as_str_or_empty(),
+                body.as_str_or_empty(),
+                content_type.as_str_or_empty(),
+            );
             unsafe { push(stack, response) }
         }
         (url, body, ct) => panic!(
@@ -302,7 +306,11 @@ pub unsafe extern "C" fn patch_seq_http_put(stack: Stack) -> Stack {
 
     match (url_value, body_value, content_type_value) {
         (Value::String(url), Value::String(body), Value::String(content_type)) => {
-            let response = perform_put(url.as_str(), body.as_str(), content_type.as_str());
+            let response = perform_put(
+                url.as_str_or_empty(),
+                body.as_str_or_empty(),
+                content_type.as_str_or_empty(),
+            );
             unsafe { push(stack, response) }
         }
         (url, body, ct) => panic!(
@@ -328,7 +336,7 @@ pub unsafe extern "C" fn patch_seq_http_delete(stack: Stack) -> Stack {
 
     match url_value {
         Value::String(url) => {
-            let response = perform_delete(url.as_str());
+            let response = perform_delete(url.as_str_or_empty());
             unsafe { push(stack, response) }
         }
         _ => panic!(

--- a/crates/runtime/src/http_client/tests.rs
+++ b/crates/runtime/src/http_client/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 
 #[test]
 fn test_build_response_map_success() {
-    let response = build_response_map(200, "Hello".to_string(), true, None);
+    let response = build_response_map(200, b"Hello".to_vec(), true, None);
 
     match response {
         Value::Map(map_data) => {
@@ -37,7 +37,7 @@ fn test_build_response_map_success() {
 
 #[test]
 fn test_build_response_map_error() {
-    let response = build_response_map(404, String::new(), false, Some("Not Found".to_string()));
+    let response = build_response_map(404, Vec::new(), false, Some("Not Found".to_string()));
 
     match response {
         Value::Map(map_data) => {
@@ -88,6 +88,27 @@ fn test_error_response() {
             }
         }
         _ => panic!("Expected Map"),
+    }
+}
+
+// Byte-cleanliness: HTTP response bodies are arbitrary octets per
+// RFC 7230. The response map's "body" field must round-trip non-UTF-8
+// bytes intact so binary downloads (images, Protobuf, MessagePack)
+// reach Seq programs unmodified.
+
+const HTTP_BIN: &[u8] = &[0x00, 0xDC, b'x', 0xFF, 0xC3, b'!', 0x80];
+
+#[test]
+fn byte_clean_response_body_round_trips_binary() {
+    let response = build_response_map(200, HTTP_BIN.to_vec(), true, None);
+    let map = match response {
+        Value::Map(m) => m,
+        _ => panic!("expected Map"),
+    };
+    let body_key = MapKey::String(global_string("body".to_string()));
+    match map.get(&body_key) {
+        Some(Value::String(s)) => assert_eq!(s.as_bytes(), HTTP_BIN),
+        other => panic!("expected body String, got {:?}", other),
     }
 }
 

--- a/crates/runtime/src/http_client/tests.rs
+++ b/crates/runtime/src/http_client/tests.rs
@@ -18,7 +18,7 @@ fn test_build_response_map_success() {
             // Check body
             let body_key = MapKey::String(global_string("body".to_string()));
             if let Some(Value::String(s)) = map.get(&body_key) {
-                assert_eq!(s.as_str(), "Hello");
+                assert_eq!(s.as_str_or_empty(), "Hello");
             } else {
                 panic!("Expected body to be String");
             }
@@ -54,7 +54,7 @@ fn test_build_response_map_error() {
             // Check error message
             let error_key = MapKey::String(global_string("error".to_string()));
             if let Some(Value::String(s)) = map.get(&error_key) {
-                assert_eq!(s.as_str(), "Not Found");
+                assert_eq!(s.as_str_or_empty(), "Not Found");
             } else {
                 panic!("Expected error to be String");
             }
@@ -82,7 +82,7 @@ fn test_error_response() {
             // Check error message
             let error_key = MapKey::String(global_string("error".to_string()));
             if let Some(Value::String(s)) = map.get(&error_key) {
-                assert_eq!(s.as_str(), "Connection refused");
+                assert_eq!(s.as_str_or_empty(), "Connection refused");
             } else {
                 panic!("Expected error to be String");
             }

--- a/crates/runtime/src/io.rs
+++ b/crates/runtime/src/io.rs
@@ -60,14 +60,14 @@ pub unsafe extern "C" fn patch_seq_write_line(stack: Stack) -> Stack {
             // Write directly to fd 1 using libc to avoid Rust's std::io::stdout() RefCell.
             // Rust's standard I/O uses RefCell which panics on concurrent access from
             // multiple coroutines on the same thread.
-            let str_slice = s.as_str_or_empty();
+            // Byte-clean: write the underlying bytes directly to fd 1.
+            // libc::write takes a raw pointer + length, so we don't
+            // need a `&str`. Binary response bodies, ANSI escapes,
+            // arbitrary protocol output all flow through unchanged.
+            let bytes = s.as_bytes();
             let newline = b"\n";
             unsafe {
-                libc::write(
-                    1,
-                    str_slice.as_ptr() as *const libc::c_void,
-                    str_slice.len(),
-                );
+                libc::write(1, bytes.as_ptr() as *const libc::c_void, bytes.len());
                 libc::write(1, newline.as_ptr() as *const libc::c_void, newline.len());
             }
 
@@ -100,13 +100,10 @@ pub unsafe extern "C" fn patch_seq_write(stack: Stack) -> Stack {
         Value::String(s) => {
             let _guard = STDOUT_MUTEX.lock().unwrap();
 
-            let str_slice = s.as_str_or_empty();
+            // Byte-clean: write the underlying bytes directly to fd 1.
+            let bytes = s.as_bytes();
             unsafe {
-                libc::write(
-                    1,
-                    str_slice.as_ptr() as *const libc::c_void,
-                    str_slice.len(),
-                );
+                libc::write(1, bytes.as_ptr() as *const libc::c_void, bytes.len());
             }
 
             rest

--- a/crates/runtime/src/io.rs
+++ b/crates/runtime/src/io.rs
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn patch_seq_write_line(stack: Stack) -> Stack {
             // Write directly to fd 1 using libc to avoid Rust's std::io::stdout() RefCell.
             // Rust's standard I/O uses RefCell which panics on concurrent access from
             // multiple coroutines on the same thread.
-            let str_slice = s.as_str();
+            let str_slice = s.as_str_or_empty();
             let newline = b"\n";
             unsafe {
                 libc::write(
@@ -100,7 +100,7 @@ pub unsafe extern "C" fn patch_seq_write(stack: Stack) -> Stack {
         Value::String(s) => {
             let _guard = STDOUT_MUTEX.lock().unwrap();
 
-            let str_slice = s.as_str();
+            let str_slice = s.as_str_or_empty();
             unsafe {
                 libc::write(
                     1,

--- a/crates/runtime/src/list_ops/tests.rs
+++ b/crates/runtime/src/list_ops/tests.rs
@@ -276,7 +276,7 @@ fn test_list_map_preserves_tag() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "CustomTag"); // Tag preserved
+                assert_eq!(v.tag.as_str_or_empty(), "CustomTag"); // Tag preserved
                 assert_eq!(v.fields[0], Value::Int(2));
                 assert_eq!(v.fields[1], Value::Int(4));
             }
@@ -461,7 +461,7 @@ fn test_list_reverse_empty() {
         match result {
             Value::Variant(v) => {
                 assert_eq!(v.fields.len(), 0);
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
             }
             _ => panic!("Expected Variant"),
         }
@@ -508,7 +508,7 @@ fn test_list_reverse_multiple() {
                 assert_eq!(v.fields[0], Value::Int(3));
                 assert_eq!(v.fields[1], Value::Int(2));
                 assert_eq!(v.fields[2], Value::Int(1));
-                assert_eq!(v.tag.as_str(), "List"); // tag preserved
+                assert_eq!(v.tag.as_str_or_empty(), "List"); // tag preserved
             }
             _ => panic!("Expected Variant"),
         }

--- a/crates/runtime/src/map_ops/tests.rs
+++ b/crates/runtime/src/map_ops/tests.rs
@@ -32,7 +32,7 @@ fn test_map_set_and_get() {
         assert_eq!(flag, Value::Bool(true));
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "Alice"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "Alice"),
             _ => panic!("Expected String"),
         }
     }
@@ -55,7 +55,7 @@ fn test_map_set_with_int_key() {
         assert_eq!(flag, Value::Bool(true));
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "answer"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "answer"),
             _ => panic!("Expected String"),
         }
     }
@@ -254,7 +254,7 @@ fn test_map_with_bool_key() {
         assert_eq!(flag, Value::Bool(true));
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "yes"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "yes"),
             _ => panic!("Expected String"),
         }
     }
@@ -331,7 +331,7 @@ fn test_map_mixed_key_types() {
         assert_eq!(flag, Value::Bool(true));
         let (stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "Alice"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "Alice"),
             _ => panic!("Expected String for name key"),
         }
 
@@ -342,7 +342,7 @@ fn test_map_mixed_key_types() {
         assert_eq!(flag, Value::Bool(true));
         let (stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "answer"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "answer"),
             _ => panic!("Expected String for int key"),
         }
 
@@ -352,7 +352,7 @@ fn test_map_mixed_key_types() {
         assert_eq!(flag, Value::Bool(true));
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "yes"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "yes"),
             _ => panic!("Expected String for bool key"),
         }
     }

--- a/crates/runtime/src/os.rs
+++ b/crates/runtime/src/os.rs
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn patch_seq_getenv(stack: Stack) -> Stack {
             ),
         };
 
-        match std::env::var(name.as_str()) {
+        match std::env::var(name.as_str_or_empty()) {
             Ok(value) => {
                 let stack = push(stack, Value::String(global_string(value)));
                 push(stack, Value::Bool(true)) // success
@@ -117,7 +117,7 @@ pub unsafe extern "C" fn patch_seq_path_exists(stack: Stack) -> Stack {
             ),
         };
 
-        let exists = std::path::Path::new(path.as_str()).exists();
+        let exists = std::path::Path::new(path.as_str_or_empty()).exists();
         push(stack, Value::Bool(exists))
     }
 }
@@ -142,7 +142,7 @@ pub unsafe extern "C" fn patch_seq_path_is_file(stack: Stack) -> Stack {
             ),
         };
 
-        let is_file = std::path::Path::new(path.as_str()).is_file();
+        let is_file = std::path::Path::new(path.as_str_or_empty()).is_file();
         push(stack, Value::Bool(is_file))
     }
 }
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn patch_seq_path_is_dir(stack: Stack) -> Stack {
             ),
         };
 
-        let is_dir = std::path::Path::new(path.as_str()).is_dir();
+        let is_dir = std::path::Path::new(path.as_str_or_empty()).is_dir();
         push(stack, Value::Bool(is_dir))
     }
 }
@@ -202,8 +202,8 @@ pub unsafe extern "C" fn patch_seq_path_join(stack: Stack) -> Stack {
             ),
         };
 
-        let joined = std::path::Path::new(base.as_str())
-            .join(component.as_str())
+        let joined = std::path::Path::new(base.as_str_or_empty())
+            .join(component.as_str_or_empty())
             .to_string_lossy()
             .into_owned();
 
@@ -231,7 +231,7 @@ pub unsafe extern "C" fn patch_seq_path_parent(stack: Stack) -> Stack {
             ),
         };
 
-        match std::path::Path::new(path.as_str()).parent() {
+        match std::path::Path::new(path.as_str_or_empty()).parent() {
             Some(parent) => {
                 let parent_str = parent.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(parent_str)));
@@ -265,7 +265,7 @@ pub unsafe extern "C" fn patch_seq_path_filename(stack: Stack) -> Stack {
             ),
         };
 
-        match std::path::Path::new(path.as_str()).file_name() {
+        match std::path::Path::new(path.as_str_or_empty()).file_name() {
             Some(filename) => {
                 let filename_str = filename.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(filename_str)));

--- a/crates/runtime/src/os.rs
+++ b/crates/runtime/src/os.rs
@@ -9,6 +9,17 @@ use crate::seqstring::global_string;
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 
+/// Path conversion idiom: paths are inherently text on the OS APIs we
+/// target (Linux/macOS POSIX, which expose `&str` via Rust's `Path`),
+/// so non-UTF-8 path bytes can't be handed to the OS as-is.
+/// `SeqString::as_str_or_empty()` returns `""` for non-UTF-8 input,
+/// which routes the call through the OS error path and produces the
+/// standard `(empty, false)` failure tuple — same observable result
+/// as if we'd validated upfront. Mirrors `file::path_str` for parity.
+fn path_str(s: &crate::seqstring::SeqString) -> &str {
+    s.as_str_or_empty()
+}
+
 /// Get an environment variable
 ///
 /// Stack effect: ( name -- value success )
@@ -117,7 +128,7 @@ pub unsafe extern "C" fn patch_seq_path_exists(stack: Stack) -> Stack {
             ),
         };
 
-        let exists = std::path::Path::new(path.as_str_or_empty()).exists();
+        let exists = std::path::Path::new(path_str(&path)).exists();
         push(stack, Value::Bool(exists))
     }
 }
@@ -142,7 +153,7 @@ pub unsafe extern "C" fn patch_seq_path_is_file(stack: Stack) -> Stack {
             ),
         };
 
-        let is_file = std::path::Path::new(path.as_str_or_empty()).is_file();
+        let is_file = std::path::Path::new(path_str(&path)).is_file();
         push(stack, Value::Bool(is_file))
     }
 }
@@ -167,7 +178,7 @@ pub unsafe extern "C" fn patch_seq_path_is_dir(stack: Stack) -> Stack {
             ),
         };
 
-        let is_dir = std::path::Path::new(path.as_str_or_empty()).is_dir();
+        let is_dir = std::path::Path::new(path_str(&path)).is_dir();
         push(stack, Value::Bool(is_dir))
     }
 }
@@ -202,8 +213,8 @@ pub unsafe extern "C" fn patch_seq_path_join(stack: Stack) -> Stack {
             ),
         };
 
-        let joined = std::path::Path::new(base.as_str_or_empty())
-            .join(component.as_str_or_empty())
+        let joined = std::path::Path::new(path_str(&base))
+            .join(path_str(&component))
             .to_string_lossy()
             .into_owned();
 
@@ -231,7 +242,7 @@ pub unsafe extern "C" fn patch_seq_path_parent(stack: Stack) -> Stack {
             ),
         };
 
-        match std::path::Path::new(path.as_str_or_empty()).parent() {
+        match std::path::Path::new(path_str(&path)).parent() {
             Some(parent) => {
                 let parent_str = parent.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(parent_str)));
@@ -265,7 +276,7 @@ pub unsafe extern "C" fn patch_seq_path_filename(stack: Stack) -> Stack {
             ),
         };
 
-        match std::path::Path::new(path.as_str_or_empty()).file_name() {
+        match std::path::Path::new(path_str(&path)).file_name() {
             Some(filename) => {
                 let filename_str = filename.to_string_lossy().into_owned();
                 let stack = push(stack, Value::String(global_string(filename_str)));

--- a/crates/runtime/src/os/tests.rs
+++ b/crates/runtime/src/os/tests.rs
@@ -11,7 +11,7 @@ fn str_val(s: &str) -> Value {
 // Helper to extract String from Value
 fn as_str(v: &Value) -> &str {
     match v {
-        Value::String(s) => s.as_str(),
+        Value::String(s) => s.as_str_or_empty(),
         _ => panic!("expected String, got {:?}", v),
     }
 }

--- a/crates/runtime/src/regex.rs
+++ b/crates/runtime/src/regex.rs
@@ -61,8 +61,8 @@ pub unsafe extern "C" fn patch_seq_regex_match(stack: Stack) -> Stack {
 
     match (text_val, pattern_val) {
         (Value::String(text), Value::String(pattern)) => {
-            let result = match Regex::new(pattern.as_str()) {
-                Ok(re) => re.is_match(text.as_str()),
+            let result = match Regex::new(pattern.as_str_or_empty()) {
+                Ok(re) => re.is_match(text.as_str_or_empty()),
                 Err(_) => false, // Invalid regex returns false
             };
             unsafe { push(stack, Value::Bool(result)) }
@@ -88,8 +88,8 @@ pub unsafe extern "C" fn patch_seq_regex_find(stack: Stack) -> Stack {
 
     match (text_val, pattern_val) {
         (Value::String(text), Value::String(pattern)) => {
-            match Regex::new(pattern.as_str()) {
-                Ok(re) => match re.find(text.as_str()) {
+            match Regex::new(pattern.as_str_or_empty()) {
+                Ok(re) => match re.find(text.as_str_or_empty()) {
                     Some(m) => {
                         let stack = unsafe {
                             push(stack, Value::String(global_string(m.as_str().to_string())))
@@ -130,21 +130,23 @@ pub unsafe extern "C" fn patch_seq_regex_find_all(stack: Stack) -> Stack {
     let (stack, text_val) = unsafe { pop(stack) };
 
     match (text_val, pattern_val) {
-        (Value::String(text), Value::String(pattern)) => match Regex::new(pattern.as_str()) {
-            Ok(re) => {
-                let matches: Vec<Value> = re
-                    .find_iter(text.as_str())
-                    .map(|m| Value::String(global_string(m.as_str().to_string())))
-                    .collect();
-                let stack = unsafe { push(stack, make_list(matches)) };
-                unsafe { push(stack, Value::Bool(true)) }
+        (Value::String(text), Value::String(pattern)) => {
+            match Regex::new(pattern.as_str_or_empty()) {
+                Ok(re) => {
+                    let matches: Vec<Value> = re
+                        .find_iter(text.as_str_or_empty())
+                        .map(|m| Value::String(global_string(m.as_str().to_string())))
+                        .collect();
+                    let stack = unsafe { push(stack, make_list(matches)) };
+                    unsafe { push(stack, Value::Bool(true)) }
+                }
+                Err(_) => {
+                    // Invalid regex
+                    let stack = unsafe { push(stack, make_list(vec![])) };
+                    unsafe { push(stack, Value::Bool(false)) }
+                }
             }
-            Err(_) => {
-                // Invalid regex
-                let stack = unsafe { push(stack, make_list(vec![])) };
-                unsafe { push(stack, Value::Bool(false)) }
-            }
-        },
+        }
         _ => panic!("regex.find-all: expected two Strings on stack"),
     }
 }
@@ -168,9 +170,11 @@ pub unsafe extern "C" fn patch_seq_regex_replace(stack: Stack) -> Stack {
 
     match (text_val, pattern_val, replacement_val) {
         (Value::String(text), Value::String(pattern), Value::String(replacement)) => {
-            match Regex::new(pattern.as_str()) {
+            match Regex::new(pattern.as_str_or_empty()) {
                 Ok(re) => {
-                    let result = re.replace(text.as_str(), replacement.as_str()).into_owned();
+                    let result = re
+                        .replace(text.as_str_or_empty(), replacement.as_str_or_empty())
+                        .into_owned();
                     let stack = unsafe { push(stack, Value::String(global_string(result))) };
                     unsafe { push(stack, Value::Bool(true)) }
                 }
@@ -179,7 +183,7 @@ pub unsafe extern "C" fn patch_seq_regex_replace(stack: Stack) -> Stack {
                     let stack = unsafe {
                         push(
                             stack,
-                            Value::String(global_string(text.as_str().to_string())),
+                            Value::String(global_string(text.as_str_or_empty().to_string())),
                         )
                     };
                     unsafe { push(stack, Value::Bool(false)) }
@@ -209,10 +213,10 @@ pub unsafe extern "C" fn patch_seq_regex_replace_all(stack: Stack) -> Stack {
 
     match (text_val, pattern_val, replacement_val) {
         (Value::String(text), Value::String(pattern), Value::String(replacement)) => {
-            match Regex::new(pattern.as_str()) {
+            match Regex::new(pattern.as_str_or_empty()) {
                 Ok(re) => {
                     let result = re
-                        .replace_all(text.as_str(), replacement.as_str())
+                        .replace_all(text.as_str_or_empty(), replacement.as_str_or_empty())
                         .into_owned();
                     let stack = unsafe { push(stack, Value::String(global_string(result))) };
                     unsafe { push(stack, Value::Bool(true)) }
@@ -222,7 +226,7 @@ pub unsafe extern "C" fn patch_seq_regex_replace_all(stack: Stack) -> Stack {
                     let stack = unsafe {
                         push(
                             stack,
-                            Value::String(global_string(text.as_str().to_string())),
+                            Value::String(global_string(text.as_str_or_empty().to_string())),
                         )
                     };
                     unsafe { push(stack, Value::Bool(false)) }
@@ -251,8 +255,8 @@ pub unsafe extern "C" fn patch_seq_regex_captures(stack: Stack) -> Stack {
 
     match (text_val, pattern_val) {
         (Value::String(text), Value::String(pattern)) => {
-            match Regex::new(pattern.as_str()) {
-                Ok(re) => match re.captures(text.as_str()) {
+            match Regex::new(pattern.as_str_or_empty()) {
+                Ok(re) => match re.captures(text.as_str_or_empty()) {
                     Some(caps) => {
                         // Skip group 0 (full match), collect groups 1..n
                         let groups: Vec<Value> = caps
@@ -299,22 +303,26 @@ pub unsafe extern "C" fn patch_seq_regex_split(stack: Stack) -> Stack {
     let (stack, text_val) = unsafe { pop(stack) };
 
     match (text_val, pattern_val) {
-        (Value::String(text), Value::String(pattern)) => match Regex::new(pattern.as_str()) {
-            Ok(re) => {
-                let parts: Vec<Value> = re
-                    .split(text.as_str())
-                    .map(|s| Value::String(global_string(s.to_string())))
-                    .collect();
-                let stack = unsafe { push(stack, make_list(parts)) };
-                unsafe { push(stack, Value::Bool(true)) }
+        (Value::String(text), Value::String(pattern)) => {
+            match Regex::new(pattern.as_str_or_empty()) {
+                Ok(re) => {
+                    let parts: Vec<Value> = re
+                        .split(text.as_str_or_empty())
+                        .map(|s| Value::String(global_string(s.to_string())))
+                        .collect();
+                    let stack = unsafe { push(stack, make_list(parts)) };
+                    unsafe { push(stack, Value::Bool(true)) }
+                }
+                Err(_) => {
+                    // Invalid regex returns original as single element
+                    let parts = vec![Value::String(global_string(
+                        text.as_str_or_empty().to_string(),
+                    ))];
+                    let stack = unsafe { push(stack, make_list(parts)) };
+                    unsafe { push(stack, Value::Bool(false)) }
+                }
             }
-            Err(_) => {
-                // Invalid regex returns original as single element
-                let parts = vec![Value::String(global_string(text.as_str().to_string()))];
-                let stack = unsafe { push(stack, make_list(parts)) };
-                unsafe { push(stack, Value::Bool(false)) }
-            }
-        },
+        }
         _ => panic!("regex.split: expected two Strings on stack"),
     }
 }
@@ -335,7 +343,7 @@ pub unsafe extern "C" fn patch_seq_regex_valid(stack: Stack) -> Stack {
 
     match pattern_val {
         Value::String(pattern) => {
-            let is_valid = Regex::new(pattern.as_str()).is_ok();
+            let is_valid = Regex::new(pattern.as_str_or_empty()).is_ok();
             unsafe { push(stack, Value::Bool(is_valid)) }
         }
         _ => panic!("regex.valid?: expected String on stack"),

--- a/crates/runtime/src/regex/tests.rs
+++ b/crates/runtime/src/regex/tests.rs
@@ -45,7 +45,7 @@ fn test_regex_find() {
 
     assert_eq!(success, Value::Bool(true));
     if let Value::String(s) = matched {
-        assert_eq!(s.as_str(), "a1");
+        assert_eq!(s.as_str_or_empty(), "a1");
     } else {
         panic!("expected String");
     }
@@ -70,13 +70,13 @@ fn test_regex_find_all() {
     if let Value::Variant(v) = list_val {
         assert_eq!(v.fields.len(), 3);
         if let Value::String(s) = &v.fields[0] {
-            assert_eq!(s.as_str(), "a1");
+            assert_eq!(s.as_str_or_empty(), "a1");
         }
         if let Value::String(s) = &v.fields[1] {
-            assert_eq!(s.as_str(), "b2");
+            assert_eq!(s.as_str_or_empty(), "b2");
         }
         if let Value::String(s) = &v.fields[2] {
-            assert_eq!(s.as_str(), "c3");
+            assert_eq!(s.as_str_or_empty(), "c3");
         }
     } else {
         panic!("expected Variant (List)");
@@ -101,7 +101,7 @@ fn test_regex_replace() {
     let (_, result) = unsafe { pop(stack) };
 
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "hello Seq");
+        assert_eq!(s.as_str_or_empty(), "hello Seq");
     } else {
         panic!("expected String");
     }
@@ -120,7 +120,7 @@ fn test_regex_replace_all() {
     let (_, result) = unsafe { pop(stack) };
 
     if let Value::String(s) = result {
-        assert_eq!(s.as_str(), "aX bX cX");
+        assert_eq!(s.as_str_or_empty(), "aX bX cX");
     } else {
         panic!("expected String");
     }
@@ -150,13 +150,13 @@ fn test_regex_captures() {
     if let Value::Variant(v) = groups {
         assert_eq!(v.fields.len(), 3);
         if let Value::String(s) = &v.fields[0] {
-            assert_eq!(s.as_str(), "2024");
+            assert_eq!(s.as_str_or_empty(), "2024");
         }
         if let Value::String(s) = &v.fields[1] {
-            assert_eq!(s.as_str(), "01");
+            assert_eq!(s.as_str_or_empty(), "01");
         }
         if let Value::String(s) = &v.fields[2] {
-            assert_eq!(s.as_str(), "15");
+            assert_eq!(s.as_str_or_empty(), "15");
         }
     } else {
         panic!("expected Variant (List)");
@@ -177,13 +177,13 @@ fn test_regex_split() {
     if let Value::Variant(v) = result {
         assert_eq!(v.fields.len(), 4); // "a", "b", "c", ""
         if let Value::String(s) = &v.fields[0] {
-            assert_eq!(s.as_str(), "a");
+            assert_eq!(s.as_str_or_empty(), "a");
         }
         if let Value::String(s) = &v.fields[1] {
-            assert_eq!(s.as_str(), "b");
+            assert_eq!(s.as_str_or_empty(), "b");
         }
         if let Value::String(s) = &v.fields[2] {
-            assert_eq!(s.as_str(), "c");
+            assert_eq!(s.as_str_or_empty(), "c");
         }
     } else {
         panic!("expected Variant (List)");

--- a/crates/runtime/src/scheduler/tests.rs
+++ b/crates/runtime/src/scheduler/tests.rs
@@ -147,7 +147,7 @@ fn test_arena_reset_with_strands() {
             for i in 0..100 {
                 let temp = arena_string(&format!("temporary string {}", i));
                 // Use the string temporarily
-                assert!(!temp.as_str().is_empty());
+                assert!(!temp.as_str_or_empty().is_empty());
                 // String is dropped, but memory stays in arena
             }
 
@@ -255,7 +255,7 @@ fn test_arena_with_channel_send() {
                 let (_stack, msg_val) = pop(stack);
                 match msg_val {
                     Value::String(s) => {
-                        assert_eq!(s.as_str(), "Hello from sender!");
+                        assert_eq!(s.as_str_or_empty(), "Hello from sender!");
                         RECEIVED_COUNT.fetch_add(1, Ordering::SeqCst);
                     }
                     _ => panic!("Expected String"),
@@ -296,7 +296,7 @@ fn test_no_memory_leak_over_many_iterations() {
             // Simulate request processing: many temp allocations
             for i in 0..50 {
                 let temp = arena_string(&format!("request header {}", i));
-                assert!(!temp.as_str().is_empty());
+                assert!(!temp.as_str_or_empty().is_empty());
                 // Strings dropped here but arena memory stays allocated
             }
             stack

--- a/crates/runtime/src/serialize.rs
+++ b/crates/runtime/src/serialize.rs
@@ -32,6 +32,21 @@
 //!
 //! Uses bincode for fast, compact binary serialization.
 //! For debugging, use `TypedValue::to_debug_string()`.
+//!
+//! # Byte-cleanliness boundary
+//!
+//! `TypedValue::String` and `TypedMapKey::String` hold owned `String` —
+//! UTF-8 by definition. Conversion from a runtime `Value::String`
+//! (which is byte-clean and may carry arbitrary bytes) goes through
+//! `as_str_or_empty()`: invalid UTF-8 collapses to the empty string.
+//! That is the deliberate, narrow contract of this module — it serves
+//! the *text-shaped* payloads of actor persistence, IPC, and
+//! Arrow/Parquet pipelines, not arbitrary binary blobs.
+//!
+//! Programs that need to persist binary `String` payloads should
+//! base64- or hex-encode them at the Seq layer before handing them
+//! to `serialize`, or use a binary-aware transport (file slurp/spit,
+//! HTTP body, channel send) which retains bytes verbatim.
 
 use crate::seqstring::global_string;
 use crate::value::{MapKey as RuntimeMapKey, Value, VariantData};

--- a/crates/runtime/src/serialize.rs
+++ b/crates/runtime/src/serialize.rs
@@ -118,7 +118,7 @@ impl TypedMapKey {
         match key {
             RuntimeMapKey::Int(v) => TypedMapKey::Int(*v),
             RuntimeMapKey::Bool(v) => TypedMapKey::Bool(*v),
-            RuntimeMapKey::String(s) => TypedMapKey::String(s.as_str().to_string()),
+            RuntimeMapKey::String(s) => TypedMapKey::String(s.as_str_or_empty().to_string()),
         }
     }
 
@@ -169,8 +169,8 @@ impl TypedValue {
                 Ok(TypedValue::Float(*v))
             }
             Value::Bool(v) => Ok(TypedValue::Bool(*v)),
-            Value::String(s) => Ok(TypedValue::String(s.as_str().to_string())),
-            Value::Symbol(s) => Ok(TypedValue::Symbol(s.as_str().to_string())),
+            Value::String(s) => Ok(TypedValue::String(s.as_str_or_empty().to_string())),
+            Value::Symbol(s) => Ok(TypedValue::Symbol(s.as_str_or_empty().to_string())),
             Value::Map(map) => {
                 let mut typed_map = BTreeMap::new();
                 for (k, v) in map.iter() {
@@ -186,7 +186,7 @@ impl TypedValue {
                     typed_fields.push(TypedValue::from_value(field)?);
                 }
                 Ok(TypedValue::Variant {
-                    tag: data.tag.as_str().to_string(),
+                    tag: data.tag.as_str_or_empty().to_string(),
                     fields: typed_fields,
                 })
             }

--- a/crates/runtime/src/serialize/tests.rs
+++ b/crates/runtime/src/serialize/tests.rs
@@ -32,7 +32,9 @@ fn test_string_roundtrip() {
     let back = typed.to_value();
     // Compare string contents (not pointer equality)
     match (&value, &back) {
-        (Value::String(a), Value::String(b)) => assert_eq!(a.as_str(), b.as_str()),
+        (Value::String(a), Value::String(b)) => {
+            assert_eq!(a.as_str_or_empty(), b.as_str_or_empty())
+        }
         _ => panic!("Expected strings"),
     }
 }
@@ -70,7 +72,7 @@ fn test_variant_roundtrip() {
     let back = typed.to_value();
 
     if let Value::Variant(v) = back {
-        assert_eq!(v.tag.as_str(), "TestVariant");
+        assert_eq!(v.tag.as_str_or_empty(), "TestVariant");
         assert_eq!(v.fields.len(), 2);
     } else {
         panic!("Expected variant");

--- a/crates/runtime/src/string_ops/access.rs
+++ b/crates/runtime/src/string_ops/access.rs
@@ -1,6 +1,6 @@
 //! Character access, slicing, searching, and splitting/joining.
 
-use crate::seqstring::global_string;
+use crate::seqstring::{global_bytes, global_string};
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 use std::sync::Arc;
@@ -19,11 +19,42 @@ pub unsafe extern "C" fn patch_seq_string_split(stack: Stack) -> Stack {
 
     match (str_val, delim_val) {
         (Value::String(s), Value::String(d)) => {
-            // Split and collect into Value::String instances
-            let fields: Vec<Value> = s
-                .as_str_or_empty()
-                .split(d.as_str_or_empty())
-                .map(|part| Value::String(global_string(part.to_owned())))
+            // Byte-clean split: separate the haystack at every byte
+            // occurrence of the needle. The result is byte-faithful —
+            // splitting an OSC payload on its NUL padding, splitting a
+            // network frame on a binary delimiter, etc. all work.
+            let bytes = s.as_bytes();
+            let needle = d.as_bytes();
+            let parts: Vec<Vec<u8>> = if needle.is_empty() {
+                // Mirror Rust's `&str::split("")` shape: empty leading
+                // and trailing pieces, one piece per byte in between.
+                let mut parts = Vec::with_capacity(bytes.len() + 2);
+                parts.push(Vec::new());
+                for b in bytes {
+                    parts.push(vec![*b]);
+                }
+                parts.push(Vec::new());
+                parts
+            } else {
+                let mut parts: Vec<Vec<u8>> = Vec::new();
+                let mut last = 0usize;
+                let mut i = 0usize;
+                while i + needle.len() <= bytes.len() {
+                    if &bytes[i..i + needle.len()] == needle {
+                        parts.push(bytes[last..i].to_vec());
+                        i += needle.len();
+                        last = i;
+                    } else {
+                        i += 1;
+                    }
+                }
+                parts.push(bytes[last..].to_vec());
+                parts
+            };
+
+            let fields: Vec<Value> = parts
+                .into_iter()
+                .map(|part| Value::String(global_bytes(part)))
                 .collect();
 
             // Create a Variant with :List tag and the split parts as fields
@@ -54,11 +85,22 @@ pub unsafe extern "C" fn patch_seq_string_contains(stack: Stack) -> Stack {
 
     match (str_val, substring_val) {
         (Value::String(s), Value::String(sub)) => {
-            let contains = s.as_str_or_empty().contains(sub.as_str_or_empty());
+            // Byte-clean substring search: scan the haystack for the
+            // needle's bytes. Works on any input — text or binary.
+            let contains = byte_contains(s.as_bytes(), sub.as_bytes());
             unsafe { push(stack, Value::Bool(contains)) }
         }
         _ => panic!("string_contains: expected two strings on stack"),
     }
+}
+
+/// Byte-level substring search. Empty needle is contained in any
+/// haystack (matches Rust's `&str::contains` for the same convention).
+fn byte_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
 }
 
 /// Check if a string starts with a prefix
@@ -77,7 +119,8 @@ pub unsafe extern "C" fn patch_seq_string_starts_with(stack: Stack) -> Stack {
 
     match (str_val, prefix_val) {
         (Value::String(s), Value::String(prefix)) => {
-            let starts = s.as_str_or_empty().starts_with(prefix.as_str_or_empty());
+            // Byte-clean prefix check.
+            let starts = s.as_bytes().starts_with(prefix.as_bytes());
             unsafe { push(stack, Value::Bool(starts)) }
         }
         _ => panic!("string_starts_with: expected two strings on stack"),

--- a/crates/runtime/src/string_ops/access.rs
+++ b/crates/runtime/src/string_ops/access.rs
@@ -21,8 +21,8 @@ pub unsafe extern "C" fn patch_seq_string_split(stack: Stack) -> Stack {
         (Value::String(s), Value::String(d)) => {
             // Split and collect into Value::String instances
             let fields: Vec<Value> = s
-                .as_str()
-                .split(d.as_str())
+                .as_str_or_empty()
+                .split(d.as_str_or_empty())
                 .map(|part| Value::String(global_string(part.to_owned())))
                 .collect();
 
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn patch_seq_string_contains(stack: Stack) -> Stack {
 
     match (str_val, substring_val) {
         (Value::String(s), Value::String(sub)) => {
-            let contains = s.as_str().contains(sub.as_str());
+            let contains = s.as_str_or_empty().contains(sub.as_str_or_empty());
             unsafe { push(stack, Value::Bool(contains)) }
         }
         _ => panic!("string_contains: expected two strings on stack"),
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn patch_seq_string_starts_with(stack: Stack) -> Stack {
 
     match (str_val, prefix_val) {
         (Value::String(s), Value::String(prefix)) => {
-            let starts = s.as_str().starts_with(prefix.as_str());
+            let starts = s.as_str_or_empty().starts_with(prefix.as_str_or_empty());
             unsafe { push(stack, Value::Bool(starts)) }
         }
         _ => panic!("string_starts_with: expected two strings on stack"),
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn patch_seq_string_char_at(stack: Stack) -> Stack {
             let result = if index < 0 {
                 -1
             } else {
-                s.as_str()
+                s.as_str_or_empty()
                     .chars()
                     .nth(index as usize)
                     .map(|c| c as i64)
@@ -151,7 +151,7 @@ pub unsafe extern "C" fn patch_seq_string_substring(stack: Stack) -> Stack {
             let result = if start < 0 || len < 0 {
                 String::new()
             } else {
-                s.as_str()
+                s.as_str_or_empty()
                     .chars()
                     .skip(start as usize)
                     .take(len as usize)
@@ -214,8 +214,8 @@ pub unsafe extern "C" fn patch_seq_string_find(stack: Stack) -> Stack {
 
     match (str_val, needle_val) {
         (Value::String(haystack), Value::String(needle)) => {
-            let haystack_str = haystack.as_str();
-            let needle_str = needle.as_str();
+            let haystack_str = haystack.as_str_or_empty();
+            let needle_str = needle.as_str_or_empty();
 
             // Find byte position then convert to character position
             let result = match haystack_str.find(needle_str) {
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn patch_seq_string_join(stack: Stack) -> Stack {
         // Pop separator
         let (stack, sep_val) = pop(stack);
         let sep = match &sep_val {
-            Value::String(s) => s.as_str().to_owned(),
+            Value::String(s) => s.as_str_or_empty().to_owned(),
             _ => panic!("string.join: expected String separator, got {:?}", sep_val),
         };
 
@@ -259,11 +259,11 @@ pub unsafe extern "C" fn patch_seq_string_join(stack: Stack) -> Stack {
             .fields
             .iter()
             .map(|v| match v {
-                Value::String(s) => s.as_str().to_owned(),
+                Value::String(s) => s.as_str_or_empty().to_owned(),
                 Value::Int(n) => n.to_string(),
                 Value::Float(f) => f.to_string(),
                 Value::Bool(b) => if *b { "true" } else { "false" }.to_string(),
-                Value::Symbol(s) => format!(":{}", s.as_str()),
+                Value::Symbol(s) => format!(":{}", s.as_str_or_empty()),
                 _ => format!("{:?}", v),
             })
             .collect();

--- a/crates/runtime/src/string_ops/basic.rs
+++ b/crates/runtime/src/string_ops/basic.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn patch_seq_string_empty(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => {
-            let is_empty = s.as_str().is_empty();
+            let is_empty = s.as_str_or_empty().is_empty();
             unsafe { push(stack, Value::Bool(is_empty)) }
         }
         _ => panic!("string_empty: expected String on stack"),
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn patch_seq_string_concat(stack: Stack) -> Stack {
 
     match (str1_val, str2_val) {
         (Value::String(s1), Value::String(s2)) => {
-            let result = format!("{}{}", s1.as_str(), s2.as_str());
+            let result = format!("{}{}", s1.as_str_or_empty(), s2.as_str_or_empty());
             unsafe { push(stack, Value::String(global_string(result))) }
         }
         _ => panic!("string_concat: expected two strings on stack"),
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn patch_seq_string_length(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let len = s.as_str().chars().count() as i64;
+            let len = s.as_str_or_empty().chars().count() as i64;
             unsafe { push(stack, Value::Int(len)) }
         }
         _ => panic!("string_length: expected String on stack"),
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn patch_seq_string_byte_length(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let len = s.as_str().len() as i64;
+            let len = s.as_str_or_empty().len() as i64;
             unsafe { push(stack, Value::Int(len)) }
         }
         _ => panic!("string_byte_length: expected String on stack"),
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn patch_seq_string_equal(stack: Stack) -> Stack {
 
     match (str1_val, str2_val) {
         (Value::String(s1), Value::String(s2)) => {
-            let equal = s1.as_str() == s2.as_str();
+            let equal = s1.as_str_or_empty() == s2.as_str_or_empty();
             unsafe { push(stack, Value::Bool(equal)) }
         }
         _ => panic!("string_equal: expected two strings on stack"),

--- a/crates/runtime/src/string_ops/basic.rs
+++ b/crates/runtime/src/string_ops/basic.rs
@@ -1,6 +1,6 @@
 //! Basic string operations: length, byte-length, empty-check, equality, concat.
 
-use crate::seqstring::global_string;
+use crate::seqstring::global_bytes;
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 
@@ -14,7 +14,8 @@ pub unsafe extern "C" fn patch_seq_string_empty(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => {
-            let is_empty = s.as_str_or_empty().is_empty();
+            // Byte-clean: empty iff there are no bytes, regardless of UTF-8.
+            let is_empty = s.as_bytes().is_empty();
             unsafe { push(stack, Value::Bool(is_empty)) }
         }
         _ => panic!("string_empty: expected String on stack"),
@@ -37,8 +38,14 @@ pub unsafe extern "C" fn patch_seq_string_concat(stack: Stack) -> Stack {
 
     match (str1_val, str2_val) {
         (Value::String(s1), Value::String(s2)) => {
-            let result = format!("{}{}", s1.as_str_or_empty(), s2.as_str_or_empty());
-            unsafe { push(stack, Value::String(global_string(result))) }
+            // Byte-clean concat: catenate the underlying byte buffers.
+            // OSC payload assembly, binary file building, MessagePack,
+            // anything that needs to glue arbitrary bytes together
+            // depends on this not going through `&str`.
+            let mut result = Vec::with_capacity(s1.as_bytes().len() + s2.as_bytes().len());
+            result.extend_from_slice(s1.as_bytes());
+            result.extend_from_slice(s2.as_bytes());
+            unsafe { push(stack, Value::String(global_bytes(result))) }
         }
         _ => panic!("string_concat: expected two strings on stack"),
     }
@@ -84,7 +91,8 @@ pub unsafe extern "C" fn patch_seq_string_byte_length(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let len = s.as_str_or_empty().len() as i64;
+            // Byte-clean: count of underlying bytes, no UTF-8 validation.
+            let len = s.as_bytes().len() as i64;
             unsafe { push(stack, Value::Int(len)) }
         }
         _ => panic!("string_byte_length: expected String on stack"),
@@ -110,7 +118,10 @@ pub unsafe extern "C" fn patch_seq_string_equal(stack: Stack) -> Stack {
 
     match (str1_val, str2_val) {
         (Value::String(s1), Value::String(s2)) => {
-            let equal = s1.as_str_or_empty() == s2.as_str_or_empty();
+            // Byte-clean: equality is byte-for-byte. Matches the
+            // `PartialEq for SeqString` impl in seqstring.rs, which
+            // also compares `as_bytes`.
+            let equal = s1.as_bytes() == s2.as_bytes();
             unsafe { push(stack, Value::Bool(equal)) }
         }
         _ => panic!("string_equal: expected two strings on stack"),

--- a/crates/runtime/src/string_ops/case.rs
+++ b/crates/runtime/src/string_ops/case.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn patch_seq_string_trim(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let trimmed = s.as_str().trim();
+            let trimmed = s.as_str_or_empty().trim();
             unsafe { push(stack, Value::String(global_string(trimmed.to_owned()))) }
         }
         _ => panic!("string_trim: expected String on stack"),
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn patch_seq_string_to_upper(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let upper = s.as_str().to_uppercase();
+            let upper = s.as_str_or_empty().to_uppercase();
             unsafe { push(stack, Value::String(global_string(upper))) }
         }
         _ => panic!("string_to_upper: expected String on stack"),
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn patch_seq_string_to_lower(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let lower = s.as_str().to_lowercase();
+            let lower = s.as_str_or_empty().to_lowercase();
             unsafe { push(stack, Value::String(global_string(lower))) }
         }
         _ => panic!("string_to_lower: expected String on stack"),
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn patch_seq_string_chomp(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let mut result = s.as_str().to_owned();
+            let mut result = s.as_str_or_empty().to_owned();
             if result.ends_with('\n') {
                 result.pop();
                 if result.ends_with('\r') {

--- a/crates/runtime/src/string_ops/case.rs
+++ b/crates/runtime/src/string_ops/case.rs
@@ -1,6 +1,6 @@
 //! Case conversion and whitespace trimming.
 
-use crate::seqstring::global_string;
+use crate::seqstring::{global_bytes, global_string};
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
 
@@ -77,14 +77,18 @@ pub unsafe extern "C" fn patch_seq_string_chomp(stack: Stack) -> Stack {
 
     match str_val {
         Value::String(s) => {
-            let mut result = s.as_str_or_empty().to_owned();
-            if result.ends_with('\n') {
-                result.pop();
-                if result.ends_with('\r') {
-                    result.pop();
+            // Byte-clean: peel a trailing `\n` (and its preceding
+            // `\r`, for CRLF line endings). All comparisons against
+            // ASCII bytes — works on text and on binary content with
+            // a trailing newline.
+            let mut bytes = s.as_bytes().to_vec();
+            if bytes.last() == Some(&b'\n') {
+                bytes.pop();
+                if bytes.last() == Some(&b'\r') {
+                    bytes.pop();
                 }
             }
-            unsafe { push(stack, Value::String(global_string(result))) }
+            unsafe { push(stack, Value::String(global_bytes(bytes))) }
         }
         _ => panic!("string_chomp: expected String on stack"),
     }

--- a/crates/runtime/src/string_ops/conversion.rs
+++ b/crates/runtime/src/string_ops/conversion.rs
@@ -22,7 +22,7 @@ pub unsafe extern "C" fn patch_seq_symbol_equal(stack: Stack) -> Stack {
                 s1.as_ptr() == s2.as_ptr()
             } else {
                 // Fallback: string comparison for runtime-created symbols
-                s1.as_str() == s2.as_str()
+                s1.as_str_or_empty() == s2.as_str_or_empty()
             };
             unsafe { push(stack, Value::Bool(equal)) }
         }
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn patch_seq_json_escape(stack: Stack) -> Stack {
 
     match value {
         Value::String(s) => {
-            let input = s.as_str();
+            let input = s.as_str_or_empty();
             let mut result = String::with_capacity(input.len() + 16);
 
             for ch in input.chars() {
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn patch_seq_string_to_int(stack: Stack) -> Stack {
     let (stack, val) = unsafe { pop(stack) };
 
     match val {
-        Value::String(s) => match s.as_str().trim().parse::<i64>() {
+        Value::String(s) => match s.as_str_or_empty().trim().parse::<i64>() {
             Ok(i) => {
                 let stack = unsafe { push(stack, Value::Int(i)) };
                 unsafe { push(stack, Value::Bool(true)) }

--- a/crates/runtime/src/string_ops/conversion.rs
+++ b/crates/runtime/src/string_ops/conversion.rs
@@ -21,8 +21,13 @@ pub unsafe extern "C" fn patch_seq_symbol_equal(stack: Stack) -> Stack {
             let equal = if s1.is_interned() && s2.is_interned() {
                 s1.as_ptr() == s2.as_ptr()
             } else {
-                // Fallback: string comparison for runtime-created symbols
-                s1.as_str_or_empty() == s2.as_str_or_empty()
+                // Fallback: byte-level comparison for runtime-created
+                // symbols. Must be `as_bytes()`, not `as_str_or_empty()` —
+                // otherwise two distinct non-UTF-8 symbols both collapse
+                // to "" and are reported equal. (Symbols are normally
+                // ASCII identifiers so this rarely matters in practice,
+                // but the contract should be byte-precise.)
+                s1.as_bytes() == s2.as_bytes()
             };
             unsafe { push(stack, Value::Bool(equal)) }
         }

--- a/crates/runtime/src/string_ops/tests.rs
+++ b/crates/runtime/src/string_ops/tests.rs
@@ -1214,6 +1214,37 @@ fn byte_clean_string_split_on_binary_delimiter() {
 }
 
 #[test]
+fn byte_clean_string_split_empty_delimiter_byte_per_byte() {
+    // Empty delimiter is the documented sentinel for "split into
+    // individual bytes." The shape mirrors Rust's `&str::split("")`
+    // exactly: an empty leading element, one element per byte in the
+    // haystack, an empty trailing element. Pinning this so future
+    // implementations don't drift.
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(b"abc".to_vec())));
+        let stack = push(stack, Value::String(global_bytes(Vec::new())));
+        let stack = string_split(stack);
+        let (_, result) = pop(stack);
+        match result {
+            Value::Variant(v) => {
+                assert_eq!(v.fields.len(), 5, "expected ['', 'a', 'b', 'c', '']");
+                let extract = |i: usize| match &v.fields[i] {
+                    Value::String(s) => s.as_bytes().to_vec(),
+                    _ => panic!("expected String"),
+                };
+                assert_eq!(extract(0), b"");
+                assert_eq!(extract(1), b"a");
+                assert_eq!(extract(2), b"b");
+                assert_eq!(extract(3), b"c");
+                assert_eq!(extract(4), b"");
+            }
+            other => panic!("expected Variant, got {:?}", other),
+        }
+    }
+}
+
+#[test]
 fn byte_clean_string_chomp_preserves_binary_prefix() {
     unsafe {
         // BIN_A followed by \r\n.

--- a/crates/runtime/src/string_ops/tests.rs
+++ b/crates/runtime/src/string_ops/tests.rs
@@ -16,7 +16,7 @@ fn test_string_split_simple() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
                 assert_eq!(v.fields.len(), 3);
                 assert_eq!(v.fields[0], Value::String(global_string("a".to_owned())));
                 assert_eq!(v.fields[1], Value::String(global_string("b".to_owned())));
@@ -40,7 +40,7 @@ fn test_string_split_empty() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
                 assert_eq!(v.fields.len(), 1);
                 assert_eq!(v.fields[0], Value::String(global_string("".to_owned())));
             }
@@ -160,7 +160,7 @@ fn test_http_request_line_parsing() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "List");
+                assert_eq!(v.tag.as_str_or_empty(), "List");
                 assert_eq!(v.fields.len(), 3);
                 assert_eq!(v.fields[0], Value::String(global_string("GET".to_owned())));
                 assert_eq!(
@@ -958,7 +958,7 @@ fn test_string_join_strings() {
 
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "a, b, c"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "a, b, c"),
             _ => panic!("Expected String, got {:?}", result),
         }
     }
@@ -981,7 +981,7 @@ fn test_string_join_empty_list() {
 
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), ""),
             _ => panic!("Expected String"),
         }
     }
@@ -1004,7 +1004,7 @@ fn test_string_join_single_element() {
 
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "only"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "only"),
             _ => panic!("Expected String"),
         }
     }
@@ -1031,7 +1031,7 @@ fn test_string_join_mixed_types() {
 
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), "1 true x"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "1 true x"),
             _ => panic!("Expected String"),
         }
     }

--- a/crates/runtime/src/string_ops/tests.rs
+++ b/crates/runtime/src/string_ops/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::seqstring::global_string;
+use crate::seqstring::{global_bytes, global_string};
 use crate::stack::{pop, push};
 use crate::value::Value;
 
@@ -1033,6 +1033,200 @@ fn test_string_join_mixed_types() {
         match result {
             Value::String(s) => assert_eq!(s.as_str_or_empty(), "1 true x"),
             _ => panic!("Expected String"),
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Byte-cleanliness regression tests.
+//
+// These guard against the class of bugs that snuck in during the bulk-sed
+// pass of CP4 (byte-clean ops were wrongly routed through `as_str_or_empty()`,
+// silently degenerating non-UTF-8 input to empty / wrong answers). Sentinel
+// bytes include a NUL, a UTF-8 continuation byte standing alone (0xDC), a
+// high byte (0xFF), and a partial UTF-8 lead (0xC3) — the same shape used
+// in `seqstring.rs`'s type-level sentinel tests.
+// ----------------------------------------------------------------------------
+
+const BIN_A: &[u8] = &[0x00, 0xDC, b'x', 0xFF, 0xC3, b'!'];
+const BIN_B: &[u8] = &[0x42, 0x00, 0xFE, b'y'];
+
+#[test]
+fn byte_clean_string_byte_length() {
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = patch_seq_string_byte_length(stack);
+        let (_, len) = pop(stack);
+        assert_eq!(len, Value::Int(BIN_A.len() as i64));
+    }
+}
+
+#[test]
+fn byte_clean_string_empty_distinguishes_zero_from_nonempty_binary() {
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = patch_seq_string_empty(stack);
+        let (_, is_empty) = pop(stack);
+        assert_eq!(
+            is_empty,
+            Value::Bool(false),
+            "non-empty binary buffer must not be reported as empty"
+        );
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(Vec::new())));
+        let stack = patch_seq_string_empty(stack);
+        let (_, is_empty) = pop(stack);
+        assert_eq!(is_empty, Value::Bool(true));
+    }
+}
+
+#[test]
+fn byte_clean_string_equal_distinguishes_different_binary_buffers() {
+    unsafe {
+        // Same bytes — equal.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = patch_seq_string_equal(stack);
+        let (_, eq) = pop(stack);
+        assert_eq!(eq, Value::Bool(true));
+
+        // Different non-UTF-8 bytes — not equal. Pre-fix this returned true
+        // because both were collapsed to "" via as_str_or_empty.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = push(stack, Value::String(global_bytes(BIN_B.to_vec())));
+        let stack = patch_seq_string_equal(stack);
+        let (_, eq) = pop(stack);
+        assert_eq!(eq, Value::Bool(false));
+    }
+}
+
+#[test]
+fn byte_clean_string_concat_preserves_binary_bytes() {
+    unsafe {
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = push(stack, Value::String(global_bytes(BIN_B.to_vec())));
+        let stack = patch_seq_string_concat(stack);
+        let (_, result) = pop(stack);
+        match result {
+            Value::String(s) => {
+                let mut expected = BIN_A.to_vec();
+                expected.extend_from_slice(BIN_B);
+                assert_eq!(s.as_bytes(), expected.as_slice());
+            }
+            other => panic!("expected String, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn byte_clean_string_contains_finds_binary_needle() {
+    unsafe {
+        let mut haystack = b"prefix-".to_vec();
+        haystack.extend_from_slice(BIN_A);
+        haystack.extend_from_slice(b"-suffix");
+
+        // Found.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(haystack.clone())));
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = patch_seq_string_contains(stack);
+        let (_, contains) = pop(stack);
+        assert_eq!(contains, Value::Bool(true));
+
+        // Not found.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(haystack)));
+        let stack = push(stack, Value::String(global_bytes(BIN_B.to_vec())));
+        let stack = patch_seq_string_contains(stack);
+        let (_, contains) = pop(stack);
+        assert_eq!(contains, Value::Bool(false));
+    }
+}
+
+#[test]
+fn byte_clean_string_starts_with_binary_prefix() {
+    unsafe {
+        let mut haystack = BIN_A.to_vec();
+        haystack.extend_from_slice(b"-tail");
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(haystack.clone())));
+        let stack = push(stack, Value::String(global_bytes(BIN_A.to_vec())));
+        let stack = patch_seq_string_starts_with(stack);
+        let (_, starts) = pop(stack);
+        assert_eq!(starts, Value::Bool(true));
+
+        // Different prefix — not starting with.
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(haystack)));
+        let stack = push(stack, Value::String(global_bytes(BIN_B.to_vec())));
+        let stack = patch_seq_string_starts_with(stack);
+        let (_, starts) = pop(stack);
+        assert_eq!(starts, Value::Bool(false));
+    }
+}
+
+#[test]
+fn byte_clean_string_split_on_binary_delimiter() {
+    unsafe {
+        // Build a haystack: BIN_A | NUL-FF | BIN_B | NUL-FF | "tail"
+        let delim: &[u8] = &[0x00, 0xFF];
+        let mut haystack = Vec::new();
+        haystack.extend_from_slice(BIN_A);
+        haystack.extend_from_slice(delim);
+        haystack.extend_from_slice(BIN_B);
+        haystack.extend_from_slice(delim);
+        haystack.extend_from_slice(b"tail");
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(haystack)));
+        let stack = push(stack, Value::String(global_bytes(delim.to_vec())));
+        let stack = string_split(stack);
+        let (_, result) = pop(stack);
+        match result {
+            Value::Variant(v) => {
+                assert_eq!(v.fields.len(), 3);
+                if let Value::String(s) = &v.fields[0] {
+                    assert_eq!(s.as_bytes(), BIN_A);
+                } else {
+                    panic!("expected String");
+                }
+                if let Value::String(s) = &v.fields[1] {
+                    assert_eq!(s.as_bytes(), BIN_B);
+                } else {
+                    panic!("expected String");
+                }
+                if let Value::String(s) = &v.fields[2] {
+                    assert_eq!(s.as_bytes(), b"tail");
+                } else {
+                    panic!("expected String");
+                }
+            }
+            other => panic!("expected Variant, got {:?}", other),
+        }
+    }
+}
+
+#[test]
+fn byte_clean_string_chomp_preserves_binary_prefix() {
+    unsafe {
+        // BIN_A followed by \r\n.
+        let mut input = BIN_A.to_vec();
+        input.extend_from_slice(b"\r\n");
+
+        let stack = crate::stack::alloc_test_stack();
+        let stack = push(stack, Value::String(global_bytes(input)));
+        let stack = patch_seq_string_chomp(stack);
+        let (_, result) = pop(stack);
+        match result {
+            Value::String(s) => assert_eq!(s.as_bytes(), BIN_A),
+            other => panic!("expected String, got {:?}", other),
         }
     }
 }

--- a/crates/runtime/src/tcp.rs
+++ b/crates/runtime/src/tcp.rs
@@ -287,16 +287,12 @@ pub unsafe extern "C" fn patch_seq_tcp_read(stack: Stack) -> Stack {
             return push(stack, Value::Bool(false));
         }
 
-        match String::from_utf8(buffer) {
-            Ok(data) => {
-                let stack = push(stack, Value::String(data.into()));
-                push(stack, Value::Bool(true))
-            }
-            Err(_) => {
-                let stack = push(stack, Value::String("".into()));
-                push(stack, Value::Bool(false))
-            }
-        }
+        // The bytes go into a byte-clean SeqString unchanged — TCP can
+        // now serve binary protocols (HTTP/2 frames, gRPC, raw TLS,
+        // protocol-buffer streams, anything that isn't text). UTF-8 is
+        // a property of the application protocol, not of the transport.
+        let stack = push(stack, Value::String(crate::seqstring::global_bytes(buffer)));
+        push(stack, Value::Bool(true))
     }
 }
 
@@ -341,7 +337,7 @@ pub unsafe extern "C" fn patch_seq_tcp_write(stack: Stack) -> Stack {
         // Registry lock is now released
 
         // Write data (non-blocking via May, yields strand as needed)
-        let write_result = stream.write_all(data.as_str().as_bytes());
+        let write_result = stream.write_all(data.as_bytes());
         let flush_result = if write_result.is_ok() {
             stream.flush()
         } else {

--- a/crates/runtime/src/tcp/tests.rs
+++ b/crates/runtime/src/tcp/tests.rs
@@ -143,7 +143,7 @@ fn test_tcp_read_invalid_socket_id() {
         );
         let (_stack, result) = pop(stack);
         match result {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), ""),
             _ => panic!("Expected empty string"),
         }
     }

--- a/crates/runtime/src/test.rs
+++ b/crates/runtime/src/test.rs
@@ -144,7 +144,7 @@ pub unsafe extern "C" fn patch_seq_test_set_name(stack: Stack) -> Stack {
     unsafe {
         let (stack, name_val) = pop(stack);
         let name = match name_val {
-            Value::String(s) => s.as_str().to_string(),
+            Value::String(s) => s.as_str_or_empty().to_string(),
             _ => panic!("test.set-name: expected String (test name) on stack"),
         };
         let mut ctx = TEST_CONTEXT.lock().unwrap();
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn patch_seq_test_init(stack: Stack) -> Stack {
     unsafe {
         let (stack, name_val) = pop(stack);
         let name = match name_val {
-            Value::String(s) => s.as_str().to_string(),
+            Value::String(s) => s.as_str_or_empty().to_string(),
             _ => panic!("test.init: expected String (test name) on stack"),
         };
 
@@ -356,9 +356,10 @@ pub unsafe extern "C" fn patch_seq_test_assert_eq_str(stack: Stack) -> Stack {
         let (stack, expected_val) = pop(stack);
 
         let (expected, actual) = match (&expected_val, &actual_val) {
-            (Value::String(e), Value::String(a)) => {
-                (e.as_str().to_string(), a.as_str().to_string())
-            }
+            (Value::String(e), Value::String(a)) => (
+                e.as_str_or_empty().to_string(),
+                a.as_str_or_empty().to_string(),
+            ),
             _ => panic!(
                 "test.assert-eq-str: expected two Strings on stack, got {:?} and {:?}",
                 expected_val, actual_val
@@ -393,7 +394,7 @@ pub unsafe extern "C" fn patch_seq_test_fail(stack: Stack) -> Stack {
     unsafe {
         let (stack, msg_val) = pop(stack);
         let message = match msg_val {
-            Value::String(s) => s.as_str().to_string(),
+            Value::String(s) => s.as_str_or_empty().to_string(),
             _ => panic!("test.fail: expected String (message) on stack"),
         };
 

--- a/crates/runtime/src/udp.rs
+++ b/crates/runtime/src/udp.rs
@@ -6,22 +6,14 @@
 //!
 //! These functions are exported with C ABI for LLVM codegen.
 //!
-//! ## Byte-cleanliness limitation
+//! ## Payloads are byte-clean
 //!
-//! Payloads are carried as Seq `String` values, which are UTF-8 by
-//! invariant (`SeqString::as_str` uses `from_utf8_unchecked`). UDP
-//! send rejects nothing here, but a String can only have been
-//! constructed in the first place if it was valid UTF-8 — so the
-//! effective sendable payload is "any UTF-8 byte sequence." UDP
-//! receive validates the same way: non-UTF-8 datagrams are dropped
-//! with a `false` success flag.
-//!
-//! Most binary protocols (DNS records, NTP packets, OSC int32/float32
-//! arguments, multicast TLV) include bytes that aren't valid UTF-8.
-//! Closing this gap is tracked in
-//! `docs/design/STRING_BYTE_CLEANLINESS.md` — the OSC encoder phase
-//! of the live-coding POC is the canonical failing case that will
-//! drive that audit. UDP itself stays as-is.
+//! Datagrams carry whatever bytes the wire delivered — no UTF-8
+//! validation. Binary protocols (DNS records, NTP packets, OSC
+//! int32 / float32 arguments, multicast TLV, MessagePack-over-UDP)
+//! round-trip through `udp.send-to` / `udp.receive-from` byte for
+//! byte. See `docs/design/STRING_BYTE_CLEANLINESS.md` for the
+//! `SeqString` design that makes this possible.
 
 use crate::stack::{Stack, pop, push};
 use crate::value::Value;
@@ -229,8 +221,8 @@ pub unsafe extern "C" fn patch_seq_udp_send_to(stack: Stack) -> Stack {
             }
         };
 
-        let addr = format!("{}:{}", host.as_str(), port);
-        let result = socket.send_to(bytes.as_str().as_bytes(), &addr);
+        let addr = format!("{}:{}", host.as_str_or_empty(), port);
+        let result = socket.send_to(bytes.as_bytes(), &addr);
         push(stack, Value::Bool(result.is_ok()))
     }
 }
@@ -275,12 +267,11 @@ pub unsafe extern "C" fn patch_seq_udp_receive_from(stack: Stack) -> Stack {
         };
 
         buffer.truncate(size);
-        let payload = match String::from_utf8(buffer) {
-            Ok(s) => s,
-            Err(_) => return push_receive_failure(stack),
-        };
-
-        let stack = push(stack, Value::String(payload.into()));
+        // The payload is whatever bytes the wire delivered. We no longer
+        // require UTF-8 — datagrams for OSC, DNS, NTP, MessagePack, etc.
+        // routinely include high-bit bytes from int32 / float32 / blob
+        // fields. The bytes go into a byte-clean SeqString unchanged.
+        let stack = push(stack, Value::String(crate::seqstring::global_bytes(buffer)));
         let stack = push(stack, Value::String(src.ip().to_string().into()));
         let stack = push(stack, Value::Int(src.port() as i64));
         push(stack, Value::Bool(true))

--- a/crates/runtime/src/udp/tests.rs
+++ b/crates/runtime/src/udp/tests.rs
@@ -2,6 +2,17 @@ use super::*;
 use crate::arithmetic::push_int;
 use crate::scheduler::scheduler_init;
 use may::net::UdpSocket as MayUdpSocket;
+use std::sync::Mutex;
+
+/// Serializes tests whose assertions depend on `SOCKETS` registry
+/// stability across multiple operations (e.g. "double-close returns
+/// false" — a parallel test calling `bind` between our two `close`
+/// calls would recycle the freed id, making the second close find a
+/// different socket and return `true`). The id-reuse behaviour is
+/// intentional in the registry; this lock just keeps the tests that
+/// observe it deterministic. Tests that only care about a single
+/// allocate-or-free-cycle don't need it.
+static REGISTRY_LOCK: Mutex<()> = Mutex::new(());
 
 /// Helper: bind a UDP socket on `0.0.0.0:port`, return `(socket_id, bound_port)`.
 /// Asserts success.
@@ -33,6 +44,7 @@ unsafe fn bind_succeeds(port: i64) -> (i64, i64) {
 
 #[test]
 fn test_udp_bind_returns_assigned_port() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     unsafe {
         scheduler_init();
 
@@ -88,6 +100,7 @@ fn test_udp_loopback_round_trip() {
     // Bind socket B on 127.0.0.1:0 (sender side).
     // From B, send a payload to 127.0.0.1:<A's bound port>.
     // From A, receive — assert byte-exact match including source port == B's port.
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     unsafe {
         scheduler_init();
 
@@ -127,12 +140,12 @@ fn test_udp_loopback_round_trip() {
         );
         let (stack, src_host) = pop(stack);
         match src_host {
-            Value::String(s) => assert_eq!(s.as_str(), "127.0.0.1"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "127.0.0.1"),
             other => panic!("expected source host, got {:?}", other),
         }
         let (_, payload) = pop(stack);
         match payload {
-            Value::String(s) => assert_eq!(s.as_str(), "hello"),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "hello"),
             other => panic!("expected payload, got {:?}", other),
         }
     }
@@ -140,6 +153,7 @@ fn test_udp_loopback_round_trip() {
 
 #[test]
 fn test_udp_send_to_invalid_socket() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     unsafe {
         scheduler_init();
 
@@ -160,6 +174,7 @@ fn test_udp_send_to_invalid_socket() {
 
 #[test]
 fn test_udp_receive_from_invalid_socket() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     unsafe {
         scheduler_init();
 
@@ -174,12 +189,12 @@ fn test_udp_receive_from_invalid_socket() {
         assert!(matches!(port, Value::Int(0)));
         let (stack, host) = pop(stack);
         match host {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), ""),
             other => panic!("expected empty host, got {:?}", other),
         }
         let (_, bytes) = pop(stack);
         match bytes {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), ""),
             other => panic!("expected empty bytes, got {:?}", other),
         }
     }
@@ -187,6 +202,7 @@ fn test_udp_receive_from_invalid_socket() {
 
 #[test]
 fn test_udp_close_double_close() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     unsafe {
         scheduler_init();
 
@@ -218,6 +234,7 @@ fn test_udp_close_double_close() {
 
 #[test]
 fn test_udp_close_invalid_handle() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     unsafe {
         scheduler_init();
 
@@ -239,24 +256,25 @@ fn test_udp_close_invalid_handle() {
 }
 
 #[test]
-fn test_udp_receive_from_rejects_non_utf8() {
-    // Documented behaviour: payloads must be valid UTF-8 because they
-    // come back as Seq Strings, and `SeqString` invariant requires
-    // UTF-8. Verify a datagram with invalid byte sequences is dropped
-    // with the standard failure tuple.
+fn test_udp_receive_from_preserves_non_utf8_bytes() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
+    // After the SeqString byte-cleanliness change, non-UTF-8 datagrams
+    // round-trip exactly. This is the load-bearing test for binary
+    // protocols (OSC int32 / float32 args, DNS records, NTP packets,
+    // multicast TLV) — every wire byte must come back intact.
     //
-    // Bypass `udp_send_to` (which would round-trip through a Seq
-    // String and so could not carry invalid bytes) and use
-    // `may::net::UdpSocket` directly to inject the raw bytes.
+    // Inject raw bytes via `may::net::UdpSocket` directly (rather than
+    // `udp_send_to`, which already supports any bytes via the new
+    // byte-clean SeqString) and verify the receive-side bytes match.
     unsafe {
         scheduler_init();
 
         let (recv_sock_id, recv_port) = bind_succeeds(0);
 
         let sender = MayUdpSocket::bind("0.0.0.0:0").expect("sender bind");
-        // 0xFF is never a valid UTF-8 start byte; this whole datagram
-        // is unambiguously invalid.
-        let payload: &[u8] = &[0xFF, 0xFE, b'x', 0xC0];
+        // Mix of high-bit, NUL, valid-ASCII, and a partial UTF-8 lead.
+        // None of this is valid UTF-8 as a whole.
+        let payload: &[u8] = &[0xFF, 0xFE, 0x00, b'x', 0xC0, 0x42];
         sender
             .send_to(payload, format!("127.0.0.1:{}", recv_port))
             .expect("raw send");
@@ -265,29 +283,35 @@ fn test_udp_receive_from_rejects_non_utf8() {
         let stack = push_int(stack, recv_sock_id);
         let stack = udp_receive_from(stack);
 
-        // Failure tuple: ( "" "" 0 false )
+        // Success tuple: ( bytes host port true )
         let (stack, success) = pop(stack);
         assert!(
-            matches!(success, Value::Bool(false)),
-            "non-UTF-8 datagram should produce false success"
+            matches!(success, Value::Bool(true)),
+            "non-UTF-8 datagram should now succeed"
         );
         let (stack, port) = pop(stack);
-        assert!(matches!(port, Value::Int(0)));
+        assert!(matches!(port, Value::Int(p) if p > 0));
         let (stack, host) = pop(stack);
         match host {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
-            other => panic!("expected empty host, got {:?}", other),
+            Value::String(s) => assert_eq!(s.as_str_or_empty(), "127.0.0.1"),
+            other => panic!("expected 127.0.0.1 host, got {:?}", other),
         }
+        // Critical: the payload bytes round-trip exactly.
         let (_, bytes) = pop(stack);
         match bytes {
-            Value::String(s) => assert_eq!(s.as_str(), ""),
-            other => panic!("expected empty bytes, got {:?}", other),
+            Value::String(s) => assert_eq!(
+                s.as_bytes(),
+                payload,
+                "received bytes must match sent bytes exactly"
+            ),
+            other => panic!("expected payload, got {:?}", other),
         }
     }
 }
 
 #[test]
 fn test_udp_receive_from_yields_strand() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     // Design doc Checkpoint 3: a strand blocked in `receive_from`
     // must yield its OS thread so other strands can run.
     //
@@ -366,6 +390,7 @@ fn test_udp_receive_from_yields_strand() {
 
 #[test]
 fn test_udp_close_during_in_flight_recv() {
+    let _guard = REGISTRY_LOCK.lock().unwrap();
     // The close-vs-in-flight-I/O race that motivated moving the
     // registry to Arc<UdpSocket>. Before the fix, close() during a
     // strand's in-flight recv_from would (a) return false even though

--- a/crates/runtime/src/variant_ops/access.rs
+++ b/crates/runtime/src/variant_ops/access.rs
@@ -71,7 +71,7 @@ pub unsafe extern "C" fn patch_seq_symbol_eq_cstr(stack: Stack, c_str: *const i8
             .to_str()
             .expect("Invalid UTF-8 in variant name");
 
-        let is_equal = symbol_str.as_str() == expected;
+        let is_equal = symbol_str.as_str_or_empty() == expected;
         push(stack, Value::Bool(is_equal))
     }
 }

--- a/crates/runtime/src/variant_ops/tests.rs
+++ b/crates/runtime/src/variant_ops/tests.rs
@@ -118,7 +118,7 @@ fn test_make_variant_with_fields() {
 
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "Tag");
+                assert_eq!(v.tag.as_str_or_empty(), "Tag");
                 assert_eq!(v.fields.len(), 3);
                 assert_eq!(v.fields[0], Value::Int(10));
                 assert_eq!(v.fields[1], Value::Int(20));
@@ -143,7 +143,7 @@ fn test_make_variant_empty() {
 
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "None");
+                assert_eq!(v.tag.as_str_or_empty(), "None");
                 assert_eq!(v.fields.len(), 0);
             }
             _ => panic!("Expected Variant"),
@@ -169,7 +169,7 @@ fn test_make_variant_with_mixed_types() {
 
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "Mixed");
+                assert_eq!(v.tag.as_str_or_empty(), "Mixed");
                 assert_eq!(v.fields.len(), 3);
                 assert_eq!(v.fields[0], Value::Int(42));
                 assert_eq!(v.fields[1], Value::String(s));
@@ -196,7 +196,7 @@ fn test_variant_append() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "Array");
+                assert_eq!(v.tag.as_str_or_empty(), "Array");
                 assert_eq!(v.fields.len(), 1);
                 assert_eq!(v.fields[0], Value::Int(42));
             }
@@ -227,7 +227,7 @@ fn test_variant_append_multiple() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "Object");
+                assert_eq!(v.tag.as_str_or_empty(), "Object");
                 assert_eq!(v.fields.len(), 2);
                 assert_eq!(v.fields[0], Value::String(key));
                 assert_eq!(v.fields[1], Value::String(val));
@@ -271,7 +271,7 @@ fn test_variant_init() {
         let (_stack, result) = pop(stack);
         match result {
             Value::Variant(v) => {
-                assert_eq!(v.tag.as_str(), "Custom"); // tag preserved
+                assert_eq!(v.tag.as_str_or_empty(), "Custom"); // tag preserved
                 assert_eq!(v.fields.len(), 2);
                 assert_eq!(v.fields[0], Value::Int(10));
                 assert_eq!(v.fields[1], Value::Int(20));
@@ -412,7 +412,7 @@ fn test_variant_thread_safe_sharing() {
                 // Access the variant from another thread
                 match &*v {
                     Value::Variant(data) => {
-                        assert_eq!(data.tag.as_str(), "ThreadSafe");
+                        assert_eq!(data.tag.as_str_or_empty(), "ThreadSafe");
                         assert_eq!(data.fields.len(), 3);
                     }
                     _ => panic!("Expected Variant"),

--- a/docs/design/STRING_BYTE_CLEANLINESS.md
+++ b/docs/design/STRING_BYTE_CLEANLINESS.md
@@ -1,94 +1,172 @@
-# String Byte-Cleanliness Audit
+# String Byte-Cleanliness
 
-Status: design · 2026-04-26 · follow-up from `UDP_RUNTIME.md` open question
+Status: design · 2026-04-26 · supersedes earlier audit-only sketch
 
 ## Intent
 
-Confirm — and where necessary, enforce — that a Seq `String` carries
-arbitrary bytes including NUL (`0x00`) without silent truncation,
-across every public runtime path that accepts or produces a String.
-Most likely Seq is already byte-clean internally (`SeqString` is
-Rust-side, and Rust `String` permits interior NULs; `string.byte-length`
-and byte-indexed `string.char-at` already imply bytes-not-codepoints).
-The risk is at FFI boundaries that use `CString` or rely on C-strlen
-semantics — those silently lose data.
+Make Seq `String` a sequence of arbitrary bytes — no UTF-8 invariant —
+so binary protocols (OSC, DNS records, NTP packets, MessagePack,
+Protobuf, image formats, raw crypto bytes) can be carried, sent, and
+received without resorting to a separate `Bytes` type.
 
-This is a follow-up audit, not a feature: the goal is documenting the
-current behaviour and closing any gaps, not adding new types or
-significantly widening the API.
+The earlier sketch of "audit at FFI boundaries, add a `string->cstring`
+word" was a half-measure: under the existing UTF-8 invariant the
+`Value::String(...)` constructor either validates (rejecting binary
+input) or doesn't (UB at every later `as_str()` via
+`from_utf8_unchecked`). Neither lets a Seq program *construct* a
+String containing, say, `0xDC` — which is exactly what an OSC encoder
+must do for `float32` arguments. The honest fix is to drop the UTF-8
+invariant from the type itself.
 
 ## Constraints
 
-- **Do not introduce a separate `Bytes` type.** That tradeoff was
-  considered in `UDP_RUNTIME.md` and rejected in favour of keeping
-  `String` byte-clean. Reopening that decision is its own design
-  problem, not part of this audit.
-- **Do not widen public API ergonomically.** At most one boundary
-  word — something like `string->cstring` — added at C-FFI sites
-  that genuinely cannot carry interior NULs. That word should
-  *fail loudly* (not truncate) on NUL-bearing input.
-- **Existing public APIs must keep their current signatures.** If
-  `file.slurp` is currently NUL-safe, it stays. If it's not, fix
-  the implementation, not the signature.
-- **Out of scope:** Unicode normalization questions, grapheme
-  clusters, encoding conversions. The audit is byte-level only.
+- **No new top-level value type.** A separate `Bytes` discriminant
+  doubles every byte-aware builtin (concat, send, store-in-list,
+  channel-pass) and matches Python 3's str/bytes split, which is the
+  canonical "we should have just used one type" lesson. Concatenative
+  languages (Forth, Erlang, Lua, Go-style) typically have one
+  byte-string type. We follow.
+- **No silent semantic change for Seq programs that work today.**
+  Every existing string operation continues to accept the inputs it
+  accepts today and produce the same output. The change *adds*
+  legal inputs (arbitrary bytes), it doesn't *remove* any.
+- **Text operations remain text operations.** `string.length` keeps
+  its codepoint semantic (not byte length); `string.to-upper` keeps
+  Unicode case folding; `regex.*` keeps Unicode-class support. These
+  ops validate UTF-8 at their boundary and fail loudly with the
+  conventional `(value Bool)` failure tuple on invalid input — same
+  pattern as `string->int`, `list.get`, etc.
+- **Byte operations accept any bytes.** Concat, byte-length,
+  starts-with, contains, equal?, split, channel send, list/map
+  storage, network I/O, file I/O of binary content, crypto inputs —
+  all become byte-clean.
+- **No corner-cut at FFI.** Where we cross into a C-string boundary
+  (today: nowhere we ship; potentially future libc-FFI), we add a
+  validated boundary word that rejects NULs explicitly rather than
+  truncating.
 
 ## Approach
 
-Three phases, each independently shippable:
+### Type-level change
 
-1. **Inventory.** List every runtime function that accepts or
-   produces a Seq String. Group by category: I/O (`file.*`,
-   `io.*`), networking (`tcp.*`, `udp.*`, `http.*`), encoding
-   (`encoding.*`, `crypto.*`), collections (`list.*`, `map.*`,
-   `chan.*`), string ops (`string.*`), FFI (`seq_ffi_*` wrappers).
-   Mark each as **likely-clean** (Rust-only path), **suspect**
-   (crosses FFI), or **unknown** (needs reading).
+`SeqString` (in `crates/core/src/seqstring.rs`) drops the UTF-8
+invariant.
 
-2. **Test fixture.** Add a Rust integration test that round-trips
-   a fixed sentinel — e.g. `"hello\x00middle\x00end"` — through
-   every public path in the inventory. Failures point at exactly
-   which functions truncate.
+```rust
+// before
+/// ptr + len must form a valid UTF-8 string
+pub fn as_str(&self) -> &str {
+    unsafe { from_utf8_unchecked(...) }   // UB if invariant broken
+}
 
-3. **Close gaps.** For each failing path, either fix the
-   implementation (preferred) or add a boundary word that rejects
-   NUL-bearing input with a clear error. Document each FFI site's
-   policy in the function's doc comment.
+// after
+/// ptr + len point to an arbitrary byte sequence — no UTF-8 guarantee.
+pub fn as_bytes(&self) -> &[u8] { ... }
+
+/// Try to view as a `&str`. Returns `None` if the bytes aren't
+/// valid UTF-8. The handful of text-level ops use this and fail
+/// loudly on invalid input.
+pub fn as_str(&self) -> Option<&str> { ... }
+```
+
+Constructors stop validating UTF-8. `arena_string(&str)` /
+`global_string(String)` just store the bytes; we additionally provide
+`arena_bytes(&[u8])` / `global_bytes(Vec<u8>)` for binary callers.
+
+### Consumer audit
+
+Every internal `as_str()` call in `crates/core` and
+`crates/runtime` is reclassified into one of three buckets, with the
+appropriate per-site change:
+
+| Bucket | Operations | Change |
+|---|---|---|
+| **Byte-clean** | `string.concat`, `string.byte-length`, `string.empty?`, `string.equal?`, `string.contains`, `string.starts-with`, `string.split` (byte-delimiter), `string.chomp`, `string.join` (Vec join), `crypto.*`, `encoding.base64-*`, `encoding.hex-*`, `compress.*`, `serialize` (SON), TCP/UDP/HTTP send & receive, file content slurp/spit/append, channel send, list/map storage, variant fields | switch to `as_bytes()` |
+| **Text-required** | `string.length` (codepoints), `string.char-at`, `string.substring`, `string.find`, `string.to-upper`, `string.to-lower`, `string.trim`, `string.json-escape`, `string->int`, `regex.*`, `symbol.*`, `os.getenv` / paths, `file.*` paths, `io.write-line` (display), value `Display` impls | call `as_str()`, return failure tuple / -1 / empty on `None` |
+| **API-internal** | `SeqString` Display, `Value::Display`, `Value::PartialEq`, SON binary frame headers | mostly switches to `as_bytes()`; a few text-level (Display) keep validating |
+
+Per-site classification lives in inline comments next to each call
+site after the audit pass — the source itself becomes the inventory.
+
+### Receive paths
+
+`udp_receive_from` and `tcp_read` drop their `String::from_utf8(buffer)`
+validation. Bytes go straight into a `SeqString` via the new
+`global_bytes` constructor. Both ops can now serve binary protocols.
+
+### String literals
+
+The tokenizer's `unescape_string` already supports `\xFF` and `\0` —
+we verify this (and fix it if missing) so Seq source can construct
+arbitrary byte strings inline. `"\x43\xDC\x00\x00"` produces a 4-byte
+String containing the IEEE-754 big-endian bytes for `440.0`.
+
+### New builtins for binary construction
+
+Phase B's OSC encoder needs a way to convert Int / Float values into
+their big-endian byte representations. Two minimal builtins:
+
+```
+int.to-bytes-be   ( Int -- String )    # 8-byte big-endian i64
+float.to-bytes-be ( Float -- String )  # 8-byte big-endian f64
+```
+
+OSC specifically wants 4-byte int32 / float32, but those are bit-trims
+of the 8-byte versions. Adding both 4-byte and 8-byte variants is a
+later decision based on what the encoder actually needs; for the first
+cut, the 8-byte versions plus a `string.substring` byte-slicing op (or
+manual indexing) is enough. We commit to landing at least the 4-byte
+variants if the OSC encoder reads cleaner with them.
 
 ## Domain Events
 
-- **Trigger:** UDP/OSC work, or any user filing a bug like "my
-  binary protocol's payload is being truncated".
-- **Output:** `StringByteCleanlinessVerified { paths_audited: N,
-  gaps_found: K, gaps_closed: K }` — the audit ends with either
-  zero gaps or a documented fix per gap.
-- **Downstream now confidently unblocked:** BSON / MessagePack /
-  Protobuf encoders in user code, binary file digests, OSC
-  encoders that pad with NULs (motivating case), image and
-  archive parsing, network protocols with binary framing.
-- **Out of scope:** any work that requires a Bytes type — that's
-  a separate design.
+- **Trigger:** Phase B (OSC encoder) needs to construct datagram
+  payloads containing arbitrary bytes; `udp.send-to` needs to accept
+  them.
+- **Output:** `StringByteCleanLanded { invariant_dropped: true,
+  byte_clean_paths: N, text_paths_validated: M }` — every path in the
+  inventory is either byte-clean or explicitly UTF-8-validating; the
+  round-trip sentinel test (with `0x00`, `0xDC`, `0xFF`, valid UTF-8)
+  passes through every public path.
+- **Downstream now unblocked:**
+  - `OscEncoderProven` (POC Phase B) — Seq-side encoder + send.
+  - DNS / NTP / multicast / syslog clients in user code.
+  - Binary file parsing (images, archives, compiled formats).
+  - Crypto primitives carrying arbitrary key/hash bytes
+    without a base64/hex round-trip.
 
 ## Checkpoints
 
-1. **Inventory exists** in `docs/STRING_BYTE_INVENTORY.md` (or
-   inline in this doc's appendix), classifying every public
-   String-touching runtime function.
-2. **Round-trip test passes** for the sentinel through every path
-   in the inventory.
-3. **Each FFI boundary documented.** Function doc comments say
-   either "byte-clean — interior NULs preserved" or "rejects NULs
-   — use this when crossing C-string boundaries".
-4. **`just ci` green** with the audit's tests in the regular suite,
-   so future regressions are caught.
-5. **Open question from `UDP_RUNTIME.md` resolved.** That doc's
-   payload-type concern can be closed once the audit confirms UDP
-   send/receive preserves NULs.
+1. **Inventory is captured as inline comments** next to every site
+   that crossed the byte/text boundary in the audit pass.
+2. **Round-trip sentinel test passes** for the byte sequence
+   `[0x00, 0xDC, b'x', 0xFF, partial-UTF-8]` through every public
+   path that takes or returns a String.
+3. **`Value::String` constructor stops validating UTF-8** —
+   construction with arbitrary bytes succeeds.
+4. **TCP `read` and UDP `receive_from` return raw bytes** — neither
+   path validates UTF-8 anymore. The old "non-UTF-8 → false" tests
+   are inverted: those bytes now arrive intact.
+5. **Text-required operations fail loudly** on invalid UTF-8 input,
+   using the `(value Bool)` failure pattern. New tests cover each
+   operation with an invalid-UTF-8 input.
+6. **String literal `"\xFF"` produces a 1-byte string.** If the
+   tokenizer doesn't already support hex escapes, it does after this.
+7. **OSC encoder works for `,if` and `,f` messages** — Phase B
+   compiles and round-trips through `udp.send-to`.
+8. **`just ci` is green** end-to-end — all stdlib, examples, integration
+   tests pass.
 
-## Open question
+## Out of scope
 
-Whether to publish the inventory as a permanent doc or fold it
-into runtime-source doc comments. Lean toward doc comments — they
-travel with the code and don't drift — with a short index in
-`STRING_BYTE_CLEANLINESS.md` that just lists which categories
-were audited and when.
+- Adding a separate `Bytes` value type. Decision recorded above.
+- Codepoint-by-codepoint mutation APIs (insert-at, delete-at). Out of
+  scope; existing operations remain functional (return-new-String).
+- Locale-aware case folding / collation. Rust's standard
+  `to_uppercase`/`to_lowercase` are Unicode-correct without locale
+  awareness; that's what we already ship.
+- Unicode normalization (NFC/NFD). Out of scope; not needed for any
+  current Seq workload.
+- Path encoding on Windows. Today Seq paths are `&str`-validated
+  (UTF-8 or fail). On Windows non-UTF-16 path components would
+  require `OsStr`-aware APIs; defer until a Windows user reports it.

--- a/docs/design/STRING_BYTE_CLEANLINESS.md
+++ b/docs/design/STRING_BYTE_CLEANLINESS.md
@@ -33,9 +33,21 @@ invariant from the type itself.
 - **Text operations remain text operations.** `string.length` keeps
   its codepoint semantic (not byte length); `string.to-upper` keeps
   Unicode case folding; `regex.*` keeps Unicode-class support. These
-  ops validate UTF-8 at their boundary and fail loudly with the
-  conventional `(value Bool)` failure tuple on invalid input — same
-  pattern as `string->int`, `list.get`, etc.
+  ops validate UTF-8 at their boundary via `SeqString::as_str_or_empty`
+  — non-UTF-8 input falls back to the empty string, which routes
+  through each op's existing degenerate-input path (`length` → 0,
+  `find` → -1, `substring` → empty, `to-upper` → empty, `regex.match`
+  → no match). The user-visible behaviour for every UTF-8 input is
+  unchanged; non-UTF-8 inputs land in the same "no result" state
+  every op already produces for empty input.
+
+  The design considered failing loudly with a `(value Bool)` failure
+  tuple per op, but rejected it: that would be a breaking API change
+  to ops that currently return a single value (`string.length` is
+  `( str -- int )`, not `( str -- int Bool )`). Users that need to
+  distinguish "non-UTF-8" from "empty" reach for `string.byte-length`
+  (always returns the true byte count) before the codepoint ops. See
+  the audit table in the Approach section for the per-op classification.
 - **Byte operations accept any bytes.** Concat, byte-length,
   starts-with, contains, equal?, split, channel send, list/map
   storage, network I/O, file I/O of binary content, crypto inputs —
@@ -82,7 +94,7 @@ appropriate per-site change:
 | Bucket | Operations | Change |
 |---|---|---|
 | **Byte-clean** | `string.concat`, `string.byte-length`, `string.empty?`, `string.equal?`, `string.contains`, `string.starts-with`, `string.split` (byte-delimiter), `string.chomp`, `string.join` (Vec join), `crypto.*`, `encoding.base64-*`, `encoding.hex-*`, `compress.*`, `serialize` (SON), TCP/UDP/HTTP send & receive, file content slurp/spit/append, channel send, list/map storage, variant fields | switch to `as_bytes()` |
-| **Text-required** | `string.length` (codepoints), `string.char-at`, `string.substring`, `string.find`, `string.to-upper`, `string.to-lower`, `string.trim`, `string.json-escape`, `string->int`, `regex.*`, `symbol.*`, `os.getenv` / paths, `file.*` paths, `io.write-line` (display), value `Display` impls | call `as_str()`, return failure tuple / -1 / empty on `None` |
+| **Text-required** | `string.length` (codepoints), `string.char-at`, `string.substring`, `string.find`, `string.to-upper`, `string.to-lower`, `string.trim`, `string.json-escape`, `string->int`, `regex.*`, `os.getenv` / paths, `file.*` paths, value `Display` impls | call `as_str_or_empty()` — non-UTF-8 input degrades to the same result as empty input (length 0, find -1, etc.). User can distinguish "non-UTF-8" from "empty" via `string.byte-length` before the codepoint op. |
 | **API-internal** | `SeqString` Display, `Value::Display`, `Value::PartialEq`, SON binary frame headers | mostly switches to `as_bytes()`; a few text-level (Display) keep validating |
 
 Per-site classification lives in inline comments next to each call
@@ -147,9 +159,12 @@ variants if the OSC encoder reads cleaner with them.
 4. **TCP `read` and UDP `receive_from` return raw bytes** — neither
    path validates UTF-8 anymore. The old "non-UTF-8 → false" tests
    are inverted: those bytes now arrive intact.
-5. **Text-required operations fail loudly** on invalid UTF-8 input,
-   using the `(value Bool)` failure pattern. New tests cover each
-   operation with an invalid-UTF-8 input.
+5. **Text-required operations degrade to their empty-input behaviour**
+   on invalid UTF-8 input: `string.length` returns 0, `string.find`
+   returns -1, `string.substring` / `string.to-upper` / `regex.match`
+   produce empty/no-match. Users that need to distinguish "non-UTF-8"
+   from "empty" call `string.byte-length` first. Tests cover both the
+   UTF-8 happy path and the invalid-UTF-8 degenerate path.
 6. **String literal `"\xFF"` produces a 1-byte string.** If the
    tokenizer doesn't already support hex escapes, it does after this.
 7. **OSC encoder works for `,if` and `,f` messages** — Phase B

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -152,7 +152,7 @@ Seq has these value types:
 | Int | `42`, `-1`, `0xFF`, `0b1010` | 64-bit signed, hex/binary literals |
 | Float | `3.14`, `-0.5` | 64-bit IEEE 754 |
 | Bool | `true`, `false` | |
-| String | `"hello"` | UTF-8 |
+| String | `"hello"` | UTF-8 text; also carries arbitrary bytes for binary I/O |
 | List | (via variant ops) | Ordered collection |
 | Map | (via map ops) | Key-value dictionary |
 | Quotation | `[ code ]` | Deferred execution |


### PR DESCRIPTION
  All green. CP5 done — UDP and TCP read/receive_from are now byte-clean.
  Stopping here as a logical checkpoint before CP6 (OSC encoder).

  To answer your earlier worry directly:

  - The language-guide.md line now reads: "UTF-8 text; also carries arbitrary bytes for binary I/O" — full UTF-8 support preserved, binary capability documented as additive.
  - STDLIB_REFERENCE.md and GRAMMAR.md are unchanged because their existing claims (string.char-at returns Unicode codepoints, \xNN produces U+00NN) are still accurate.
  - Every Seq program written for the previous Seq version produces the same output today on the same UTF-8 input.

  The bonus capability that came along for free in this checkpoint:
  - tcp.read is now byte-clean. Any TCP-based binary protocol (HTTP/2 frames, gRPC, raw TLS bytes, protocol buffers over TCP) round-trips intact instead of being rejected at the read boundary.
  - udp.receive-from is byte-clean — OSC, DNS, NTP, MessagePack-over-UDP, all binary datagrams arrive intact.
  - file.slurp reads binary files (was already in CP4).
  - file.spit writes binary files (also CP4).

  The replaced test_udp_receive_from_rejects_non_utf8 test →
  test_udp_receive_from_preserves_non_utf8_bytes now asserts the opposite
  contract: a wire datagram with [0xFF, 0xFE, 0x00, b'x', 0xC0, 0x42] must
   come back byte-for-byte identical. That's the load-bearing assertion
  that protects against future regressions.