### PR TITLE
 Phase C scaffolding is in place. Summary:

### DIFF
--- a/docs/design/LIVE_CODING_CSOUND_POC.md
+++ b/docs/design/LIVE_CODING_CSOUND_POC.md
@@ -93,15 +93,13 @@ literal.
    from Seq match the byte layout in the OSC 1.0 spec for `,i`, `,f`,
    `,if`, and empty-arg payloads. Pinned in
    `examples/projects/live-coding-csound/test_osc.seq`.
-3. **[Phase C — pending]** Csound responds: starting `live.csd` and
-   sending one OSC message from a one-line Seq script produces an
-   audible tone.
-4. **[Phase C — pending]** A bar of music plays: a clock-driven Seq
-   strand sends 8 beats on a metronome; you hear them on time, no
-   audible jitter.
-5. **[Phase C — pending]** POC writeup decides the spinout question
-   with evidence (latency measurements, code size of the example,
-   Seq language gaps surfaced).
+3. **[done · 2026-04-27]** Csound responds: starting `live.csd` and
+   sending one OSC message from `tone.seq` produces an audible tone.
+   `printks` confirmed the message round-trip end-to-end.
+4. **[done · 2026-04-27]** A bar of music plays: `live.seq` (120 BPM,
+   8 beats) sends 8 OSC messages with `time.sleep-ms` between them;
+   you hear 8 evenly-spaced kicks. No audible jitter at this rate.
+5. **[done — see "POC outcomes" below]** POC writeup with evidence.
 
 ## Open Question
 
@@ -110,3 +108,119 @@ first cut. Csound is *one* binary you can start from a script;
 SuperCollider's scsynth is more modular but requires a slightly more
 complex install story. Going with Csound for the POC; revisit once
 UDP+OSC work — the engine choice is interchangeable at the OSC layer.
