### PR TITLE
CP8 complete. Two design-doc updates in line with the existing

### DIFF
--- a/docs/design/LIVE_CODING_CSOUND_POC.md
+++ b/docs/design/LIVE_CODING_CSOUND_POC.md
@@ -1,5 +1,10 @@
 # Live-Coding POC: Seq → OSC → Csound
 
+Status: Phase A and Phase B implemented · PR #434 (UDP runtime),
+#436 (string byte-cleanliness), #437 (OSC encoder + byte
+construction primitives), #439 (OSC-over-UDP loopback) · 2026-04-27 ·
+Phase C (Csound `live.csd` + audible kick) remains.
+
 ## Intent
 
 Validate that Seq is a credible host language for live-coding music by
@@ -80,18 +85,23 @@ literal.
 
 ## Checkpoints
 
-1. **UDP loopback test passes** in patch-seq: send a message to
-   yourself, receive it back, round-trip is byte-exact.
-2. **OSC fixture test passes**: an encoded OSC message from Seq
-   matches the byte layout in the OSC 1.0 spec for a known input
-   (e.g. `/foo` with one int and one float).
-3. **Csound responds**: starting `live.csd` and sending one OSC
-   message from a one-line Seq script produces an audible tone.
-4. **A bar of music plays**: a clock-driven Seq strand sends 8 beats
-   on a metronome; you hear them on time, no audible jitter.
-5. **POC writeup decides the spinout question** with evidence
-   (latency measurements, code size of the example, Seq language
-   gaps surfaced).
+1. **[done · PR #439]** UDP loopback test passes in patch-seq: send
+   a message to yourself, receive it back, round-trip is byte-exact.
+   Lives at `examples/projects/live-coding-csound/test_osc_loopback.seq`
+   and runs as part of `just test-integration`.
+2. **[done · PR #437]** OSC fixture test passes: encoded OSC messages
+   from Seq match the byte layout in the OSC 1.0 spec for `,i`, `,f`,
+   `,if`, and empty-arg payloads. Pinned in
+   `examples/projects/live-coding-csound/test_osc.seq`.
+3. **[Phase C — pending]** Csound responds: starting `live.csd` and
+   sending one OSC message from a one-line Seq script produces an
+   audible tone.
+4. **[Phase C — pending]** A bar of music plays: a clock-driven Seq
+   strand sends 8 beats on a metronome; you hear them on time, no
+   audible jitter.
+5. **[Phase C — pending]** POC writeup decides the spinout question
+   with evidence (latency measurements, code size of the example,
+   Seq language gaps surfaced).
 
 ## Open Question
 

--- a/docs/design/STRING_BYTE_CLEANLINESS.md
+++ b/docs/design/STRING_BYTE_CLEANLINESS.md
@@ -1,6 +1,8 @@
 # String Byte-Cleanliness
 
-Status: design · 2026-04-26 · supersedes earlier audit-only sketch
+Status: implemented · PR #436 (invariant drop + consumer audit, plus
+follow-ups CP5b/c/d) and PR #437 (Path B `\xNN` byte literals) · 2026-04-27 ·
+supersedes earlier audit-only sketch
 
 ## Intent
 
@@ -149,28 +151,34 @@ variants if the OSC encoder reads cleaner with them.
 
 ## Checkpoints
 
-1. **Inventory is captured as inline comments** next to every site
-   that crossed the byte/text boundary in the audit pass.
-2. **Round-trip sentinel test passes** for the byte sequence
-   `[0x00, 0xDC, b'x', 0xFF, partial-UTF-8]` through every public
-   path that takes or returns a String.
-3. **`Value::String` constructor stops validating UTF-8** —
-   construction with arbitrary bytes succeeds.
-4. **TCP `read` and UDP `receive_from` return raw bytes** — neither
-   path validates UTF-8 anymore. The old "non-UTF-8 → false" tests
-   are inverted: those bytes now arrive intact.
-5. **Text-required operations degrade to their empty-input behaviour**
-   on invalid UTF-8 input: `string.length` returns 0, `string.find`
-   returns -1, `string.substring` / `string.to-upper` / `regex.match`
-   produce empty/no-match. Users that need to distinguish "non-UTF-8"
-   from "empty" call `string.byte-length` first. Tests cover both the
-   UTF-8 happy path and the invalid-UTF-8 degenerate path.
-6. **String literal `"\xFF"` produces a 1-byte string.** If the
-   tokenizer doesn't already support hex escapes, it does after this.
-7. **OSC encoder works for `,if` and `,f` messages** — Phase B
-   compiles and round-trips through `udp.send-to`.
-8. **`just ci` is green** end-to-end — all stdlib, examples, integration
-   tests pass.
+1. **[done · PR #436]** Inventory is captured as inline comments next
+   to every site that crossed the byte/text boundary in the audit pass.
+2. **[done · PR #436]** Round-trip sentinel test passes for the byte
+   sequence `[0x00, 0xDC, b'x', 0xFF, partial-UTF-8]` through every
+   public path that takes or returns a String.
+3. **[done · PR #436]** `Value::String` constructor stops validating
+   UTF-8 — construction with arbitrary bytes succeeds.
+4. **[done · PR #436]** TCP `read` and UDP `receive_from` return raw
+   bytes — neither path validates UTF-8 anymore. The old "non-UTF-8 →
+   false" tests are inverted: those bytes now arrive intact.
+5. **[done · PR #436]** Text-required operations degrade to their
+   empty-input behaviour on invalid UTF-8 input: `string.length`
+   returns 0, `string.find` returns -1, `string.substring` /
+   `string.to-upper` / `regex.match` produce empty/no-match. Users
+   that need to distinguish "non-UTF-8" from "empty" call
+   `string.byte-length` first. Tests cover both the UTF-8 happy path
+   and the invalid-UTF-8 degenerate path.
+6. **[done · PR #437]** String literal `"\xFF"` produces a 1-byte
+   string. The tokenizer's `unescape_string` returns `Vec<u8>`,
+   `Statement::StringLiteral` carries `Vec<u8>`, and codegen emits
+   `(ptr, len)` to a new `patch_seq_push_string_bytes` runtime FFI
+   so embedded NULs survive.
+7. **[done · PRs #437 + #439]** OSC encoder works for `,i`, `,f`,
+   `,if`, and empty-arg messages — Phase B compiles, byte-format
+   tests pin the wire layout, and the loopback suite proves
+   end-to-end round-trip through `udp.send-to` / `udp.receive-from`.
+8. **[done]** `just ci` is green end-to-end — all stdlib, examples,
+   integration tests pass.
 
 ## Out of scope
 


### PR DESCRIPTION
  convention (VARIANT_OP_TYPE_SAFETY.md is the precedent — status line +
  per-checkpoint annotations):

  docs/design/STRING_BYTE_CLEANLINESS.md
  - Status line updated to implemented · PR #436 ... PR #437 ....
  - All 8 checkpoints marked [done · PR #N] with the specific PR that landed each.

  docs/design/LIVE_CODING_CSOUND_POC.md
  - Status line: Phase A and Phase B implemented, Phase C remains.
  - Checkpoint 1 (UDP loopback) and Checkpoint 2 (OSC byte-format) marked done with file paths.
  - Checkpoints 3–5 explicitly tagged [Phase C — pending] so it's clear what's left.

  Left other shipped design docs (UDP_RUNTIME, IF_AS_COMBINATOR) untouched
   — out of CP8's scope and the convention is inconsistent on whether to
  retro-update them.

  That closes the byte-cleanliness/OSC arc cleanly. Whenever you're ready,
   Phase C is the next milestone — actually running Csound with a live.csd
   and getting a tone out the speakers.