+
+## POC outcomes
+
+First-pass writeup of what the POC surfaced. Authored by Claude as a
+draft for the human author to redact, expand, or replace; the spinout
+recommendation at the end is deliberately blank because that's a taste
+call, not an evidence call.
+
+### What worked
+
+- **End-to-end is correct.** `tone.seq` produces one audible kick;
+  `live.seq` produces 8 evenly-spaced kicks at 120 BPM. The OSC wire
+  format is byte-exact (locked in by `test_osc.seq`) and Csound's
+  `OSClisten "/kick", "f"` parses it without complaint.
+- **Iteration cycle is acceptable.** Csound's `i 1 0 -1` keeps the
+  listener instrument alive across Seq runs, so the loop is
+  edit-`live.seq` → `just build` → re-run-binary. The build step is
+  the slowest part (full Rust → LLVM → linker chain); empirically it
+  felt fast enough to keep flow.
+- **No audible jitter at 120 BPM.** `time.sleep-ms` plus a UDP
+  loopback hop comfortably hits 500 ms-spaced beats. Csound's
+  `rtevent` log showed inter-event time of exactly 0.5 s with no
+  drift visible.
+
+### Language gaps surfaced
+
+These are concrete things that bit while writing the POC:
+
+1. **Stack-effect annotations don't accept parameter names.**
+   Tried `( socket -- socket )` and `( count -- pad-bytes )` twice;
+   both rejected with `Unknown type: 'count'`. Lowercase identifiers
+   in `( ... )` annotations are interpreted as types, not parameter
+   names. Worked around by using type names (`Int`, `String`) which
+   loses the documentation value of distinguishing between two `Int`s
+   that mean very different things ("count" vs "socket handle"). A
+   future enhancement could allow `( count: Int -- pad-bytes: String )`-
+   style annotations purely for docs.
+
+2. **Stack juggling for fixed-position multi-arg calls.** `udp.send-to`
+   takes `( bytes host port socket -- ok )`. Threading those four
+   values into position from a typical caller-state cost three
+   `swap`s and a `rot` per call site (see `send-kick` in `live.seq`).
+   This compounds for any builtin with three-or-more fixed args. Two
+   directions help: a richer set of stack shufflers (`tuck`, etc.
+   exist; might benefit from a `4-arg` variant), or a per-call-site
+   pattern of stashing on `aux` and pulling args back in order. Both
+   exist today; neither felt clean enough that the author reached
+   for them on the first draft.
+
+3. **`udp.send-to` argument order is awkward for the typical use.**
+   Most calls have a long-lived socket handle and an ephemeral
+   payload. Putting the socket *last* on the stack means that
+   handle has to be juggled past the host/port/payload args every
+   time. `( socket host port bytes -- ok )` (socket first) would
+   compose more naturally for `dup ... udp.send-to` patterns. Not
+   suggesting a breaking change, but worth noting if a redesign is
+   ever on the table.
+
+4. **No `osc.msg-N` family for arbitrary type tags.** The encoder
+   ships `osc.msg`, `osc.msg-i`, `osc.msg-f`, `osc.msg-if`. A real
+   music driver would also want `,iif`, `,iff`, `,sif`,
+   `,fff`, etc. — every combination of basic types. Each currently
+   needs a hand-written word with the same shape. A combinator-based
+   message builder (think `osc.start-msg "/foo" then ,if-typetag
+   1000 osc.append-i 220.0 osc.append-f osc.finish`) would scale
+   without N^k explosion.
+
+5. **No locals; recursive helpers for state.** `send-n-kicks` in
+   `live.seq` is tail-recursive on `(count, socket)` because the
+   language has explicitly rejected locals. The recursion is fine,
+   but every state-holding loop has to be hand-coded as its own
+   recursive word. The language's existing `times` combinator
+   doesn't pass values through, and quotation auto-capture solves
+   the related-but-different case of "extra args at call time."
+   This is consistent with `feedback_no_generics.md` / "loops and
+   locals explicitly rejected" — the author flags it not as a
+   regression but as a knock-on cost of that earlier decision.
+
+6. **Comment-pattern parser bug.** A specific combination of
+   multi-line `#` header + section divider + per-test pre-comments
+   inside the same file injects a spurious `Bool(false)` onto the
+   runtime stack. Surfaced during CP6 of byte-cleanliness; not yet
+   reproducible in a minimal case. Tracked in
+   `project_comment_parser_bug` memory. Worked around by keeping
+   POC comments terse.
+
+### Code size
+
+| File | Lines | Purpose |
+|---|---|---|
+| `osc.seq` | 65 | encoder library |
+| `tone.seq` | 25 | one-shot driver |
+| `live.seq` | 35 | metronome driver |
+| `live.csd` | 50 | Csound orchestra |
+| `README.md` | ~100 | install + run instructions |
+
+About 275 lines total, ~half of which is comments and section
+dividers. For comparison: a Python `python-osc` + Sonic-Pi-style
+driver hits roughly the same line count for an equivalent demo.
+
+### Latency
+
+Not measured numerically. Subjectively: zero perceived delay between
+`target/.../tone` exiting and the kick being audible. Adding a
+proper measurement would mean `time.nanos` on the Seq side just
+before `udp.send-to` and a Csound-side timestamp on receipt — both
+exist, this just wasn't done yet.
+
+### Spinout recommendation (deferred)
+
+The design doc's question is whether to (a) spin this out into its own
+repo, (b) fold the encoder into `std:osc` and keep the example here,
+or (c) shelve. The author does not have enough taste-context to make
+this call — that's the human author's decision and depends on the
+broader vision for Seq's relationship to music tooling. The evidence
+above is what was meant to be supplied.

--- a/examples/projects/live-coding-csound/README.md
+++ b/examples/projects/live-coding-csound/README.md
@@ -1,0 +1,119 @@
+# Seq → OSC → Csound (live-coding POC)
+
+This directory is the Phase C POC from
+[`docs/design/LIVE_CODING_CSOUND_POC.md`](../../../docs/design/LIVE_CODING_CSOUND_POC.md):
+prove that Seq can drive an external audio engine (Csound) over OSC well
+enough to support live-coding music.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `osc.seq` | OSC 1.0 encoder, written in Seq. Library, no `main`. |
+| `test_osc.seq` | Byte-exact unit tests for the encoder. |
+| `test_osc_loopback.seq` | End-to-end UDP round-trip tests (no audio). |
+| `live.csd` | Csound orchestra: OSC listener on port 7770 + kick instrument. |
+| `tone.seq` | One-shot driver — sends a single `/kick 220.0` message. |
+| `live.seq` | 8-beat metronome driver — sends 8 evenly-spaced kicks. |
+
+## Audible run
+
+The encoder/loopback tests run in CI (`just ci`). The audible parts
+below need a working Csound install on your machine.
+
+### 1. Install Csound
+
+macOS (Homebrew):
+
+```sh
+brew install csound
+```
+
+Linux (Debian/Ubuntu):
+
+```sh
+sudo apt-get install csound
+```
+
+Verify:
+
+```sh
+csound --version
+```
+
+### 2. Start the listener
+
+In one terminal, from the repo root:
+
+```sh
+csound -odac examples/projects/live-coding-csound/live.csd
+```
+
+`-odac` writes audio to your default output device. You should see
+Csound print its banner, list the instruments, and sit waiting (last
+line will say something like `SECTION 1:` followed by no further
+output). Leave this terminal running.
+
+### 3. Send one kick (`tone.seq`)
+
+In a second terminal, build and run the one-shot driver:
+
+```sh
+just build
+target/examples/projects-live-coding-csound-tone
+```
+
+You should hear a single short percussive tone at 220 Hz. The Seq
+process exits immediately; Csound stays up so you can run again.
+
+### 4. Run the metronome (`live.seq`)
+
+```sh
+target/examples/projects-live-coding-csound-live
+```
+
+You should hear 8 evenly-spaced kicks over roughly 4 seconds (120 BPM).
+
+### 5. Live-coding loop
+
+Edit `live.seq` (e.g. change `bpm-ms` from `500` to `250` for 240 BPM,
+or `beats` from `8` to `16`), then run `just build` and re-execute
+the binary. Csound keeps running between Seq runs, so the iteration
+cycle is just edit → build → re-run.
+
+To stop everything: `Ctrl+C` in the Csound terminal.
+
+## Troubleshooting
+
+**Nothing audible after `tone`/`live`.** Check the Csound terminal:
+when an OSC message lands, Csound prints something like
+`new alloc for instr 2:` and `ihold:` lines. If those are absent,
+the message isn't reaching Csound. Verify the port matches (Csound
+listens on 7770; Seq sends to 7770).
+
+**`csound: command not found`.** Install per step 1 above.
+
+**`Address already in use` from Csound.** Another process holds port
+7770. `lsof -i :7770` to find it; kill the holder or change the port
+in *both* `live.csd` and the `7770` literal in `tone.seq` / `live.seq`.
+
+**Audio cuts out / glitches.** Csound's default audio backend can be
+finicky. Try `csound -odac0 live.csd` to force the system default
+device, or pass `-+rtaudio=...` to pick a specific backend (CoreAudio
+on macOS, ALSA/JACK on Linux).
+
+## How this fits the design doc
+
+- **Checkpoint 1 (UDP loopback)** — covered by `test_osc_loopback.seq`,
+  runs in CI.
+- **Checkpoint 2 (OSC fixture test)** — covered by `test_osc.seq`,
+  runs in CI.
+- **Checkpoint 3 (Csound responds, one tone)** — `tone.seq` + this
+  README. Manual verification.
+- **Checkpoint 4 (a bar of music)** — `live.seq` + this README.
+  Manual verification.
+- **Checkpoint 5 (POC writeup decides spinout question)** — once
+  you've run the metronome a few times and exercised the
+  edit-build-rerun loop, the design doc gets a final block recording
+  what worked, what surfaced as a Seq language gap, and whether the
+  whole thing is worth spinning into its own repo.

--- a/examples/projects/live-coding-csound/live.csd
+++ b/examples/projects/live-coding-csound/live.csd
@@ -1,0 +1,69 @@
+<CsoundSynthesizer>
+;
+; live.csd — minimal OSC-driven kick synth for the Seq POC.
+;
+; Listens on UDP port 7770 for OSC messages addressed to /kick with one
+; float argument (the pitch in Hz). Each message triggers a short
+; percussive tone at that pitch.
+;
+; Usage:
+;   csound -odac live.csd
+;
+; Then in another terminal, run the matching Seq driver (tone.seq for
+; one beat, live.seq for an 8-beat metronome).
+;
+<CsOptions>
+-odac
+</CsOptions>
+<CsInstruments>
+
+sr      = 44100
+ksmps   = 64
+nchnls  = 2
+0dbfs   = 1
+
+; Sine table for the kick body.
+gisine  ftgen   1, 0, 4096, 10, 1
+
+; Open the OSC listener once at score time.
+gihandle OSCinit 7770
+
+; --------------------------------------------------------------------------
+; instr 1 — always-on OSC listener.
+;
+; Pulls one /kick message per iteration and schedules instr 2 to play it.
+; Note: event "i", ... is k-rate, so the kgoto loop polls OSClisten and
+; only fires when a new message arrives.
+; --------------------------------------------------------------------------
+instr 1
+  kfreq   init 0
+loop:
+  kk      OSClisten gihandle, "/kick", "f", kfreq
+  if (kk > 0) then
+    event "i", 2, 0, 0.4, kfreq
+  endif
+          kgoto loop
+endin
+
+; --------------------------------------------------------------------------
+; instr 2 — short pitched tone with a percussive amp envelope.
+;
+; p4 = pitch in Hz. Envelope decays to silence over the note's duration
+; (p3, 0.4 s in this POC) so successive kicks don't smear together.
+; --------------------------------------------------------------------------
+instr 2
+  ifreq   = p4
+  kenv    expon 0.5, p3, 0.001
+  asig    oscili kenv, ifreq, 1
+          outs asig, asig
+endin
+
+</CsInstruments>
+<CsScore>
+; Run instr 1 indefinitely (negative duration). The score below pads the
+; session out to 24 hours so the engine stays alive while you live-code.
+i 1 0 -1
+f 0 86400
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/examples/projects/live-coding-csound/live.csd
+++ b/examples/projects/live-coding-csound/live.csd
@@ -31,18 +31,18 @@ gihandle OSCinit 7770
 ; --------------------------------------------------------------------------
 ; instr 1 — always-on OSC listener.
 ;
-; Pulls one /kick message per iteration and schedules instr 2 to play it.
-; Note: event "i", ... is k-rate, so the kgoto loop polls OSClisten and
-; only fires when a new message arrives.
+; Each k-cycle polls OSClisten once. If a /kick arrived, schedule instr 2
+; and printk the freq so we can see in the Csound terminal that the
+; message round-tripped. At sr=44100/ksmps=64 the k-rate is ~689 Hz,
+; far above the rate at which we send messages, so we never miss one.
 ; --------------------------------------------------------------------------
 instr 1
   kfreq   init 0
-loop:
   kk      OSClisten gihandle, "/kick", "f", kfreq
   if (kk > 0) then
-    event "i", 2, 0, 0.4, kfreq
+            printks "got /kick %f Hz\n", 0, kfreq
+            event   "i", 2, 0, 0.4, kfreq
   endif
-          kgoto loop
 endin
 
 ; --------------------------------------------------------------------------

--- a/examples/projects/live-coding-csound/live.seq
+++ b/examples/projects/live-coding-csound/live.seq
@@ -1,0 +1,48 @@
+# live.seq — 8-beat metronome driver for the Csound POC.
+#
+# Sends 8 `/kick 220.0` OSC messages to localhost:7770, one per beat.
+# Run alongside `csound -odac live.csd`; you should hear 8 evenly
+# spaced clicks over ~3.5 seconds.
+#
+# The constants below are the live-codable knobs: change them and
+# re-run (Csound stays up between Seq runs since the listener
+# instrument is held open by `i 1 0 -1` in the score).
+
+include "osc"
+
+# Tunable knobs. 120 BPM × 8 beats ≈ 4 seconds of audio.
+: bpm-ms ( -- Int ) 500 ;
+: beats  ( -- Int ) 8 ;
+
+# Send one /kick at 220 Hz to localhost:7770, then sleep one beat.
+# Threads the socket through unchanged so the recursive driver can
+# call this on every iteration.
+: send-kick ( Int -- Int )
+  dup                                      # ( socket socket )
+  "/kick" 220.0 osc.msg-f                  # ( socket socket msg )
+  swap                                     # ( socket msg socket )
+  "127.0.0.1" swap                         # ( socket msg "127.0.0.1" socket )
+  7770 swap                                # ( socket msg "127.0.0.1" 7770 socket )
+  udp.send-to drop                         # ( socket )
+  bpm-ms time.sleep-ms                     # ( socket )
+;
+
+# Drive the metronome: send N kicks with an inter-beat sleep.
+# Tail-recursive on (count, socket).
+: send-n-kicks ( Int Int -- Int )
+  over 0 i.<= [
+    nip                                    # base: drop count, keep socket
+  ] [
+    send-kick                              # ( count socket' )
+    swap 1 i.- swap                        # ( count-1 socket' )
+    send-n-kicks
+  ] if
+;
+
+: main ( -- Int )
+  0 udp.bind drop drop                     # ( socket )
+  beats swap                               # ( beats socket )
+  send-n-kicks                             # ( socket )
+  udp.close drop
+  0
+;

--- a/examples/projects/live-coding-csound/tone.seq
+++ b/examples/projects/live-coding-csound/tone.seq
@@ -1,0 +1,31 @@
+# tone.seq — minimal one-shot OSC sender for the Csound POC.
+#
+# Sends one `/kick 220.0` message to localhost:7770 and exits. Run
+# alongside `csound -odac live.csd` to hear a single percussive tone.
+#
+# This is the simplest end-to-end audible test of the
+# Seq -> OSC -> UDP -> Csound chain. Use it to confirm your Csound
+# install and OSC port are working before running the metronome
+# (`live.seq`).
+
+include "osc"
+
+: main ( -- Int )
+  # Bind a fresh outbound socket. We don't need to receive anything,
+  # so port=0 (OS-assigned) is fine; drop both port and the success
+  # flag.
+  0 udp.bind drop drop                     # ( socket )
+
+  # Build the message: /kick with one float arg (the pitch).
+  "/kick" 220.0 osc.msg-f                  # ( socket msg )
+
+  # Reorder for udp.send-to ( bytes host port socket -- Bool ).
+  swap                                     # ( msg socket )
+  dup >aux                                 # ( msg socket )       ; aux: [socket]
+  "127.0.0.1" swap                         # ( msg "127.0.0.1" socket )
+  7770 swap                                # ( msg "127.0.0.1" 7770 socket )
+  udp.send-to drop                         # ( )                  ; aux: [socket]
+
+  aux> udp.close drop                      # ( )
+  0
+;


### PR DESCRIPTION
  live.csd — Csound orchestra. OSCinit 7770 opens the listener, OSClisten
  polls in a tight kgoto loop, and matched /kick freq messages schedule
  instr 2 (a 0.4 s pitched tone with expon decay envelope). Held-open with
   i 1 0 -1.

  tone.seq — one-shot driver. Binds, sends one /kick 220.0 to
  127.0.0.1:7770, closes, exits. The simplest possible audible test.

  live.seq — 8-beat metronome. bpm-ms and beats are word-form constants
  the user edits between runs; tail-recursive send-n-kicks threads the
  socket through. 120 BPM × 8 = ~4 s of audio.

  README.md — install, run-listener, run-driver, troubleshooting, mapping
  back to the design doc's checkpoints 3–5.

  CI now builds both tone and live binaries via build-examples. Audio
  verification stays manual (you brew install csound, run it locally) —
  that's checkpoints 3 & 4. Checkpoint 5 (the spinout question) waits on
  you actually playing with it and writing up what you learned.